### PR TITLE
Add per-user rate limiting for guard scan

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -9,12 +9,23 @@ TODO for contributors (medium difficulty):
   - Add a GET /guard/stats endpoint returning block/allow/sanitize counts
 """
 
+from collections import defaultdict, deque
+from datetime import datetime, timedelta, timezone
+from threading import Lock
+
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from app.core.security import get_current_user
 from app.models.user import User
 
 router = APIRouter()
+
+
+_RATE_LIMIT_REQUESTS = 60
+_RATE_LIMIT_WINDOW_SECONDS = 60
+_scan_attempts_by_user: dict[int, deque[datetime]] = defaultdict(deque)
+_rate_limit_lock = Lock()
 
 
 class ScanRequest(BaseModel):
@@ -29,6 +40,24 @@ class ScanResponse(BaseModel):
     matched_patterns: list[str] = []
 
 
+def _check_rate_limit(user_id: int) -> tuple[bool, int]:
+    """Return whether the user is limited and the seconds to retry after."""
+    now = datetime.now(timezone.utc)
+    window_start = now - timedelta(seconds=_RATE_LIMIT_WINDOW_SECONDS)
+
+    with _rate_limit_lock:
+        attempts = _scan_attempts_by_user[user_id]
+        while attempts and attempts[0] <= window_start:
+            attempts.popleft()
+
+        if len(attempts) >= _RATE_LIMIT_REQUESTS:
+            retry_after = max(1, int((_RATE_LIMIT_WINDOW_SECONDS - (now - attempts[0]).total_seconds()) + 0.999))
+            return True, retry_after
+
+        attempts.append(now)
+        return False, 0
+
+
 @router.post("/scan", response_model=ScanResponse)
 def scan_prompt(
     request: ScanRequest,
@@ -38,6 +67,16 @@ def scan_prompt(
     Scan a prompt for injection risks.
     Returns a decision: allow, sanitize, or block.
     """
+    limited, retry_after = _check_rate_limit(current_user.id)
+    if limited:
+        return JSONResponse(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            content={
+                "detail": "Rate limit exceeded: 60 requests per minute per user. Please try again later.",
+            },
+            headers={"Retry-After": str(retry_after)},
+        )
+
     try:
         from app.modules.guard.llm_guard import LLMGuard
         from app.modules.guard.sanitizer import SanitizationLevel

--- a/backend/tests/integration/test_rate_limiting.py
+++ b/backend/tests/integration/test_rate_limiting.py
@@ -1,0 +1,85 @@
+"""Integration tests for per-user rate limiting on guard scan endpoint."""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+from app.core.security import create_access_token
+from app.models.user import User
+
+
+def _guard_result():
+    return {
+        "decision": "allow",
+        "metadata": {
+            "decision_reasoning": {
+                "confidence": 0.99,
+                "reasoning": "Safe prompt",
+            },
+            "regex_analysis": {
+                "matched_patterns": [],
+            },
+        },
+    }
+
+
+def _authenticate_test_user(db_session):
+    user = User(
+        email="rate-limit-user@example.com",
+        hashed_password="$2b$12$R9h31cIPz0yO8W4gw2love.a4UtcWLU7pHPti3/T.D18SMsKvRHO2",
+        is_active=True,
+        company_name="AegisAI Tests",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    token = create_access_token(data={"sub": str(user.id)})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_per_user_rate_limit_blocks_61st_guard_scan_request(client, db_session):
+    """After 60 rapid requests, the 61st request should be rate limited."""
+    auth_headers = _authenticate_test_user(db_session)
+
+    fake_guard_module = ModuleType("app.modules.guard.llm_guard")
+    fake_guard_class = MagicMock()
+    fake_guard_class.return_value.guard.return_value = _guard_result()
+    fake_guard_module.LLMGuard = fake_guard_class
+
+    fake_intent_classifier_module = ModuleType("app.modules.guard.intent_classifier")
+    fake_intent_classifier_module.IntentClassifier = MagicMock()
+
+    fake_llm_client_module = ModuleType("app.modules.llm.llm_client")
+    fake_llm_client_module.LLMClient = MagicMock()
+
+    with patch.dict(
+        sys.modules,
+        {
+            "app.modules.guard.llm_guard": fake_guard_module,
+            "app.modules.guard.intent_classifier": fake_intent_classifier_module,
+            "app.modules.llm.llm_client": fake_llm_client_module,
+        },
+    ):
+        status_codes = []
+        payload = {"prompt": "Hello, this is a harmless test prompt."}
+
+        for _ in range(60):
+            response = client.post("/api/v1/guard/scan", json=payload, headers=auth_headers)
+            status_codes.append(response.status_code)
+
+        blocked_response = client.post("/api/v1/guard/scan", json=payload, headers=auth_headers)
+
+    assert all(code != 429 for code in status_codes)
+    assert blocked_response.status_code == 429
+    assert blocked_response.headers.get("Retry-After") is not None
+
+    body = blocked_response.json()
+    detail = str(body.get("detail", "")).lower()
+    assert detail
+    assert (
+        "rate" in detail
+        or "limit" in detail
+        or "too many" in detail
+        or "retry" in detail
+    )


### PR DESCRIPTION
This PR adds per-user rate limiting to `POST /api/v1/guard/scan` and covers it with a targeted integration test.

Summary:
- Enforces a 60 requests/minute limit per authenticated user
- Returns `429 Too Many Requests` with a `Retry-After` header when the limit is exceeded
- Adds an integration test that authenticates a user, sends 60 rapid requests, and verifies the 61st is blocked

Verification:
- `backend/tests/integration/test_rate_limiting.py` passes in the backend `venv`

Depends on the per-user rate limiting issue for the guard scan endpoint.