### PR TITLE
Implement SVG compliance badge generator with unit test

### DIFF
--- a/backend/app/modules/badge/badge_generator.py
+++ b/backend/app/modules/badge/badge_generator.py
@@ -36,17 +36,24 @@ def generate_badge_svg(
 ) -> str:
     """
     Generate an SVG compliance badge.
-
-    Args:
-        system_name: Name of the AI system.
-        risk_level: One of minimal / limited / high / unacceptable, or None.
-        compliance_status: One of the ComplianceStatus enum values.
-
-    Returns:
-        SVG string ready for serving with Content-Type: image/svg+xml.
-
-    TODO (good first issue): implement the body of this function.
-    Hint: build the SVG as an f-string using STATUS_COLORS and RISK_LABELS.
     """
-    # TODO: implement
-    raise NotImplementedError("generate_badge_svg is not yet implemented — see TODO above")
+
+    color = STATUS_COLORS.get(compliance_status, "#9ca3af") #(fallback to gray if unknown)
+
+    status_label = compliance_status.replace("_", " ").title()
+
+    risk_text = ""
+    if risk_level:
+        risk_text = f" ({RISK_LABELS.get(risk_level, risk_level.title())})"
+
+    full_label = f"{status_label}{risk_text}"
+
+    # SVG badge
+    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" width="220" height="20">
+  <rect width="100" height="20" fill="#555"/>
+  <rect x="100" width="120" height="20" fill="{color}"/>
+  <text x="50" y="14" fill="#fff" font-size="11" font-family="sans-serif" text-anchor="middle">AegisAI</text>
+  <text x="160" y="14" fill="#fff" font-size="11" font-family="sans-serif" text-anchor="middle">{full_label}</text>
+</svg>'''
+
+    return svg

--- a/backend/tests/test_badge_generator.py
+++ b/backend/tests/test_badge_generator.py
@@ -1,0 +1,10 @@
+from app.modules.badge.badge_generator import generate_badge_svg
+
+def test_generate_badge_svg():
+    svg = generate_badge_svg("My AI", "high", "compliant")
+
+    assert svg.startswith("<svg")
+    assert "AegisAI" in svg
+    assert "Compliant" in svg
+    assert "High Risk" in svg
+    assert "</svg>" in svg


### PR DESCRIPTION
## Summary

Closes #122

Implemented the `generate_badge_svg` function to return a valid SVG compliance badge using the provided STATUS_COLORS mapping. Also added a unit test to verify the correctness of the generated SVG output.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally for svg_generator
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)

N/A (SVG output can be viewed by saving the returned string as a `.svg` file) 
<img width="1074" height="237" alt="Screenshot 2026-05-10 190156" src="https://github.com/user-attachments/assets/d79d7263-58fe-4f19-86c3-d0f261869695" />
] 