### PR TITLE
feat: Wire Guard Scanner frontend page to POST /guard/scan

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import AISystems from './pages/AISystems'
 import Classification from './pages/Classification'
 import Documents from './pages/Documents'
 import Notifications from './pages/Notifications'
+import GuardScanner from './pages/GuardScanner'
 import { Toaster } from 'react-hot-toast'
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
@@ -54,6 +55,7 @@ function App() {
           <Route path="classification/:systemId?" element={<Classification />} />
           <Route path="documents" element={<Documents />} />
           <Route path="notifications" element={<Notifications />} />
+          <Route path="guard" element={<GuardScanner />} />
         </Route>
       </Routes>
     </>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   LogOut,
   Shield,
+  ShieldAlert,
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react'
@@ -21,6 +22,7 @@ const navigation = [
   { name: 'AI Systems', href: '/ai-systems', icon: Bot },
   { name: 'Risk Classification', href: '/classification', icon: FileCheck },
   { name: 'Documents', href: '/documents', icon: FileText },
+  { name: 'Guard Scanner', href: '/guard', icon: ShieldAlert },
 ]
 
 export default function Layout() {

--- a/frontend/src/pages/GuardScanner.tsx
+++ b/frontend/src/pages/GuardScanner.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { guardApi } from '../services/api'
+import { ShieldAlert, ShieldCheck, ShieldX, Loader2, AlertCircle } from 'lucide-react'
+
+interface ScanResult {
+  decision: string
+  confidence: number
+  reasoning: string
+  sanitized_prompt: string | null
+  matched_patterns: string[]
+}
+
+export default function GuardScanner() {
+  const [prompt, setPrompt] = useState('')
+  const [result, setResult] = useState<ScanResult | null>(null)
+
+  const scanMutation = useMutation({
+    mutationFn: (text: string) => guardApi.scan(text),
+    onSuccess: (data) => {
+      setResult(data)
+    },
+  })
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!prompt.trim()) return
+    scanMutation.mutate(prompt)
+  }
+
+  const getDecisionBadge = (decision: string) => {
+    switch (decision) {
+      case 'allow':
+        return (
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800">
+            <ShieldCheck className="w-4 h-4" />
+            Allow
+          </span>
+        )
+      case 'sanitize':
+        return (
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium bg-orange-100 text-orange-800">
+            <ShieldAlert className="w-4 h-4" />
+            Sanitize
+          </span>
+        )
+      case 'block':
+        return (
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800">
+            <ShieldX className="w-4 h-4" />
+            Block
+          </span>
+        )
+      default:
+        return null
+    }
+  }
+
+  const getDecisionColor = (decision: string) => {
+    switch (decision) {
+      case 'allow':
+        return 'bg-green-50 border-green-200'
+      case 'sanitize':
+        return 'bg-orange-50 border-orange-200'
+      case 'block':
+        return 'bg-red-50 border-red-200'
+      default:
+        return 'bg-gray-50 border-gray-200'
+    }
+  }
+
+  const getConfidenceColor = (confidence: number) => {
+    if (confidence >= 0.8) return 'text-green-600'
+    if (confidence >= 0.5) return 'text-orange-600'
+    return 'text-red-600'
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Guard Scanner</h1>
+        <p className="text-gray-600">
+          Scan prompts for injection risks using the LLM Guard module
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {/* Input Form */}
+        <div className="bg-white rounded-xl border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+            Prompt Input
+          </h2>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label
+                htmlFor="guard-prompt-input"
+                className="block text-sm font-medium text-gray-700 mb-2"
+              >
+                Enter a prompt to scan
+              </label>
+              <textarea
+                id="guard-prompt-input"
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                rows={8}
+                placeholder="Type or paste a prompt to check for injection risks..."
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg resize-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={scanMutation.isPending || !prompt.trim()}
+              className="w-full py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 flex items-center justify-center gap-2"
+            >
+              {scanMutation.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Scanning...
+                </>
+              ) : (
+                'Scan Prompt'
+              )}
+            </button>
+          </form>
+        </div>
+
+        {/* Results */}
+        <div>
+          {scanMutation.isError && (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-6 mb-4">
+              <div className="flex items-center gap-3 mb-2">
+                <AlertCircle className="w-6 h-6 text-red-600" />
+                <h3 className="text-lg font-medium text-red-900">Scan Failed</h3>
+              </div>
+              <p className="text-sm text-red-700">
+                {scanMutation.error instanceof Error
+                  ? scanMutation.error.message
+                  : 'An unexpected error occurred. Please try again.'}
+              </p>
+            </div>
+          )}
+
+          {result ? (
+            <div className={`rounded-xl border p-6 ${getDecisionColor(result.decision)}`}>
+              {/* Decision Badge */}
+              <div className="flex items-center justify-between mb-6">
+                <div className="flex items-center gap-4">
+                  {getDecisionBadge(result.decision)}
+                </div>
+                <span className={`text-lg font-semibold ${getConfidenceColor(result.confidence)}`}>
+                  {Math.round(result.confidence * 100)}% confidence
+                </span>
+              </div>
+
+              {/* Reasoning */}
+              <div className="mb-6">
+                <h3 className="font-medium text-gray-900 mb-2">Reasoning</h3>
+                <p className="text-sm text-gray-600">{result.reasoning}</p>
+              </div>
+
+              {/* Matched Patterns */}
+              {result.matched_patterns.length > 0 && (
+                <div>
+                  <h3 className="font-medium text-gray-900 mb-2">
+                    Matched Patterns ({result.matched_patterns.length})
+                  </h3>
+                  <ul className="space-y-1">
+                    {result.matched_patterns.map((pattern, i) => (
+                      <li key={i} className="text-sm text-gray-600 flex items-start gap-2">
+                        <span className="text-gray-400">•</span>
+                        <code className="bg-white/60 px-1.5 py-0.5 rounded text-xs font-mono">
+                          {pattern}
+                        </code>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="bg-gray-50 rounded-xl border border-gray-200 p-8 text-center">
+              <ShieldAlert className="w-12 h-12 text-gray-300 mx-auto mb-4" />
+              <h3 className="text-lg font-medium text-gray-900">
+                Enter a Prompt to Scan
+              </h3>
+              <p className="text-gray-500 mt-2">
+                Submit a prompt to check for injection risks, jailbreak attempts,
+                and other malicious patterns.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -125,4 +125,12 @@ export const notificationsApi = {
     api.post('/notifications/read', { ids }),
 }
 
+// Guard Scanner API
+export const guardApi = {
+  scan: async (prompt: string) => {
+    const { data } = await api.post('/guard/scan', { prompt })
+    return data
+  },
+}
+
 export default api


### PR DESCRIPTION
## Summary

Wire the Guard Scanner frontend page to `POST /api/v1/guard/scan`, implementing all four requirements from the issue.

## Changes

### New: `frontend/src/pages/GuardScanner.tsx`
Complete Guard Scanner page implementing:

1. **Loading state** — Spinner with "Scanning..." text while the API call is in progress, submit button disabled during loading
2. **Decision badge (colour-coded)** — Green for `allow`, orange for `sanitize`, red for `block`, using lucide-react shield icons
3. **Confidence % & reasoning** — Confidence displayed as percentage with colour-coding (green ≥80%, orange ≥50%, red <50%), full reasoning text section
4. **Matched patterns list** — Rendered as a monospace-formatted list with bullet points
5. **Graceful error handling** — API errors caught and displayed in a styled error banner with the error message

### Modified: `frontend/src/services/api.ts`
- Added `guardApi.scan()` method calling `POST /guard/scan`

### Modified: `frontend/src/App.tsx`
- Added `/guard` route pointing to `GuardScanner` page

### Modified: `frontend/src/components/Layout.tsx`
- Added "Guard Scanner" to sidebar navigation with `ShieldAlert` icon

## Checklist
- [x] 4 files changed (1 new, 3 modified)
- [x] Follows existing project patterns (useMutation, api service, Layout nav)
- [x] All 4 issue requirements addressed
- [x] No backend changes needed — wires to existing endpoint

Closes #72