### PR TITLE
feat(compliance): add GET /ai-systems/export — download registry as CSV

### DIFF
--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Query
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Optional
 import csv
 import io
 from app.core.database import get_db
@@ -8,8 +9,8 @@ from app.core.security import get_current_user
 from app.models.user import User
 from app.models.ai_system import AISystem
 from app.schemas.ai_system import (
-    AISystemCreate, 
-    AISystemUpdate, 
+    AISystemCreate,
+    AISystemUpdate,
     AISystemResponse,
     BulkImportResponse
 )
@@ -48,6 +49,137 @@ def list_ai_systems(
     return systems
 
 
+@router.post("/import", response_model=BulkImportResponse)
+def bulk_import_systems(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Import AI systems from a CSV file."""
+    errors = []
+    created_count = 0
+
+    if not file.filename or not file.filename.lower().endswith('.csv'):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid CSV format: File must have .csv extension"
+        )
+
+    try:
+        content = file.file.read()
+        decoded_content = content.decode("utf-8")
+
+        if not decoded_content.strip():
+            return BulkImportResponse(created=0, errors=[])
+
+        f = io.StringIO(decoded_content)
+        csv_reader = csv.DictReader(f)
+
+        if not csv_reader.fieldnames:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid CSV format: No headers found"
+            )
+
+        for row_num, row in enumerate(csv_reader, start=2):
+            if not any(row.values()):
+                continue
+
+            name = row.get("name", "").strip()
+            if not name:
+                errors.append({"row": row_num, "error": "name is required"})
+                continue
+
+            existing = db.query(AISystem).filter(
+                AISystem.owner_id == current_user.id,
+                AISystem.name == name
+            ).first()
+
+            if existing:
+                errors.append({"row": row_num, "error": f"duplicate name '{name}'"})
+                continue
+
+            try:
+                ai_system = AISystem(
+                    owner_id=current_user.id,
+                    name=name,
+                    description=row.get("description", "").strip() or None,
+                    version=row.get("version", "").strip() or None,
+                    use_case=row.get("use_case", "").strip() or None,
+                    sector=row.get("sector", "").strip() or None
+                )
+                db.add(ai_system)
+                created_count += 1
+            except Exception as e:
+                errors.append({"row": row_num, "error": str(e)})
+
+        db.commit()
+
+    except UnicodeDecodeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File must be UTF-8 encoded CSV"
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Error processing CSV: {str(e)}"
+        )
+
+    return BulkImportResponse(created=created_count, errors=errors)
+
+
+@router.get("/export")
+def export_ai_systems(
+    risk_level: Optional[str] = Query(None, description="Filter by risk level: minimal, limited, high, unacceptable"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Export the authenticated user's AI systems registry as a CSV file."""
+    query = db.query(AISystem).filter(AISystem.owner_id == current_user.id)
+
+    if risk_level is not None:
+        allowed = {"minimal", "limited", "high", "unacceptable"}
+        if risk_level.lower() not in allowed:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid risk_level '{risk_level}'. Allowed: {', '.join(sorted(allowed))}",
+            )
+        query = query.filter(AISystem.risk_level == risk_level.lower())
+
+    systems = query.all()
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow([
+        "id", "name", "description", "version", "use_case", "sector",
+        "risk_level", "compliance_status", "compliance_score", "created_at",
+    ])
+    for s in systems:
+        writer.writerow([
+            s.id,
+            s.name,
+            s.description or "",
+            s.version or "",
+            s.use_case or "",
+            s.sector or "",
+            s.risk_level.value if s.risk_level else "",
+            s.compliance_status.value if s.compliance_status else "",
+            s.compliance_score if s.compliance_score is not None else "",
+            s.created_at.isoformat() if s.created_at else "",
+        ])
+
+    output.seek(0)
+    return StreamingResponse(
+        iter([output.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=\"ai_systems.csv\""},
+    )
+
+
 @router.get("/{system_id}", response_model=AISystemResponse)
 def get_ai_system(
     system_id: int,
@@ -59,7 +191,7 @@ def get_ai_system(
         AISystem.id == system_id,
         AISystem.owner_id == current_user.id
     ).first()
-    
+
     if not system:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -80,17 +212,17 @@ def update_ai_system(
         AISystem.id == system_id,
         AISystem.owner_id == current_user.id
     ).first()
-    
+
     if not system:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="AI system not found"
         )
-    
+
     update_data = system_data.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         setattr(system, field, value)
-    
+
     db.commit()
     db.refresh(system)
     return system
@@ -107,99 +239,12 @@ def delete_ai_system(
         AISystem.id == system_id,
         AISystem.owner_id == current_user.id
     ).first()
-    
+
     if not system:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="AI system not found"
         )
-    
+
     db.delete(system)
     db.commit()
-
-
-@router.post("/import", response_model=BulkImportResponse)
-def bulk_import_systems(
-    file: UploadFile = File(...),
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
-):
-    """Import AI systems from a CSV file."""
-    errors = []
-    created_count = 0
-    
-    # Basic validation: check file extension
-    if not file.filename or not file.filename.lower().endswith('.csv'):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid CSV format: File must have .csv extension"
-        )
-
-    try:
-        content = file.file.read()
-        decoded_content = content.decode("utf-8")
-        
-        # Check if file is empty
-        if not decoded_content.strip():
-            return BulkImportResponse(created=0, errors=[])
-
-        f = io.StringIO(decoded_content)
-        csv_reader = csv.DictReader(f)
-        
-        # Check if we have headers
-        if not csv_reader.fieldnames:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid CSV format: No headers found"
-            )
-
-        for row_num, row in enumerate(csv_reader, start=2):
-            # Skip empty rows
-            if not any(row.values()):
-                continue
-
-            name = row.get("name", "").strip()
-            if not name:
-                errors.append({"row": row_num, "error": "name is required"})
-                continue
-            
-            existing = db.query(AISystem).filter(
-                AISystem.owner_id == current_user.id,
-                AISystem.name == name
-            ).first()
-            
-            if existing:
-                errors.append({"row": row_num, "error": f"duplicate name '{name}'"})
-                continue
-            
-            try:
-                ai_system = AISystem(
-                    owner_id=current_user.id,
-                    name=name,
-                    description=row.get("description", "").strip() or None,
-                    version=row.get("version", "").strip() or None,
-                    use_case=row.get("use_case", "").strip() or None,
-                    sector=row.get("sector", "").strip() or None
-                )
-                db.add(ai_system)
-                created_count += 1
-            except Exception as e:
-                errors.append({"row": row_num, "error": str(e)})
-        
-        db.commit()
-        
-    except UnicodeDecodeError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="File must be UTF-8 encoded CSV"
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Error processing CSV: {str(e)}"
-        )
-    
-    return BulkImportResponse(created=created_count, errors=errors)

--- a/backend/tests/test_csv_export.py
+++ b/backend/tests/test_csv_export.py
@@ -1,0 +1,121 @@
+"""Tests for GET /api/v1/ai-systems/export endpoint."""
+
+import csv
+import io
+import os
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.database import Base, get_db
+from app.core.security import get_current_user
+from app.main import app
+from app.models.ai_system import AISystem, ComplianceStatus, RiskLevel
+from app.models.user import User
+
+
+@pytest.fixture(scope="module")
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=eng)
+    yield eng
+    Base.metadata.drop_all(bind=eng)
+
+
+@pytest.fixture
+def db(engine):
+    conn = engine.connect()
+    tx = conn.begin()
+    session = sessionmaker(autocommit=False, autoflush=False, bind=conn)()
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+@pytest.fixture
+def client(db):
+    user = User(email="export@test.com", hashed_password="x", full_name="Tester")
+    db.add(user)
+    db.flush()
+
+    def override_db():
+        yield db
+
+    def override_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    with TestClient(app) as c:
+        yield c, db, user
+
+    app.dependency_overrides.clear()
+
+
+class TestCSVExport:
+    def test_export_returns_csv_content_type(self, client):
+        c, db, user = client
+        resp = c.get("/api/v1/ai-systems/export")
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "ai_systems.csv" in resp.headers.get("content-disposition", "")
+
+    def test_export_empty_registry_returns_header_row_only(self, client):
+        c, db, user = client
+        resp = c.get("/api/v1/ai-systems/export")
+        reader = csv.reader(io.StringIO(resp.text))
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0][0] == "id"
+        assert "name" in rows[0]
+        assert "risk_level" in rows[0]
+
+    def test_export_includes_system_data(self, client):
+        c, db, user = client
+        system = AISystem(
+            owner_id=user.id,
+            name="Credit Scorer",
+            use_case="Credit",
+            sector="Finance",
+            risk_level=RiskLevel.HIGH,
+            compliance_status=ComplianceStatus.IN_PROGRESS,
+            compliance_score=65.5,
+        )
+        db.add(system)
+        db.flush()
+
+        resp = c.get("/api/v1/ai-systems/export")
+        assert resp.status_code == 200
+
+        reader = csv.DictReader(io.StringIO(resp.text))
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Credit Scorer"
+        assert rows[0]["risk_level"] == "high"
+        assert rows[0]["compliance_score"] == "65.5"
+
+    def test_export_risk_level_filter(self, client):
+        c, db, user = client
+        db.add(AISystem(owner_id=user.id, name="Low Risk System", risk_level=RiskLevel.MINIMAL))
+        db.add(AISystem(owner_id=user.id, name="High Risk System", risk_level=RiskLevel.HIGH))
+        db.flush()
+
+        resp = c.get("/api/v1/ai-systems/export?risk_level=minimal")
+        assert resp.status_code == 200
+
+        reader = csv.DictReader(io.StringIO(resp.text))
+        rows = list(reader)
+        assert all(r["risk_level"] == "minimal" for r in rows)
+
+    def test_export_invalid_risk_level_returns_400(self, client):
+        c, db, user = client
+        resp = c.get("/api/v1/ai-systems/export?risk_level=banana")
+        assert resp.status_code == 400
+        assert "risk_level" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Implements #203.

- Adds `GET /api/v1/ai-systems/export` returning the authenticated user's AI systems as a downloadable CSV file
- Optional `?risk_level=` query param filters the export (returns 400 on invalid value)
- Response sets `Content-Type: text/csv` and `Content-Disposition: attachment; filename="ai_systems.csv"`
- Empty registry returns a CSV with headers only (not 404)
- Export route is registered before `/{system_id}` to avoid FastAPI routing conflicts

## Changes

- `backend/app/api/v1/ai_systems.py` — new `/export` endpoint + route ordering fix
- `backend/tests/test_csv_export.py` — 5 unit tests (headers, empty, data rows, filter, invalid param)

## Test plan

- [x] `test_export_returns_csv_content_type` — correct headers returned
- [x] `test_export_empty_registry_returns_header_row_only` — no 404 on empty
- [x] `test_export_includes_system_data` — row data matches DB record
- [x] `test_export_risk_level_filter` — filter limits rows correctly
- [x] `test_export_invalid_risk_level_returns_400` — bad param rejected cleanly