### PR TITLE
test(guard): verify config path resolution and trained model fallback

### DIFF
--- a/backend/tests/test_guard_config.py
+++ b/backend/tests/test_guard_config.py
@@ -1,0 +1,58 @@
+"""Regression tests for guard_config path resolution.
+
+These tests prevent regressions in path variables that previously broke —
+DATA_DIR, MODELS_DIR, BACKEND_ROOT, and get_trained_model_path().
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location(
+    "guard_config",
+    __import__("pathlib").Path(__file__).parent.parent / "app/modules/guard/guard_config.py",
+)
+guard_config = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard_config)
+
+
+_GUARD_CONFIG_FILE = Path(guard_config.__file__).resolve()
+_EXPECTED_BACKEND_ROOT = _GUARD_CONFIG_FILE.parent.parent.parent.parent
+
+
+class TestPathResolution:
+    def test_backend_root_resolves_to_backend(self):
+        assert guard_config.BACKEND_ROOT.resolve() == _EXPECTED_BACKEND_ROOT
+
+    def test_data_dir_resolves_under_backend(self):
+        assert guard_config.DATA_DIR.resolve() == _EXPECTED_BACKEND_ROOT / "data"
+
+    def test_models_dir_resolves_under_guard(self):
+        expected = _GUARD_CONFIG_FILE.parent / "models"
+        assert guard_config.MODELS_DIR.resolve() == expected.resolve()
+
+    def test_backend_root_name_is_backend(self):
+        assert guard_config.BACKEND_ROOT.name == "backend"
+
+    def test_data_dir_name_is_data(self):
+        assert guard_config.DATA_DIR.name == "data"
+
+    def test_models_dir_name_is_models(self):
+        assert guard_config.MODELS_DIR.name == "models"
+
+
+class TestGetTrainedModelPath:
+    def test_returns_default_when_no_fine_tuned_model(self):
+        with patch("os.path.exists", return_value=False):
+            result = guard_config.get_trained_model_path()
+        assert result == guard_config.CLASSIFIER_MODEL_PATH
+
+    def test_returns_string(self):
+        with patch("os.path.exists", return_value=False):
+            result = guard_config.get_trained_model_path()
+        assert isinstance(result, str)
+
+    def test_returns_env_path_when_it_exists(self):
+        with patch("os.path.exists", return_value=True):
+            result = guard_config.get_trained_model_path()
+        assert result == guard_config.CLASSIFIER_MODEL_PATH


### PR DESCRIPTION
Closes #99

## Summary

Closes #99 

Adds `backend/tests/test_guard_config.py` with 9 tests covering:
- TestPathResolution — verifies `BACKEND_ROOT`, `DATA_DIR`, and `MODELS_DIR` resolve to the correct directories (by full path and by name)
- TestGetTrainedModelPath — verifies fallback behavior when no fine-tuned model exists, and that the env-configured path is returned when found

Note: the import uses `importlib` to load `guard_config` directly rather than via the package, because `app/modules/guard/__init__.py` eagerly imports `torch`, which isn't installed in the test environment and would block collection.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)

N/A — tests only.

## Test Output
```
srivani@Srivanis-MacBook-Air backend % python3 -m pytest tests/test_guard_config.py -v
================================================================= test session starts =================================================================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0 -- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3
cachedir: .pytest_cache
rootdir: /Users/srivani/AegisAI/backend
configfile: pytest.ini
collected 9 items                                                                                                                                     

tests/test_guard_config.py::TestPathResolution::test_backend_root_resolves_to_backend PASSED                                                    [ 11%]
tests/test_guard_config.py::TestPathResolution::test_data_dir_resolves_under_backend PASSED                                                     [ 22%]
tests/test_guard_config.py::TestPathResolution::test_models_dir_resolves_under_guard PASSED                                                     [ 33%]
tests/test_guard_config.py::TestPathResolution::test_backend_root_name_is_backend PASSED                                                        [ 44%]
tests/test_guard_config.py::TestPathResolution::test_data_dir_name_is_data PASSED                                                               [ 55%]
tests/test_guard_config.py::TestPathResolution::test_models_dir_name_is_models PASSED                                                           [ 66%]
tests/test_guard_config.py::TestGetTrainedModelPath::test_returns_default_when_no_fine_tuned_model PASSED                                       [ 77%]
tests/test_guard_config.py::TestGetTrainedModelPath::test_returns_string PASSED                                                                 [ 88%]
tests/test_guard_config.py::TestGetTrainedModelPath::test_returns_env_path_when_it_exists PASSED                                                [100%]

================================================================== 9 passed in 0.44s ==================================================================
```