### PR TITLE
feat: implement SVG compliance badge generator and add unit tests #122

### DIFF
--- a/backend/app/modules/badge/badge_generator.py
+++ b/backend/app/modules/badge/badge_generator.py
@@ -48,5 +48,14 @@ def generate_badge_svg(
     TODO (good first issue): implement the body of this function.
     Hint: build the SVG as an f-string using STATUS_COLORS and RISK_LABELS.
     """
-    # TODO: implement
-    raise NotImplementedError("generate_badge_svg is not yet implemented — see TODO above")
+    color = STATUS_COLORS.get(compliance_status, STATUS_COLORS["not_started"])
+    status_label = compliance_status.replace("_", " ").title()
+
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20">'
+        f'<rect width="80" height="20" fill="#555"/>'
+        f'<rect x="80" width="120" height="20" fill="{color}"/>'
+        f'<text x="40" y="14" fill="#fff" font-size="11" font-family="sans-serif" text-anchor="middle">AegisAI</text>'
+        f'<text x="140" y="14" fill="#fff" font-size="11" font-family="sans-serif" text-anchor="middle">{status_label}</text>'
+        f'</svg>'
+    )

--- a/backend/tests/test_badge.py
+++ b/backend/tests/test_badge.py
@@ -1,0 +1,26 @@
+import pytest
+from app.modules.badge.badge_generator import generate_badge_svg, STATUS_COLORS
+
+def test_generate_badge_svg_compliant():
+    system_name = "Test AI"
+    risk_level = "high"
+    compliance_status = "compliant"
+    
+    svg = generate_badge_svg(system_name, risk_level, compliance_status)
+    
+    assert svg.startswith("<svg")
+    assert svg.endswith("</svg>")
+    assert f'fill="{STATUS_COLORS["compliant"]}"' in svg
+    assert "Compliant" in svg
+    assert "AegisAI" in svg
+
+def test_generate_badge_svg_in_progress():
+    svg = generate_badge_svg("My AI", None, "in_progress")
+    assert f'fill="{STATUS_COLORS["in_progress"]}"' in svg
+    assert "In Progress" in svg
+
+def test_generate_badge_svg_unknown_status():
+    # Should default to not_started color
+    svg = generate_badge_svg("My AI", None, "unknown")
+    assert f'fill="{STATUS_COLORS["not_started"]}"' in svg
+    assert "Unknown" in svg


### PR DESCRIPTION
## Summary

Closes #122

Implemented the `generate_badge_svg` function to produce dynamic, shields.io-style SVG badges for AI system compliance.

## Type of Change

- [x] New feature
- [x] Tests

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/phanishree2005/AegisAI/blob/main/CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/test_badge.py` passes locally
- [x] I have not committed `.env` or any secrets

## Screenshots (if UI change)

The generated SVG badge looks like this for a compliant system:
![Badge](https://img.shields.io/badge/AegisAI-Compliant-4ade80)
