### PR TITLE
feat(rag): add low-quality chunk aggregation (#144)

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -14,6 +14,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from app.core.security import get_current_user
 from app.models.user import User
+from app.core.database import get_db
+from sqlalchemy.orm import Session
+from app.models.rag_feedback import RAGFeedback
+from app.models.user import SubscriptionTier
+from typing import Optional
 
 router = APIRouter()
 
@@ -25,12 +30,14 @@ class RAGQueryRequest(BaseModel):
 class RAGQueryResponse(BaseModel):
     answer: str
     sources: list[str] = []
+    answer_id: Optional[str] = None
 
 
 @router.post("/query", response_model=RAGQueryResponse)
 def query_knowledge_base(
     request: RAGQueryRequest,
     current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
     """
     Ask a regulatory question and get an answer grounded in source documents.
@@ -43,8 +50,29 @@ def query_knowledge_base(
         from app.modules.rag.retrieval_chain import get_qa_chain
         qa_chain = get_qa_chain()
         result = qa_chain({"query": request.question})
-        sources = [str(doc.metadata.get("source", "")) for doc in result.get("source_documents", [])]
-        return RAGQueryResponse(answer=result["result"], sources=sources)
+        source_docs = result.get("source_documents", [])
+        sources = [str(doc.metadata.get("source", "")) for doc in source_docs]
+
+        # Ensure tables exist on this DB bind (useful for test DB overrides)
+        from app.core.database import Base
+        try:
+            Base.metadata.create_all(bind=db.get_bind())
+        except Exception:
+            # best-effort: ignore if bind not available
+            pass
+
+        # Persist an initial RAGFeedback row to capture the answer and contributing chunks
+        feedback = RAGFeedback(
+            question=request.question,
+            answer=str(result.get("result", "")),
+            source_chunks=sources,
+        )
+        db.add(feedback)
+        db.commit()
+        db.refresh(feedback)
+        answer_id = feedback.id
+
+        return RAGQueryResponse(answer=result["result"], sources=sources, answer_id=answer_id)
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -56,3 +84,68 @@ def query_knowledge_base(
 def rag_health():
     """Check if the RAG module is available."""
     return {"module": "rag_intelligence", "status": "available"}
+
+
+class RAGFeedbackRequest(BaseModel):
+    answer_id: str
+    vote: str  # "up" or "down"
+
+
+@router.post("/feedback")
+def rag_feedback(
+    payload: RAGFeedbackRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Record a thumbs-up or thumbs-down for a previously returned answer."""
+    fb = db.query(RAGFeedback).filter(RAGFeedback.id == payload.answer_id).first()
+    if not fb:
+        raise HTTPException(status_code=404, detail="Answer not found")
+    if payload.vote == "up":
+        fb.thumbs_up = (fb.thumbs_up or 0) + 1
+    else:
+        fb.thumbs_down = (fb.thumbs_down or 0) + 1
+    db.add(fb)
+    db.commit()
+    db.refresh(fb)
+    return {"status": "ok", "answer_id": fb.id}
+
+
+@router.get("/low-quality-chunks")
+def get_low_quality_chunks(
+    threshold: float = 0.3,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Admin endpoint: aggregate feedback by source chunk and return low-quality candidates.
+
+    A chunk is considered low-quality when thumbs_down / total_feedback > threshold.
+    """
+    # Admin-only access: restrict to system owners / scale tier
+    try:
+        if current_user.subscription_tier != SubscriptionTier.SCALE:
+            raise HTTPException(status_code=403, detail="Admin access required")
+    except Exception:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    # Aggregate counts per chunk
+    counts: dict[str, dict[str, int]] = {}
+    rows = db.query(RAGFeedback).all()
+    for r in rows:
+        total = (r.thumbs_up or 0) + (r.thumbs_down or 0)
+        for chunk in (r.source_chunks or []):
+            if chunk not in counts:
+                counts[chunk] = {"thumbs_up": 0, "thumbs_down": 0, "total": 0}
+            counts[chunk]["thumbs_up"] += (r.thumbs_up or 0)
+            counts[chunk]["thumbs_down"] += (r.thumbs_down or 0)
+            counts[chunk]["total"] += total
+
+    low_quality = []
+    for chunk, c in counts.items():
+        if c["total"] == 0:
+            continue
+        ratio = c["thumbs_down"] / c["total"]
+        if ratio > threshold:
+            low_quality.append({"chunk": chunk, "thumbs_down": c["thumbs_down"], "total": c["total"], "ratio": ratio})
+
+    return {"threshold": threshold, "low_quality_chunks": low_quality}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
 from app.core.database import engine, Base
 from app.api.v1 import api_router
+import app.models  # ensure all ORM models are imported so tables are created
 
 Base.metadata.create_all(bind=engine)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.user import User
 from app.models.ai_system import AISystem, RiskAssessment
 from app.models.document import Document
+from app.models.rag_feedback import RAGFeedback
 
-__all__ = ["User", "AISystem", "RiskAssessment", "Document"]
+__all__ = ["User", "AISystem", "RiskAssessment", "Document", "RAGFeedback"]

--- a/backend/app/models/rag_feedback.py
+++ b/backend/app/models/rag_feedback.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, DateTime, JSON
+from datetime import datetime
+import uuid
+from app.core.database import Base
+
+
+class RAGFeedback(Base):
+    __tablename__ = "rag_feedback"
+
+    id = Column(String(64), primary_key=True, default=lambda: str(uuid.uuid4()))
+    question = Column(String(2000), nullable=True)
+    answer = Column(String(4000), nullable=True)
+    thumbs_up = Column(Integer, default=0)
+    thumbs_down = Column(Integer, default=0)
+    source_chunks = Column(JSON, default=list)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/backend/tests/integration/test_rag_feedback.py
+++ b/backend/tests/integration/test_rag_feedback.py
@@ -1,0 +1,95 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+import importlib
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.core.database import Base, get_db
+from app.core.security import get_current_user
+from app.models.user import User, SubscriptionTier
+
+
+class DummyDoc:
+    def __init__(self, source):
+        self.metadata = {"source": source}
+
+
+def _get_test_db():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    return _override_get_db
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[get_db] = _get_test_db()
+
+    # override auth to return a user; default non-admin
+    def _fake_user():
+        u = User()
+        u.id = 1
+        u.email = "tester@example.com"
+        u.subscription_tier = SubscriptionTier.FREE
+        return u
+
+    app.dependency_overrides[get_current_user] = _fake_user
+
+    with TestClient(app) as c:
+        yield c
+
+
+def test_query_feedback_and_low_quality_flow(client):
+    # Mock the QA chain to return controlled result and sources
+    fake_result = {"result": "Test answer", "source_documents": [DummyDoc("doc1.pdf#chunk1"), DummyDoc("doc2.pdf#chunk2")]}
+
+    # Provide a lightweight fake retrieval_chain module (avoid heavy langchain imports)
+    import types, sys
+
+    mod = types.ModuleType("app.modules.rag.retrieval_chain")
+
+    def _fake_get_qa_chain():
+        return lambda payload: fake_result
+
+    mod.get_qa_chain = _fake_get_qa_chain
+    sys.modules["app.modules.rag.retrieval_chain"] = mod
+
+    # Call query endpoint
+    resp = client.post("/api/v1/rag/query", json={"question": "What is X?"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "answer" in data and data["answer"] == "Test answer"
+    assert "answer_id" in data
+    answer_id = data["answer_id"]
+
+    # Submit a thumbs-down for that answer
+    resp2 = client.post("/api/v1/rag/feedback", json={"answer_id": answer_id, "vote": "down"})
+    assert resp2.status_code == 200
+
+    # Now query low-quality-chunks as admin: override current_user to be admin
+    def _admin_user():
+        u = User()
+        u.id = 2
+        u.email = "admin@example.com"
+        u.subscription_tier = SubscriptionTier.SCALE
+        return u
+
+    app.dependency_overrides[get_current_user] = _admin_user
+
+    resp3 = client.get("/api/v1/rag/low-quality-chunks?threshold=0.0")
+    assert resp3.status_code == 200
+    out = resp3.json()
+    assert "low_quality_chunks" in out
+    # Should contain our two chunks (since total feedback for the answer was 1 down)
+    chunks = {c["chunk"] for c in out["low_quality_chunks"]}
+    assert "doc1.pdf#chunk1" in chunks or "doc2.pdf#chunk2" in chunks

--- a/docs/rag-module.md
+++ b/docs/rag-module.md
@@ -1,3 +1,20 @@
+## Maintaining Knowledge Base Quality
+
+### Low-quality chunk aggregation
+
+The API provides an administrative endpoint to surface RAG chunks that receive low user feedback (thumbs-down). Use this to decide which chunks to re-ingest, repair, or remove from the FAISS index.
+
+- GET `/api/v1/rag/low-quality-chunks?threshold=0.3`
+  - Protected: admin/system-owner only (users on the `scale` subscription tier).
+  - Returns a list of chunk identifiers (the `source` metadata saved during ingestion) that have a thumbs-down ratio greater than `threshold`.
+
+Workflow:
+
+1. Query the RAG endpoint as usual: `POST /api/v1/rag/query` — the server stores the returned `answer_id` and the list of contributing chunk sources.
+2. Have users submit feedback: `POST /api/v1/rag/feedback` with `{"answer_id": "...", "vote": "down"}`.
+3. Run the aggregation endpoint: `GET /api/v1/rag/low-quality-chunks` to get candidate chunks for re-ingestion.
+
+The endpoint returns objects with `chunk`, `thumbs_down`, `total` and `ratio` fields to help prioritize remediation.
 # RAG Intelligence Module
 
 The RAG (Retrieval-Augmented Generation) module lets you ask natural language questions about AI regulations and receive grounded answers with source citations — rather than relying on an LLM's potentially outdated or hallucinated knowledge.


### PR DESCRIPTION
Implements issue #144.

Summary:
- Stores source chunk metadata from RAG queries
- Adds an admin endpoint to surface low-quality chunks for re-ingestion
- Adds integration coverage for query -> thumbs-down -> aggregation
- Updates RAG docs with the maintenance workflow

Validation:
- `python -m pytest backend/tests/integration/test_rag_feedback.py -q`
