### PR TITLE
feat: add bulk scan endpoint POST /api/v1/guard/scan/batch

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -106,3 +106,74 @@ def scan_prompt(
 def guard_health():
     """Check if the Guard module is available."""
     return {"module": "llm_guard", "status": "available"}
+class BulkScanRequest(BaseModel):
+    prompts: list[str]
+
+    def validate_prompts(self):
+        if len(self.prompts) > 50:
+            raise ValueError("Maximum 50 prompts allowed per batch request.")
+        return self
+
+class BulkScanResponse(BaseModel):
+    results: list[ScanResponse]
+    total: int
+    processed: int
+
+@router.post("/scan/batch", response_model=BulkScanResponse)
+def bulk_scan_prompts(
+    request: BulkScanRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Scan a batch of prompts (max 50) for injection risks.
+    Processes sequentially to respect memory constraints.
+    Returns a decision for each prompt.
+    """
+    if len(request.prompts) > 50:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Maximum 50 prompts allowed per batch request."
+        )
+
+    limited, retry_after = _check_rate_limit(current_user.id)
+    if limited:
+        return JSONResponse(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            content={"detail": "Rate limit exceeded. Please try again later."},
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    try:
+        from app.modules.guard.llm_guard import LLMGuard
+        from app.modules.guard.sanitizer import SanitizationLevel
+        from app.core.config import settings
+
+        level_map = {
+            "low": SanitizationLevel.LOW,
+            "medium": SanitizationLevel.MEDIUM,
+            "high": SanitizationLevel.HIGH,
+        }
+        san_level = level_map.get(settings.GUARD_SANITIZATION_LEVEL, SanitizationLevel.MEDIUM)
+        guard = LLMGuard(sanitization_level=san_level)
+
+        results = []
+        for prompt in request.prompts:
+            result = guard.guard(prompt)
+            results.append(ScanResponse(
+                decision=result["decision"],
+                confidence=result["metadata"]["decision_reasoning"]["confidence"],
+                reasoning=result["metadata"]["decision_reasoning"]["reasoning"],
+                sanitized_prompt=None,
+                matched_patterns=result["metadata"]["regex_analysis"].get("matched_patterns", []),
+            ))
+
+        return BulkScanResponse(
+            results=results,
+            total=len(request.prompts),
+            processed=len(results),
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e)
+        )


### PR DESCRIPTION
## Summary

Closes #58

Added a new bulk scan endpoint `POST /api/v1/guard/scan/batch` that accepts 
a list of prompts (max 50) and returns a decision for each, processing 
sequentially to respect memory constraints.
## Type of Change

- [x] New feature

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style (PEP 8 for Python)
- [x] I have not committed `.env` or any secrets

