### PR TITLE
feat: implement dark mode persistence and toggle logic using localStorage

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,6 +11,7 @@ import {
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react'
+import ThemeToggle from './ThemeToggle'
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: LayoutDashboard },
@@ -96,25 +97,28 @@ export default function Layout() {
               <p className="text-sm font-medium text-gray-900 truncate">
                 {displayName}
               </p>
-              <p className="text-xs text-gray-500 truncate">
+              <p className="text-xs text-gray-500 truncate dark:text-gray-400">
                 {companyName}
               </p>
             </div>
-            <button
-              onClick={logout}
-              className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100"
-              aria-label="Log out"
-              title="Log out"
-            >
-              <LogOut className="w-5 h-5" />
-            </button>
+            <div className="flex items-center gap-1">
+              <ThemeToggle />
+              <button
+                onClick={logout}
+                className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+                aria-label="Log out"
+                title="Log out"
+              >
+                <LogOut className="w-5 h-5" />
+              </button>
+            </div>
           </div>
         </div>
       </div>
 
       {/* Main content */}
       <div className={isCollapsed ? 'pl-20' : 'pl-64'}>
-        <main className="p-8">
+        <main className="p-8 min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -17,13 +17,20 @@ import { Sun, Moon } from 'lucide-react'
 
 export default function ThemeToggle() {
   const [isDark, setIsDark] = useState(() => {
-    // TODO (good first issue): read initial value from localStorage
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('theme') === 'dark'
+    }
     return false
   })
 
   useEffect(() => {
-    // TODO (good first issue): apply / remove `dark` class on documentElement
-    // and persist to localStorage when isDark changes
+    if (isDark) {
+      document.documentElement.classList.add('dark')
+      localStorage.setItem('theme', 'dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+      localStorage.setItem('theme', 'light')
+    }
   }, [isDark])
 
   return (

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
Fixes #193

Implemented the TODO items for the `ThemeToggle` component:
- Added `darkMode: 'class'` to the Tailwind config to enable manual class-based theme switching.
- Implemented `localStorage` persistence in `ThemeToggle.tsx` to save and load the user's theme preference across sessions.
- Added a `useEffect` hook to apply/remove the `dark` class from the `document.documentElement` based on the active state.
- Ensured the dark mode styles correctly apply to the main `Layout.tsx` sidebar and background.

Tested locally, the toggle smoothly transitions between light and dark themes and persists correctly after page reload.