### PR TITLE
feat: add compliance_score as Float nullable field in AISystem model and schemas

### DIFF
--- a/backend/app/models/ai_system.py
+++ b/backend/app/models/ai_system.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, Enum, ForeignKey, JSON
+from sqlalchemy import Column, Integer, String, Text, DateTime, Enum, ForeignKey, JSON, Float
 from sqlalchemy.orm import relationship
 from datetime import datetime
 import enum
@@ -38,7 +38,7 @@ class AISystem(Base):
     
     # Compliance tracking
     compliance_status = Column(Enum(ComplianceStatus), default=ComplianceStatus.NOT_STARTED)
-    compliance_score = Column(Integer, default=0)  # 0-100
+    compliance_score = Column(Float, nullable=True, default=None)  # 0.0–100.0, null until classification runs
     
     # Questionnaire responses (JSON)
     questionnaire_responses = Column(JSON, default=dict)

--- a/backend/app/schemas/ai_system.py
+++ b/backend/app/schemas/ai_system.py
@@ -30,7 +30,7 @@ class AISystemResponse(BaseModel):
     sector: Optional[str]
     risk_level: Optional[RiskLevel]
     compliance_status: ComplianceStatus
-    compliance_score: int
+    compliance_score: Optional[float] = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -6,11 +6,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 from pydantic import BaseModel
 from datetime import datetime
+from typing import Optional
 
 
 class ComplianceSnapshotResponse(BaseModel):
     ai_system_id: int
-    compliance_score: int
+    compliance_score: Optional[float] = None
     compliance_status: str
     risk_level: str | None
     snapshotted_at: datetime


### PR DESCRIPTION
## Summary
Closes #44

Changed `compliance_score` from `Integer` to `Float` with `nullable=True` and 
`default=None` in the AISystem model, and updated the schemas to expose it as 
`Optional[float] = None` in API responses.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)
N/A