### PR TITLE
feat: Add password strength validation to POST /auth/change-password

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
+import re
 from pydantic import BaseModel, field_validator
 from sqlalchemy.orm import Session
 from datetime import timedelta
@@ -23,8 +24,17 @@ class ChangePasswordRequest(BaseModel):
     @field_validator("new_password")
     @classmethod
     def validate_new_password(cls, v: str) -> str:
+        errors = []
         if len(v) < 8:
-            raise ValueError("new_password must be at least 8 characters")
+            errors.append("at least 8 characters")
+        if not re.search(r'[A-Z]', v):
+            errors.append("at least one uppercase letter")
+        if not re.search(r'\d', v):
+            errors.append("at least one digit")
+        if not re.search(r'[!@#$%^&*]', v):
+            errors.append("at least one special character (!@#$%^&*)")
+        if errors:
+            raise ValueError("Password must contain: " + ", ".join(errors))
         return v
 
 router = APIRouter()

--- a/backend/tests/test_change_password.py
+++ b/backend/tests/test_change_password.py
@@ -38,7 +38,7 @@ def db(engine):
 def client(db):
     user = User(
         email="pw@test.com",
-        hashed_password=get_password_hash("oldpassword"),
+        hashed_password=get_password_hash("OldPass1!"),
         full_name="Password Tester",
     )
     db.add(user)
@@ -64,17 +64,17 @@ class TestChangePassword:
         c, user = client
         resp = c.post(
             "/api/v1/auth/change-password",
-            json={"current_password": "oldpassword", "new_password": "newsecret123"},
+            json={"current_password": "OldPass1!", "new_password": "NewSecret1!"},
         )
         assert resp.status_code == 200
         assert resp.json()["message"] == "Password updated successfully"
-        assert verify_password("newsecret123", user.hashed_password)
+        assert verify_password("NewSecret1!", user.hashed_password)
 
     def test_wrong_current_password_returns_400(self, client):
         c, user = client
         resp = c.post(
             "/api/v1/auth/change-password",
-            json={"current_password": "wrongpassword", "new_password": "newsecret123"},
+            json={"current_password": "WrongPass1!", "new_password": "NewSecret1!"},
         )
         assert resp.status_code == 400
         assert "incorrect" in resp.json()["detail"].lower()
@@ -83,6 +83,47 @@ class TestChangePassword:
         c, user = client
         resp = c.post(
             "/api/v1/auth/change-password",
-            json={"current_password": "oldpassword", "new_password": "short"},
+            json={"current_password": "OldPass1!", "new_password": "Ab1!"},
         )
         assert resp.status_code == 422
+        assert "at least 8 characters" in str(resp.json())
+
+    def test_missing_uppercase_returns_422(self, client):
+        c, user = client
+        resp = c.post(
+            "/api/v1/auth/change-password",
+            json={"current_password": "OldPass1!", "new_password": "alllower1!"},
+        )
+        assert resp.status_code == 422
+        assert "uppercase" in str(resp.json())
+
+    def test_missing_digit_returns_422(self, client):
+        c, user = client
+        resp = c.post(
+            "/api/v1/auth/change-password",
+            json={"current_password": "OldPass1!", "new_password": "AllUpper!!"},
+        )
+        assert resp.status_code == 422
+        assert "digit" in str(resp.json())
+
+    def test_missing_special_char_returns_422(self, client):
+        c, user = client
+        resp = c.post(
+            "/api/v1/auth/change-password",
+            json={"current_password": "OldPass1!", "new_password": "NoSpecial1A"},
+        )
+        assert resp.status_code == 422
+        assert "special character" in str(resp.json())
+
+    def test_multiple_missing_criteria_returns_422(self, client):
+        c, user = client
+        resp = c.post(
+            "/api/v1/auth/change-password",
+            json={"current_password": "OldPass1!", "new_password": "abc"},
+        )
+        assert resp.status_code == 422
+        body = str(resp.json())
+        assert "at least 8 characters" in body
+        assert "uppercase" in body
+        assert "digit" in body
+        assert "special character" in body


### PR DESCRIPTION
## Summary

Extend the `ChangePasswordRequest` validator in `backend/app/api/v1/auth.py` to enforce a richer password policy as described in the issue.

## Changes

### `backend/app/api/v1/auth.py`
Extended `validate_new_password` to enforce 4 rules:

| Rule | Example failure |
|---|---|
| At least 8 characters | `abc123` |
| At least one uppercase letter | `alllowercase1!` |
| At least one digit | `Allupper!` |
| At least one special character (`!@#$%^&*`) | `Onlyletters1` |

Returns a **single 422 response listing all unmet criteria** — not just the first failure.

### `backend/tests/test_change_password.py`
- Updated existing test passwords (`oldpassword` → `OldPass1!`, `newsecret123` → `NewSecret1!`) to pass the new policy
- Added **5 new tests**:
  - `test_missing_uppercase_returns_422`
  - `test_missing_digit_returns_422`
  - `test_missing_special_char_returns_422`
  - `test_multiple_missing_criteria_returns_422` (verifies all 4 rules listed)
  - Updated `test_short_new_password_returns_422` to also assert the error message

## Acceptance Criteria

- [x] Passwords missing any of the 4 rules return 422 with descriptive message
- [x] Valid passwords (meeting all rules) still return 200
- [x] Existing test for short password still passes
- [x] Added at least 4 new unit tests — one per failing rule

Closes #213