### PR TITLE
fix: compute and persist compliance_score after classification

### DIFF
--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -6,7 +6,8 @@ import io
 from app.core.database import get_db
 from app.core.security import get_current_user
 from app.models.user import User
-from app.models.ai_system import AISystem
+from app.models.ai_system import AISystem, RiskAssessment
+from app.core.scoring import compute_compliance_score
 from app.schemas.ai_system import (
     AISystemCreate, 
     AISystemUpdate, 
@@ -134,8 +135,6 @@ async def bulk_import_systems(
         csv_reader = csv.DictReader(io.StringIO(decoded_content))
         
         for row_num, row in enumerate(csv_reader, start=2):
-            row_errors = []
-            
             if not row.get("name", "").strip():
                 errors.append({"row": row_num, "error": "name is required"})
                 continue
@@ -185,3 +184,32 @@ async def bulk_import_systems(
         )
     
     return BulkImportResponse(created=created_count, errors=errors)
+
+
+@router.post("/{system_id}/recalculate-score")
+def recalculate_score(
+    system_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Recalculate compliance score from the latest risk assessment."""
+    system = db.query(AISystem).filter(
+        AISystem.id == system_id,
+        AISystem.owner_id == current_user.id
+    ).first()
+    if not system:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="AI system not found")
+
+    assessment = (
+        db.query(RiskAssessment)
+        .filter(RiskAssessment.ai_system_id == system_id)
+        .order_by(RiskAssessment.assessed_at.desc())
+        .first()
+    )
+
+    if assessment:
+        system.compliance_score = compute_compliance_score(assessment)
+        db.commit()
+        return {"id": system_id, "assessment_id": assessment.id, "compliance_score": system.compliance_score}
+
+    return {"id": system_id, "assessment_id": None, "compliance_score": system.compliance_score}

--- a/backend/app/api/v1/classification.py
+++ b/backend/app/api/v1/classification.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from typing import List
 
 from app.core.database import get_db
 from app.core.security import get_current_user
 from app.models.user import User
 from app.models.ai_system import AISystem, RiskLevel, RiskAssessment, ComplianceStatus
 from app.schemas.ai_system import RiskClassificationRequest, RiskClassificationResponse
+from app.core.scoring import compute_compliance_score
 
 router = APIRouter()
 
@@ -20,11 +20,7 @@ def classify_risk(data: RiskClassificationRequest) -> RiskClassificationResponse
     risk_level = RiskLevel.MINIMAL
     confidence = 0.9
     
-    # Check for UNACCEPTABLE risk (Article 5 - Prohibited practices)
-    # Social scoring, real-time biometric identification in public spaces, etc.
-    # These are typically banned outright
-    
-    # Check for HIGH risk (Article 6 + Annex III)
+    # HIGH risk (Article 6 + Annex III)
     high_risk_indicators = []
     
     # HR and recruitment AI (Annex III, point 4)
@@ -61,11 +57,8 @@ def classify_risk(data: RiskClassificationRequest) -> RiskClassificationResponse
         high_risk_indicators.append("Law enforcement/justice system use")
         reasons.append("Use in law enforcement, border control, or justice is HIGH risk")
     
-    # Determine if HIGH risk
     if high_risk_indicators:
         risk_level = RiskLevel.HIGH
-    
-    # Check for LIMITED risk (Article 52 - Transparency obligations)
     elif data.interacts_with_humans or data.emotion_recognition or data.generates_synthetic_content:
         risk_level = RiskLevel.LIMITED
         if data.interacts_with_humans:
@@ -78,12 +71,10 @@ def classify_risk(data: RiskClassificationRequest) -> RiskClassificationResponse
             reasons.append("System generates synthetic/manipulated content")
             requirements.append("Label AI-generated content appropriately")
     
-    # MINIMAL risk - no specific requirements
     else:
         reasons.append("System does not fall into high-risk or limited-risk categories")
         requirements.append("No mandatory requirements, but voluntary codes of conduct encouraged")
     
-    # Generate next steps based on risk level
     next_steps = []
     if risk_level == RiskLevel.HIGH:
         next_steps = [
@@ -138,7 +129,6 @@ def classify_and_save(
     """
     Classify an AI system and save the result to the database.
     """
-    # Get the AI system
     system = db.query(AISystem).filter(
         AISystem.id == system_id,
         AISystem.owner_id == current_user.id
@@ -150,25 +140,30 @@ def classify_and_save(
             detail="AI system not found"
         )
     
-    # Perform classification
     result = classify_risk(data)
-    
-    # Update the AI system
+
     system.risk_level = result.risk_level
     system.compliance_status = ComplianceStatus.IN_PROGRESS
     system.questionnaire_responses = data.model_dump()
     
-    # Create risk assessment record
+    base_score = 70 if result.risk_level == RiskLevel.MINIMAL else (50 if result.risk_level == RiskLevel.LIMITED else 30)
     assessment = RiskAssessment(
         ai_system_id=system.id,
         assessment_type="initial",
         risk_level=result.risk_level,
         findings=[{"type": "classification", "reasons": result.reasons}],
         recommendations=[{"requirements": result.requirements, "next_steps": result.next_steps}],
-        overall_score=70 if result.risk_level == RiskLevel.MINIMAL else 30
+        overall_score=base_score,
+        data_governance_score=base_score,
+        transparency_score=base_score,
+        human_oversight_score=base_score,
+        robustness_score=base_score,
     )
     db.add(assessment)
-    
+    db.flush()
+
+    system.compliance_score = compute_compliance_score(assessment)
+
     db.commit()
     db.refresh(system)
     

--- a/backend/app/core/scoring.py
+++ b/backend/app/core/scoring.py
@@ -1,0 +1,24 @@
+from app.models.ai_system import RiskAssessment
+
+
+def compute_compliance_score(assessment: RiskAssessment) -> int:
+    """
+    Compute a 0–100 compliance score from sub-scores.
+    Weights:
+      data_governance:     25%
+      transparency:        25%
+      human_oversight:     25%
+      robustness:          25%
+    Missing sub-scores are treated as 0.
+    """
+    weights = {
+        "data_governance_score": 0.25,
+        "transparency_score": 0.25,
+        "human_oversight_score": 0.25,
+        "robustness_score": 0.25,
+    }
+    total = sum(
+        (getattr(assessment, field) or 0) * weight
+        for field, weight in weights.items()
+    )
+    return round(total)


### PR DESCRIPTION
## Summary

Closes #<!143>

## Problem

`AISystem.compliance_score` defaulted to `0` / `null` and was never
updated after classification ran. The dashboard compliance bar always
showed 0 regardless of the system's actual risk posture.

## Root Cause

Two gaps:
1. No utility existed to compute a score from sub-scores.
2. `classify_and_save()` created a `RiskAssessment` without setting any
   of the four sub-score columns (`data_governance_score`,
   `transparency_score`, `human_oversight_score`, `robustness_score`),
   so any rollup would have summed `None → 0`.

## Changes

### `backend/app/core/scoring.py` (new file)
- `compute_compliance_score(assessment)` — weights the four sub-scores
  equally at 25% each; missing/null sub-scores treated as 0; returns
  `round(total)` as `int`.

### `backend/app/api/v1/classification.py`
- Seeds all four sub-scores from `base_score` at assessment creation
  time (`MINIMAL=70`, `LIMITED=50`, `HIGH=30`).
- Calls `compute_compliance_score()` after `db.flush()` and writes the
  result to `AISystem.compliance_score` before `db.commit()`.
- Removed unused `from typing import List` import.

### `backend/app/api/v1/ai_systems.py`
- Added `POST /ai-systems/{id}/recalculate-score` endpoint — fetches
  the latest `RiskAssessment` (ordered by `assessed_at DESC`),
  recomputes the score, persists it, and returns
  `{id, assessment_id, compliance_score}`. Returns 404 if the system
  does not exist.
- Removed unused `row_errors = []` variable in `bulk_import_systems()`.

## Acceptance Criteria

- [x] After `POST /classification/classify/{id}`, `AISystem.compliance_score`
      is non-zero (`70` / `50` / `30` depending on risk level).
- [x] A system with all four sub-scores at `80` → `compliance_score == 80`
      (`0.25 × 80 × 4 = 80`).
- [x] Dashboard compliance bar reflects the real value — no frontend
      changes required; the field was already present in
      `AISystemResponse`.

## Testing Notes

**Manual (Swagger UI at `/docs`)**
1. Register + login to get a JWT.
2. `POST /ai-systems/` — create a system, note the `id`.
3. `POST /classification/classify/{id}` with any questionnaire payload.
4. `GET /ai-systems/{id}` — confirm `compliance_score` is `70`, `50`,
   or `30` (not `null`).
5. `POST /ai-systems/{id}/recalculate-score` — confirm it returns the
   same score and the `assessment_id`.

**Unit test (no DB required)**
```python
from unittest.mock import MagicMock
from app.core.scoring import compute_compliance_score

def test_all_80():
    a = MagicMock(
        data_governance_score=80,
        transparency_score=80,
        human_oversight_score=80,
        robustness_score=80,
    )
    assert compute_compliance_score(a) == 80

def test_missing_scores():
    a = MagicMock(
        data_governance_score=None,
        transparency_score=None,
        human_oversight_score=None,
        robustness_score=None,
    )
    assert compute_compliance_score(a) == 0
