### PR TITLE
feat(compliance): add sort_by and order query params to GET /ai-systems

### DIFF
--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Query
 from fastapi.responses import StreamingResponse
+from sqlalchemy import asc, desc
 from sqlalchemy.orm import Session
 from typing import List, Optional
 import csv
@@ -39,13 +40,42 @@ def create_ai_system(
     return ai_system
 
 
+_SORTABLE_FIELDS = {
+    "name": AISystem.name,
+    "risk_level": AISystem.risk_level,
+    "compliance_score": AISystem.compliance_score,
+    "created_at": AISystem.created_at,
+}
+
+
 @router.get("/", response_model=List[AISystemResponse])
 def list_ai_systems(
+    sort_by: Optional[str] = Query("created_at", description="Sort field: name, risk_level, compliance_score, created_at"),
+    order: Optional[str] = Query("desc", description="Sort direction: asc, desc"),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user),
 ):
-    """List all AI systems for the current user."""
-    systems = db.query(AISystem).filter(AISystem.owner_id == current_user.id).all()
+    """List all AI systems for the current user, with optional sorting."""
+    if sort_by not in _SORTABLE_FIELDS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid sort_by '{sort_by}'. Allowed: {', '.join(sorted(_SORTABLE_FIELDS))}",
+        )
+    if order not in ("asc", "desc"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid order. Use 'asc' or 'desc'.",
+        )
+
+    column = _SORTABLE_FIELDS[sort_by]
+    direction = asc(column) if order == "asc" else desc(column)
+
+    systems = (
+        db.query(AISystem)
+        .filter(AISystem.owner_id == current_user.id)
+        .order_by(direction)
+        .all()
+    )
     return systems
 
 

--- a/backend/tests/test_ai_systems_sorting.py
+++ b/backend/tests/test_ai_systems_sorting.py
@@ -1,0 +1,96 @@
+"""Tests for sort_by / order query params on GET /api/v1/ai-systems."""
+
+import os
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.database import Base, get_db
+from app.core.security import get_current_user
+from app.main import app
+from app.models.ai_system import AISystem, RiskLevel
+from app.models.user import User
+
+
+@pytest.fixture(scope="module")
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=eng)
+    yield eng
+    Base.metadata.drop_all(bind=eng)
+
+
+@pytest.fixture
+def db(engine):
+    conn = engine.connect()
+    tx = conn.begin()
+    session = sessionmaker(autocommit=False, autoflush=False, bind=conn)()
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+@pytest.fixture
+def client(db):
+    user = User(email="sort@test.com", hashed_password="x", full_name="Sorter")
+    db.add(user)
+    db.flush()
+
+    db.add(AISystem(owner_id=user.id, name="Alpha System", compliance_score=90.0, risk_level=RiskLevel.MINIMAL))
+    db.add(AISystem(owner_id=user.id, name="Beta System", compliance_score=50.0, risk_level=RiskLevel.HIGH))
+    db.add(AISystem(owner_id=user.id, name="Gamma System", compliance_score=70.0, risk_level=RiskLevel.LIMITED))
+    db.flush()
+
+    def override_db():
+        yield db
+
+    def override_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+class TestAISystemsSorting:
+    def test_default_sort_returns_200(self, client):
+        resp = client.get("/api/v1/ai-systems/")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 3
+
+    def test_sort_by_name_asc(self, client):
+        resp = client.get("/api/v1/ai-systems/?sort_by=name&order=asc")
+        assert resp.status_code == 200
+        names = [s["name"] for s in resp.json()]
+        assert names == sorted(names)
+
+    def test_sort_by_name_desc(self, client):
+        resp = client.get("/api/v1/ai-systems/?sort_by=name&order=desc")
+        assert resp.status_code == 200
+        names = [s["name"] for s in resp.json()]
+        assert names == sorted(names, reverse=True)
+
+    def test_sort_by_compliance_score_desc(self, client):
+        resp = client.get("/api/v1/ai-systems/?sort_by=compliance_score&order=desc")
+        assert resp.status_code == 200
+        scores = [s["compliance_score"] for s in resp.json() if s["compliance_score"] is not None]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_invalid_sort_by_returns_400(self, client):
+        resp = client.get("/api/v1/ai-systems/?sort_by=banana")
+        assert resp.status_code == 400
+        assert "sort_by" in resp.json()["detail"].lower()
+
+    def test_invalid_order_returns_400(self, client):
+        resp = client.get("/api/v1/ai-systems/?order=sideways")
+        assert resp.status_code == 400
+        assert "order" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Implements #204.

- Adds `?sort_by=` and `?order=` query params to `GET /api/v1/ai-systems/`
- Sortable fields: `name`, `risk_level`, `compliance_score`, `created_at`
- Defaults: `sort_by=created_at`, `order=desc` — fully backwards compatible
- Invalid values return `400` with a descriptive message
- Uses SQLAlchemy `asc()`/`desc()` — no raw SQL

## Changes

- `backend/app/api/v1/ai_systems.py` — sorting logic on list endpoint
- `backend/tests/test_ai_systems_sorting.py` — 6 unit tests

## Test plan

- [x] Default call (no params) returns all systems — no regression
- [x] `sort_by=name&order=asc` — alphabetical ascending
- [x] `sort_by=name&order=desc` — alphabetical descending
- [x] `sort_by=compliance_score&order=desc` — highest score first
- [x] Invalid `sort_by` → 400
- [x] Invalid `order` → 400