### PR TITLE
Add SQLAlchemy event listener for AISystem audit logging

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,5 +2,5 @@ from app.models.user import User
 from app.models.ai_system import AISystem, RiskAssessment
 from app.models.document import Document
 from app.models.rag_feedback import RAGFeedback
-
+from app.models.audit_log import AISystemAuditLog
 __all__ = ["User", "AISystem", "RiskAssessment", "Document", "RAGFeedback"]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,4 +3,11 @@ from app.models.ai_system import AISystem, RiskAssessment
 from app.models.document import Document
 from app.models.rag_feedback import RAGFeedback
 from app.models.audit_log import AISystemAuditLog
-__all__ = ["User", "AISystem", "RiskAssessment", "Document", "RAGFeedback"]
+__all__ = [
+    "User",
+    "AISystem",
+    "RiskAssessment",
+    "Document",
+    "RAGFeedback",
+    "AISystemAuditLog",
+]

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -14,10 +14,25 @@ TODO for contributors (help wanted):
     new row in ai_system_audit_logs with correct old/new values.
 """
 
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, JSON
-from sqlalchemy.orm import relationship
 from datetime import datetime
+
+from sqlalchemy import Column, Integer, DateTime, ForeignKey, JSON, event
+from sqlalchemy.orm import relationship
+from sqlalchemy.orm.attributes import get_history
+
 from app.core.database import Base
+from app.models.ai_system import AISystem
+
+
+TRACKED_FIELDS = [
+    "name",
+    "description",
+    "use_case",
+    "sector",
+    "risk_level",
+    "compliance_status",
+    "compliance_score",
+]
 
 
 class AISystemAuditLog(Base):
@@ -36,3 +51,32 @@ class AISystemAuditLog(Base):
     # Relationships
     ai_system = relationship("AISystem")
     changed_by = relationship("User")
+
+
+@event.listens_for(AISystem, "after_update")
+def after_ai_system_update(mapper, connection, target):
+    old_values = {}
+    new_values = {}
+
+    for field in TRACKED_FIELDS:
+        history = get_history(target, field)
+
+        if history.has_changes():
+            old_values[field] = (
+                history.deleted[0] if history.deleted else None
+            )
+            new_values[field] = (
+                history.added[0] if history.added else None
+            )
+
+    if old_values:
+        connection.execute(
+            AISystemAuditLog.__table__.insert().values(
+                ai_system_id=target.id,
+                changed_by_id=target.owner_id,
+                old_values=old_values,
+                new_values=new_values,
+                changed_at=datetime.utcnow(),
+            )
+        )
+        

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -78,5 +78,13 @@ def after_ai_system_update(mapper, connection, target):
                 new_values=new_values,
                 changed_at=datetime.utcnow(),
             )
-        )
+        ) 
+            
+            
+            
+            
+            
+        
+        
+        
         


### PR DESCRIPTION
## Description

Implemented SQLAlchemy ORM event listener support for automatically tracking AISystem field updates into `AISystemAuditLog`.

### Changes made

* Added `after_update` SQLAlchemy event listener for `AISystem`
* Tracked changes for:

  * name
  * description
  * use_case
  * sector
  * risk_level
  * compliance_status
  * compliance_score
* Stored changed field history in:

  * `old_values`
  * `new_values`
* Registered `AISystemAuditLog` model import in `models/__init__.py`

### Validation

* Verified model compilation using:

  * `python -m compileall backend/app/models`

Closes #132
