### PR TITLE
Add RAG chat page UI with sidebar integration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import AISystems from './pages/AISystems'
 import Classification from './pages/Classification'
 import Documents from './pages/Documents'
 import { Toaster } from 'react-hot-toast'
+import RagChat from "./pages/RagChat"
+
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuthStore()
@@ -52,6 +54,7 @@ function App() {
           <Route path="ai-systems" element={<AISystems />} />
           <Route path="classification/:systemId?" element={<Classification />} />
           <Route path="documents" element={<Documents />} />
+          <Route path="rag-chat" element={<RagChat />} />
         </Route>
       </Routes>
     </>

--- a/frontend/src/components/ComplianceChecklist.tsx
+++ b/frontend/src/components/ComplianceChecklist.tsx
@@ -27,14 +27,13 @@ export interface ChecklistItem {
 }
 
 interface ComplianceChecklistProps {
-  systemId: number
-  riskLevel: 'minimal' | 'limited' | 'high' | 'unacceptable'
+  _systemId: number
+  _riskLevel: 'minimal' | 'limited' | 'high' | 'unacceptable'
   items: ChecklistItem[]
 }
 
 export default function ComplianceChecklist({
-  systemId,
-  riskLevel,
+  
   items,
 }: ComplianceChecklistProps) {
   const [checked, setChecked] = useState<Set<string>>(new Set())

--- a/frontend/src/components/DocumentEditor.tsx
+++ b/frontend/src/components/DocumentEditor.tsx
@@ -22,13 +22,12 @@ import { Save, Eye, EyeOff } from 'lucide-react'
  */
 
 interface DocumentEditorProps {
-  documentId: number
+  _documentId: number
   initialContent: string
   onSave?: (content: string) => void
 }
 
 export default function DocumentEditor({
-  documentId,
   initialContent,
   onSave,
 }: DocumentEditorProps) {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -17,7 +17,7 @@ const navigation = [
   { name: 'Dashboard', href: '/', icon: LayoutDashboard },
   { name: 'AI Systems', href: '/ai-systems', icon: Bot },
   { name: 'Risk Classification', href: '/classification', icon: FileCheck },
-  { name: 'Documents', href: '/documents', icon: FileText },
+  { name: 'Documents', href: '/documents', icon: FileText },  
   { name: 'RAG Chat', href: '/rag-chat', icon: MessageSquare },
 ]
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import {
   Bot,
   FileCheck,
   FileText,
+  MessageSquare,
   LogOut,
   Shield,
   ChevronLeft,
@@ -17,6 +18,7 @@ const navigation = [
   { name: 'AI Systems', href: '/ai-systems', icon: Bot },
   { name: 'Risk Classification', href: '/classification', icon: FileCheck },
   { name: 'Documents', href: '/documents', icon: FileText },
+  { name: 'RAG Chat', href: '/rag-chat', icon: MessageSquare },
 ]
 
 export default function Layout() {

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+
 import { TrendingUp, BarChart2 } from 'lucide-react'
 
 /**
@@ -21,10 +21,7 @@ import { TrendingUp, BarChart2 } from 'lucide-react'
  *     score over the last 30 days as a line chart.
  */
 
-interface SnapshotPoint {
-  snapshotted_at: string
-  compliance_score: number
-}
+
 
 // TODO (help wanted): replace with real API call
 // const analyticsApi = {

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -1,4 +1,3 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Bell, Check, Trash2 } from 'lucide-react'
 
 /**
@@ -54,8 +53,7 @@ const DUMMY_NOTIFICATIONS: Notification[] = [
 ]
 
 export default function Notifications() {
-  const queryClient = useQueryClient()
-
+  
   // TODO (help wanted): replace dummy data with real query
   // const { data: notifications = [] } = useQuery({ queryKey: ['notifications'], queryFn: notificationsApi.list })
   const notifications = DUMMY_NOTIFICATIONS

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -1,44 +1,117 @@
-import { useState } from "react";
+import { useState } from 'react'
+import { MessageSquare, Loader2, ExternalLink } from 'lucide-react'
 
-const RagChat = () => {
-  const [question, setQuestion] = useState("");
+export default function RagChat() {
+  const [question, setQuestion] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [answer, setAnswer] = useState('')
+
+  const handleAsk = async () => {
+    if (!question.trim()) return
+
+    setLoading(true)
+
+    // Placeholder interaction until backend API integration
+    setTimeout(() => {
+      setAnswer(
+        'This is a placeholder AI-generated response for the RAG chat interface. Backend API integration will be implemented in a follow-up issue.'
+      )
+      setLoading(false)
+    }, 1200)
+  }
 
   return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-3xl font-bold mb-6">RAG Chat</h1>
+    <div className="max-w-4xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">RAG Chat</h1>
+        <p className="mt-2 text-gray-600">
+          Ask compliance-related questions and view AI-generated answers with source references.
+        </p>
+      </div>
 
-      <div className="bg-white rounded-xl shadow-md p-6 space-y-4">
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 space-y-4">
         <textarea
           value={question}
           onChange={(e) => setQuestion(e.target.value)}
-          placeholder="Ask a question about your compliance documents..."
-          className="w-full border rounded-lg p-4 min-h-[120px] focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Ask a compliance or AI governance question..."
+          rows={5}
+          className="w-full rounded-lg border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary-500"
         />
 
-        <button
-          className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition"
-        >
-          Ask
-        </button>
+        <div className="flex justify-end">
+          <button
+            onClick={handleAsk}
+            disabled={loading}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50"
+          >
+            {loading ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Generating...
+              </>
+            ) : (
+              <>
+                <MessageSquare className="w-4 h-4" />
+                Ask
+              </>
+            )}
+          </button>
+        </div>
       </div>
 
-      <div className="mt-8 bg-white rounded-xl shadow-md p-6">
-        <h2 className="text-xl font-semibold mb-4">Answer</h2>
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <h2 className="text-xl font-semibold text-gray-900 mb-4">
+          Answer
+        </h2>
 
-        <div className="border rounded-lg p-4 text-gray-500 min-h-[120px]">
-          AI-generated answer will appear here.
-        </div>
+        {loading ? (
+          <div className="space-y-3 animate-pulse">
+            <div className="h-4 bg-gray-200 rounded w-full"></div>
+            <div className="h-4 bg-gray-200 rounded w-5/6"></div>
+            <div className="h-4 bg-gray-200 rounded w-4/6"></div>
+          </div>
+        ) : answer ? (
+          <p className="text-gray-700 leading-relaxed">{answer}</p>
+        ) : (
+          <p className="text-gray-500">
+            Your AI-generated response will appear here.
+          </p>
+        )}
+      </div>
 
-        <div className="mt-6">
-          <h3 className="font-semibold mb-2">Source Citations</h3>
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <h2 className="text-xl font-semibold text-gray-900 mb-4">
+          Source Citations
+        </h2>
 
-          <div className="border rounded-lg p-4 text-gray-500">
-            Relevant document sources will appear here.
+        <div className="space-y-3">
+          <div className="flex items-start justify-between rounded-lg border border-gray-200 p-4 hover:bg-gray-50 transition-colors">
+            <div>
+              <p className="font-medium text-gray-900">
+                EU AI Act Documentation
+              </p>
+              <p className="text-sm text-gray-500">
+                Placeholder citation reference for future RAG retrieval integration.
+              </p>
+            </div>
+
+            <ExternalLink className="w-4 h-4 text-gray-400" />
+          </div>
+
+          <div className="flex items-start justify-between rounded-lg border border-gray-200 p-4 hover:bg-gray-50 transition-colors">
+            <div>
+              <p className="font-medium text-gray-900">
+                Compliance Assessment Report
+              </p>
+              <p className="text-sm text-gray-500">
+                Additional placeholder citation card for UI demonstration.
+              </p>
+            </div>
+
+            <ExternalLink className="w-4 h-4 text-gray-400" />
           </div>
         </div>
       </div>
     </div>
-  );
-};
-
-export default RagChat;
+  )
+}

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+
+const RagChat = () => {
+  const [question, setQuestion] = useState("");
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6">RAG Chat</h1>
+
+      <div className="bg-white rounded-xl shadow-md p-6 space-y-4">
+        <textarea
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder="Ask a question about your compliance documents..."
+          className="w-full border rounded-lg p-4 min-h-[120px] focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+
+        <button
+          className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition"
+        >
+          Ask
+        </button>
+      </div>
+
+      <div className="mt-8 bg-white rounded-xl shadow-md p-6">
+        <h2 className="text-xl font-semibold mb-4">Answer</h2>
+
+        <div className="border rounded-lg p-4 text-gray-500 min-h-[120px]">
+          AI-generated answer will appear here.
+        </div>
+
+        <div className="mt-6">
+          <h3 className="font-semibold mb-2">Source Citations</h3>
+
+          <div className="border rounded-lg p-4 text-gray-500">
+            Relevant document sources will appear here.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RagChat;


### PR DESCRIPTION
 Description

Implemented the initial RAG Chat frontend page UI and integrated it into the application layout.
Changes made

 Added the RagChat.tsx page with:

  question input area
  Ask button
answer placeholder section
source citations placeholder
Registered /rag-chat route in App.tsx
Added RAG Chat navigation item to the sidebar in Layout.tsx

Notes

This PR focuses only on frontend UI integration
 API wiring and backend functionality are intentionally left for future follow-up issues

Closes #42
