### PR TITLE
feat: add docker-compose.override.yml for Ollama zero-API-key local setup

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: aegisai-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
+
+  backend:
+    environment:
+      - LLM_BASE_URL=http://ollama:11434/v1
+      - LLM_MODEL=llama3.2
+
+volumes:
+  ollama_data:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -392,3 +392,23 @@ python -m app.modules.guard.train --all --epochs 3
 ```
 
 Training takes ~30 min on CPU, ~5 min on GPU. Model is saved to `backend/app/modules/guard/models/intent_classifier/` and picked up automatically on restart.
+## Ollama Setup (Free, No API Key Required)
+
+If you don't have an OpenAI API key, you can run AegisAI locally using Ollama.
+
+### Prerequisites
+- Docker & Docker Compose installed
+
+### Steps
+
+1. Start the stack with Ollama override:
+```bash
+   docker-compose -f docker-compose.yml -f docker-compose.override.yml up
+```
+
+2. Pull the model (first time only):
+```bash
+   docker exec aegisai-ollama ollama pull llama3.2
+```
+
+3. The backend will automatically connect to Ollama at:


### PR DESCRIPTION
Closes #68

## Summary
Added Ollama support for contributors who don't have an OpenAI API key.

## Changes made
- Added `docker-compose.override.yml` with Ollama container configuration
- Pre-configured backend with `LLM_BASE_URL=http://ollama:11434/v1` and `LLM_MODEL=llama3.2`
- Updated `docs/getting-started.md` with Ollama free local setup section

## Type of Change
- [x] New feature

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style
- [x] I have not committed `.env` or any secrets