### PR TITLE
feat: add sidebar toggle for collapse to icon-only mode

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Outlet, Link, useLocation } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
 import {
@@ -7,6 +8,8 @@ import {
   FileText,
   LogOut,
   Shield,
+  ChevronLeft,
+  ChevronRight,
 } from 'lucide-react'
 
 const navigation = [
@@ -19,17 +22,43 @@ const navigation = [
 export default function Layout() {
   const location = useLocation()
   const { user, logout } = useAuthStore()
+  const displayName = user?.full_name || user?.email || 'Demo User'
+  const companyName = user?.company_name || 'Free Plan'
+  const [isCollapsed, setIsCollapsed] = useState(false)
 
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Sidebar */}
-      <div className="fixed inset-y-0 left-0 w-64 bg-white border-r border-gray-200">
+      <div
+        className={`fixed inset-y-0 left-0 bg-white border-r border-gray-200 transition-[width] duration-200 ${
+          isCollapsed ? 'w-20' : 'w-64'
+        }`}
+      >
         {/* Logo */}
-        <div className="flex items-center gap-2 px-6 py-4 border-b border-gray-200">
-          <Shield className="w-8 h-8 text-primary-600" />
-          <span className="text-lg font-semibold text-gray-900">
-            AI Compliance
-          </span>
+        <div className="flex items-center justify-between gap-2 px-4 py-4 border-b border-gray-200">
+          <div className="flex items-center gap-2">
+            <Shield className="w-8 h-8 text-primary-600" />
+            <span
+              className={`text-lg font-semibold text-gray-900 ${
+                isCollapsed ? 'sr-only' : ''
+              }`}
+            >
+              AI Compliance
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsCollapsed((prev) => !prev)}
+            className="p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
+            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            {isCollapsed ? (
+              <ChevronRight className="w-5 h-5" />
+            ) : (
+              <ChevronLeft className="w-5 h-5" />
+            )}
+          </button>
         </div>
 
         {/* Navigation */}
@@ -40,14 +69,17 @@ export default function Layout() {
               <Link
                 key={item.name}
                 to={item.href}
+                title={item.name}
                 className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
                   isActive
                     ? 'bg-primary-50 text-primary-700'
                     : 'text-gray-600 hover:bg-gray-100'
-                }`}
+                } ${isCollapsed ? 'justify-center' : ''}`}
               >
                 <item.icon className="w-5 h-5" />
-                {item.name}
+                <span className={isCollapsed ? 'sr-only' : ''}>
+                  {item.name}
+                </span>
               </Link>
             )
           })}
@@ -55,18 +87,24 @@ export default function Layout() {
 
         {/* User section */}
         <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200">
-          <div className="flex items-center justify-between">
-            <div className="truncate">
+          <div
+            className={`flex items-center ${
+              isCollapsed ? 'justify-center' : 'justify-between'
+            }`}
+          >
+            <div className={isCollapsed ? 'sr-only' : 'truncate'}>
               <p className="text-sm font-medium text-gray-900 truncate">
-                {user?.full_name || user?.email}
+                {displayName}
               </p>
               <p className="text-xs text-gray-500 truncate">
-                {user?.company_name || 'Free Plan'}
+                {companyName}
               </p>
             </div>
             <button
               onClick={logout}
               className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100"
+              aria-label="Log out"
+              title="Log out"
             >
               <LogOut className="w-5 h-5" />
             </button>
@@ -75,7 +113,7 @@ export default function Layout() {
       </div>
 
       {/* Main content */}
-      <div className="pl-64">
+      <div className={isCollapsed ? 'pl-20' : 'pl-64'}>
         <main className="p-8">
           <Outlet />
         </main>


### PR DESCRIPTION
# Summary
Adds a toggle button in the sidebar header to collapse the sidebar to an icon‑only view, reducing width to save space on smaller screens. Navigation labels and user info are visually hidden while icons remain accessible, and the main content padding adjusts accordingly.