### PR TITLE
chore: Export ComplianceStatusUpdateSchema from schemas package

### DIFF
--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -3,6 +3,7 @@ from app.schemas.ai_system import (
     AISystemCreate, 
     AISystemUpdate, 
     AISystemResponse,
+    ComplianceStatusUpdateSchema,
     RiskClassificationRequest,
     RiskClassificationResponse
 )
@@ -11,6 +12,7 @@ from app.schemas.document import DocumentCreate, DocumentResponse
 __all__ = [
     "UserCreate", "UserLogin", "UserResponse", "UserUpdateSchema", "Token",
     "AISystemCreate", "AISystemUpdate", "AISystemResponse",
+    "ComplianceStatusUpdateSchema",
     "RiskClassificationRequest", "RiskClassificationResponse",
     "DocumentCreate", "DocumentResponse"
 ]


### PR DESCRIPTION
## Summary

Export `ComplianceStatusUpdateSchema` from `backend/app/schemas/__init__.py` for package-level discoverability.

The schema itself was already implemented in PR #209 (`feat(compliance): add PATCH /ai-systems/{id}/status endpoint`) and is actively used by the `PATCH /api/v1/ai-systems/{id}/status` endpoint. However, it was not exported from the schemas package `__init__.py`, making it invisible to consumers importing from `app.schemas`.

## Changes

### `backend/app/schemas/__init__.py`
- Added `ComplianceStatusUpdateSchema` to the import from `app.schemas.ai_system`
- Added `"ComplianceStatusUpdateSchema"` to `__all__`

## Verification
- Schema definition: `backend/app/schemas/ai_system.py:97`
- Endpoint usage: `backend/app/api/v1/ai_systems.py:287`
- Both already exist — this PR only completes the package export

## Checklist
- [x] 1 file changed, 2 insertions
- [x] No functional changes — export only
- [x] Consistent with existing export pattern in `__init__.py`

Closes #35