### PR TITLE
Feature/46 update user profile

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -4,6 +4,7 @@ from app.api.v1 import auth, ai_systems, documents, classification, guard, rag
 api_router = APIRouter()
 
 api_router.include_router(auth.router, prefix="/auth", tags=["Authentication"])
+api_router.include_router(auth.users_router, prefix="/users", tags=["Users"])
 api_router.include_router(ai_systems.router, prefix="/ai-systems", tags=["AI Systems"])
 api_router.include_router(classification.router, prefix="/classification", tags=["Risk Classification"])
 api_router.include_router(documents.router, prefix="/documents", tags=["Documents"])

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -11,8 +11,9 @@ from app.core.security import (
     get_current_user
 )
 from app.core.config import settings
+from app.core.database import get_db
 from app.models.user import User
-from app.schemas.user import UserCreate, UserResponse, Token
+from app.schemas.user import UserCreate, UserResponse, UserUpdateSchema, Token
 
 router = APIRouter()
 
@@ -74,4 +75,22 @@ def login(
 @router.get("/me", response_model=UserResponse)
 def get_current_user_info(current_user: User = Depends(get_current_user)):
     """Get current user information."""
+    return current_user
+
+
+@router.patch("/me", response_model=UserResponse)
+def update_current_user_info(
+    user_data: UserUpdateSchema,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update the authenticated user's profile details."""
+    if user_data.full_name is not None:
+        current_user.full_name = user_data.full_name
+    if user_data.company_name is not None:
+        current_user.company_name = user_data.company_name
+
+    current_user = db.merge(current_user)
+    db.commit()
+    db.refresh(current_user)
     return current_user

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -16,6 +16,7 @@ from app.models.user import User
 from app.schemas.user import UserCreate, UserResponse, UserUpdateSchema, Token
 
 router = APIRouter()
+users_router = APIRouter()
 
 
 @router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
@@ -78,7 +79,7 @@ def get_current_user_info(current_user: User = Depends(get_current_user)):
     return current_user
 
 
-@router.patch("/me", response_model=UserResponse)
+@users_router.patch("/me", response_model=UserResponse)
 def update_current_user_info(
     user_data: UserUpdateSchema,
     current_user: User = Depends(get_current_user),

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,4 +1,4 @@
-from app.schemas.user import UserCreate, UserLogin, UserResponse, Token
+from app.schemas.user import UserCreate, UserLogin, UserResponse, UserUpdateSchema, Token
 from app.schemas.ai_system import (
     AISystemCreate, 
     AISystemUpdate, 
@@ -9,7 +9,7 @@ from app.schemas.ai_system import (
 from app.schemas.document import DocumentCreate, DocumentResponse
 
 __all__ = [
-    "UserCreate", "UserLogin", "UserResponse", "Token",
+    "UserCreate", "UserLogin", "UserResponse", "UserUpdateSchema", "Token",
     "AISystemCreate", "AISystemUpdate", "AISystemResponse",
     "RiskClassificationRequest", "RiskClassificationResponse",
     "DocumentCreate", "DocumentResponse"

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -30,7 +30,7 @@ class UserResponse(BaseModel):
         from_attributes = True
 
 
-class UserUpdate(BaseModel):
+class UserUpdateSchema(BaseModel):
     full_name: Optional[str] = None
     company_name: Optional[str] = None
 

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -1,0 +1,68 @@
+import os
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.core.database import Base, get_db
+from app.core.security import get_current_user
+from app.models.user import User, SubscriptionTier
+
+
+def _build_test_session_local(database_url: str):
+    engine = create_engine(database_url, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def test_patch_me_updates_profile_fields(tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'auth_me.db'}"
+    testing_session_local = _build_test_session_local(database_url)
+
+    def override_get_db():
+        db = testing_session_local()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    db = testing_session_local()
+    user = User(
+        email="user@example.com",
+        hashed_password="hashed",
+        full_name="Old Name",
+        company_name="Old Company",
+        subscription_tier=SubscriptionTier.FREE,
+        is_active=True,
+        is_verified=False,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    def override_current_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    client = TestClient(app)
+    response = client.patch(
+        "/api/v1/auth/me",
+        json={"full_name": "New Name", "company_name": "New Company"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["full_name"] == "New Name"
+    assert data["company_name"] == "New Company"
+
+    refreshed = db.query(User).filter(User.id == user.id).first()
+    assert refreshed.full_name == "New Name"
+    assert refreshed.company_name == "New Company"
+
+    app.dependency_overrides.clear()
+    db.close()

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -51,7 +51,7 @@ def test_patch_me_updates_profile_fields(tmp_path):
 
     client = TestClient(app)
     response = client.patch(
-        "/api/v1/auth/me",
+        "/api/v1/users/me",
         json={"full_name": "New Name", "company_name": "New Company"},
     )
 


### PR DESCRIPTION
This pull request implements the user profile update endpoint for authenticated users, addressing issue #46.

What was implemented  
The solution adds a new endpoint that allows authenticated users to update their profile name and company details. This is useful for letting users keep their account information current without affecting authentication or other account settings.

Technical details  
The implementation adds a dedicated users route and a reusable update schema to support profile edits. The endpoint includes:

Full support for updating full_name and company_name
Updated user response returned after the change is saved
Proper authentication protection so only the current user can update their own profile
Database session handling to persist the changes safely
A dedicated route mounted at /api/v1/users/me

Testing  
Focused API coverage was added for the profile update flow, covering:

Successful update of full_name and company_name
Correct response payload with the updated user data
Database persistence of the changes
Correct endpoint path for the authenticated user profile update

Files changed  
- auth.py: Added the profile update endpoint and users route
- __init__.py: Mounted the users router
- user.py: Added UserUpdateSchema
- __init__.py: Exported the new schema
- test_auth_me.py: Added endpoint test coverage

Verification  
The profile update test can be run with:

```bash
cd backend
python -m pytest tests/test_auth_me.py -q
```
