### PR TITLE
feat: add global toast notification system using react-hot-toast (#20)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.49.3",
+        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^6.21.3",
         "tailwind-merge": "^2.2.1",
         "zod": "^3.22.4",
@@ -2162,7 +2163,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2913,6 +2913,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -3856,6 +3865,23 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,18 +10,19 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.3",
+    "@hookform/resolvers": "^3.3.4",
     "@tanstack/react-query": "^5.17.19",
     "axios": "^1.6.7",
-    "zustand": "^4.5.0",
-    "react-hook-form": "^7.49.3",
-    "@hookform/resolvers": "^3.3.4",
-    "zod": "^3.22.4",
-    "lucide-react": "^0.314.0",
     "clsx": "^2.1.0",
-    "tailwind-merge": "^2.2.1"
+    "lucide-react": "^0.314.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.49.3",
+    "react-hot-toast": "^2.6.0",
+    "react-router-dom": "^6.21.3",
+    "tailwind-merge": "^2.2.1",
+    "zod": "^3.22.4",
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.48",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Dashboard from './pages/Dashboard'
 import AISystems from './pages/AISystems'
 import Classification from './pages/Classification'
 import Documents from './pages/Documents'
+import { Toaster } from 'react-hot-toast'
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuthStore()
@@ -15,23 +16,45 @@ function PrivateRoute({ children }: { children: React.ReactNode }) {
 
 function App() {
   return (
-    <Routes>
-      <Route path="/login" element={<Login />} />
-      <Route path="/register" element={<Register />} />
-      <Route
-        path="/"
-        element={
-          <PrivateRoute>
-            <Layout />
-          </PrivateRoute>
-        }
-      >
-        <Route index element={<Dashboard />} />
-        <Route path="ai-systems" element={<AISystems />} />
-        <Route path="classification/:systemId?" element={<Classification />} />
-        <Route path="documents" element={<Documents />} />
-      </Route>
-    </Routes>
+    <>
+      <Toaster
+        position="top-right"
+        toastOptions={{
+          duration: 4000,
+          success: {
+            style: {
+              background: '#f0fdf4',
+              color: '#166534',
+              border: '1px solid #bbf7d0',
+            },
+          },
+          error: {
+            style: {
+              background: '#fef2f2',
+              color: '#991b1b',
+              border: '1px solid #fecaca',
+            },
+          },
+        }}
+      />
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route
+          path="/"
+          element={
+            <PrivateRoute>
+              <Layout />
+            </PrivateRoute>
+          }
+        >
+          <Route index element={<Dashboard />} />
+          <Route path="ai-systems" element={<AISystems />} />
+          <Route path="classification/:systemId?" element={<Classification />} />
+          <Route path="documents" element={<Documents />} />
+        </Route>
+      </Routes>
+    </>
   )
 }
 

--- a/frontend/src/utils/toast.ts
+++ b/frontend/src/utils/toast.ts
@@ -1,0 +1,17 @@
+import toast from 'react-hot-toast'
+
+export const notify = {
+  success: (msg: string) => toast.success(msg),
+  error: (msg: string) => toast.error(msg),
+  loading: (msg: string) => toast.loading(msg),
+  dismiss: (id?: string) => toast.dismiss(id),
+  promise: <T,>(
+    promise: Promise<T>,
+    msgs: { loading: string; success: string; error: string }
+  ) =>
+    toast.promise(promise, {
+      loading: msgs.loading,
+      success: msgs.success,
+      error: msgs.error,
+    }),
+}


### PR DESCRIPTION
## Summary

Closes #20 

<!-- What does this PR do? 2-3 sentences. -->

Adds a global toast notification system using `react-hot-toast` so users 
see instant success/error feedback after actions like creating an AI system, 
generating documents, or handling failures. A reusable `notify` helper is 
provided so any component can trigger toasts in one line.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## What was added
- `react-hot-toast` installed as a dependency
- `<Toaster />` mounted globally in `App.tsx` with Tailwind-consistent 
  success (green) and error (red) styles, positioned top-right
- `src/utils/toast.ts` — reusable `notify` helper exposing:
  - `notify.success(msg)` 
  - `notify.error(msg)`
  - `notify.loading(msg)`
  - `notify.dismiss(id?)`
  - `notify.promise(promise, { loading, success, error })`

## How to use in any component
```tsx
import { notify } from '../utils/toast'

// Success
notify.success('AI System created successfully!')

// Error
notify.error('Failed to delete document.')

// Promise (handles loading → success/error automatically)
notify.promise(apiCall(), {
  loading: 'Saving...',
  success: 'Saved successfully!',
  error: 'Something went wrong.',
})
```

## Screenshots
Toast appears top-right with green styling for success, red for error.

<!-- Add before/after screenshots here -->
<img width="759" height="726" alt="Screenshot 2026-05-10 231147" src="https://github.com/user-attachments/assets/8fcb8a7c-e14e-4687-b08b-c3792ceb1904" />
<img width="630" height="210" alt="Screenshot 2026-05-10 231004" src="https://github.com/user-attachments/assets/c556bb34-3d6e-4dd6-abb7-f9a9eef1c556" />
<img width="731" height="436" alt="Screenshot 2026-05-10 230958" src="https://github.com/user-attachments/assets/b54c2e6c-5d78-421c-a404-4cd10ac37d20" />
