### PR TITLE
Add compliance score rollup calculation for AISystem

### DIFF
--- a/backend/app/api/v1/classification.py
+++ b/backend/app/api/v1/classification.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from typing import List
 
 from app.core.database import get_db
+from app.services.compliance_score import calculate_compliance_score
 from app.core.security import get_current_user
 from app.models.user import User
 from app.models.ai_system import AISystem, RiskLevel, RiskAssessment, ComplianceStatus
@@ -168,7 +169,7 @@ def classify_and_save(
         overall_score=70 if result.risk_level == RiskLevel.MINIMAL else 30
     )
     db.add(assessment)
-    
+    system.compliance_score = calculate_compliance_score(assessment)
     db.commit()
     db.refresh(system)
     

--- a/backend/app/services/compliance_score.py
+++ b/backend/app/services/compliance_score.py
@@ -1,0 +1,22 @@
+from app.models.ai_system import RiskAssessment
+
+
+def calculate_compliance_score(assessment: RiskAssessment) -> float:
+    """
+    Calculate weighted compliance score from assessment sub-scores.
+    Returns a value between 0.0 and 100.0.
+    """
+
+    scores = [
+        assessment.data_governance_score,
+        assessment.transparency_score,
+        assessment.human_oversight_score,
+        assessment.robustness_score,
+    ]
+
+    valid_scores = [score for score in scores if score is not None]
+
+    if not valid_scores:
+        return float(assessment.overall_score or 0)
+
+    return round(sum(valid_scores) / len(valid_scores), 2)


### PR DESCRIPTION
 Description

Implemented a compliance score rollup calculation for AISystem. compliance_score based on the latest RiskAssessment sub-scores.

What’s included

 Added a reusable calculate_compliance_score() utility in the services layer
 Calculated compliance score using:

    data_governance_score
    transparency_score
    human_oversight_score
    robustness_score
Added a fallback to overall_score when detailed sub-scores are not available Updated the classification flow so the compliance score is automatically updated whenever a new assessment is created

Why this approach

I kept the calculation logic separate from the API route to make it cleaner, reusable, and easier to extend in the future if scoring weights or additional metrics are introduced.

Closes #143
