### PR TITLE
feat(auth): add POST /auth/change-password endpoint

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,19 +1,31 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel, field_validator
 from sqlalchemy.orm import Session
 from datetime import timedelta
 
 from app.core.database import get_db
 from app.core.security import (
-    verify_password, 
-    get_password_hash, 
+    verify_password,
+    get_password_hash,
     create_access_token,
     get_current_user
 )
 from app.core.config import settings
-from app.core.database import get_db
 from app.models.user import User
 from app.schemas.user import UserCreate, UserResponse, UserUpdateSchema, Token
+
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_new_password(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("new_password must be at least 8 characters")
+        return v
 
 router = APIRouter()
 users_router = APIRouter()
@@ -77,6 +89,25 @@ def login(
 def get_current_user_info(current_user: User = Depends(get_current_user)):
     """Get current user information."""
     return current_user
+
+
+@router.post("/change-password", status_code=status.HTTP_200_OK)
+def change_password(
+    payload: ChangePasswordRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Change the authenticated user's password."""
+    if not verify_password(payload.current_password, current_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Current password is incorrect",
+        )
+
+    current_user.hashed_password = get_password_hash(payload.new_password)
+    current_user = db.merge(current_user)
+    db.commit()
+    return {"message": "Password updated successfully"}
 
 
 @users_router.patch("/me", response_model=UserResponse)

--- a/backend/tests/test_change_password.py
+++ b/backend/tests/test_change_password.py
@@ -1,0 +1,88 @@
+"""Tests for POST /api/v1/auth/change-password endpoint."""
+
+import os
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.database import Base, get_db
+from app.core.security import get_current_user, get_password_hash, verify_password
+from app.main import app
+from app.models.user import User
+
+
+@pytest.fixture(scope="module")
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=eng)
+    yield eng
+    Base.metadata.drop_all(bind=eng)
+
+
+@pytest.fixture
+def db(engine):
+    conn = engine.connect()
+    tx = conn.begin()
+    session = sessionmaker(autocommit=False, autoflush=False, bind=conn)()
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+@pytest.fixture
+def client(db):
+    user = User(
+        email="pw@test.com",
+        hashed_password=get_password_hash("oldpassword"),
+        full_name="Password Tester",
+    )
+    db.add(user)
+    db.flush()
+
+    def override_db():
+        yield db
+
+    def override_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    with TestClient(app) as c:
+        yield c, user
+
+    app.dependency_overrides.clear()
+
+
+class TestChangePassword:
+    def test_change_password_success(self, client):
+        c, user = client
+        resp = c.post(
+            "/api/v1/auth/change-password",
+            json={"current_password": "oldpassword", "new_password": "newsecret123"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "Password updated successfully"
+        assert verify_password("newsecret123", user.hashed_password)
+
+    def test_wrong_current_password_returns_400(self, client):
+        c, user = client
+        resp = c.post(
+            "/api/v1/auth/change-password",
+            json={"current_password": "wrongpassword", "new_password": "newsecret123"},
+        )
+        assert resp.status_code == 400
+        assert "incorrect" in resp.json()["detail"].lower()
+
+    def test_short_new_password_returns_422(self, client):
+        c, user = client
+        resp = c.post(
+            "/api/v1/auth/change-password",
+            json={"current_password": "oldpassword", "new_password": "short"},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Implements #206.

- Adds `POST /api/v1/auth/change-password` — lets authenticated users change their password
- Verifies `current_password` against stored bcrypt hash; returns 400 on mismatch
- Validates `new_password` is at least 8 characters via Pydantic validator; returns 422 if too short
- New password is hashed with bcrypt (same as registration) before saving
- Reuses `verify_password` and `get_password_hash` from `app/core/security.py` — no new crypto code
- Existing tokens remain valid after the change (token invalidation is a separate concern)

## Changes

- `backend/app/api/v1/auth.py` — `ChangePasswordRequest` schema + `POST /change-password` endpoint
- `backend/tests/test_change_password.py` — 3 unit tests

## Test plan

- [x] Valid current password + strong new password → 200 + hash updated in DB
- [x] Wrong current password → 400 with descriptive message
- [x] New password under 8 chars → 422