### PR TITLE
fix: improve RAG error handling for missing FAISS index

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -74,17 +74,38 @@ def query_knowledge_base(
         answer_id = feedback.id
 
         return RAGQueryResponse(answer=result["result"], sources=sources, answer_id=answer_id)
+    except FileNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(e),
+        )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"RAG module not ready: {str(e)}. Run POST /rag/ingest first.",
+            detail=f"RAG module error: {str(e)}",
         )
 
 
 @router.get("/health", tags=["RAG Intelligence"])
 def rag_health():
     """Check if the RAG module is available."""
-    return {"module": "rag_intelligence", "status": "available"}
+    from app.modules.rag.vector_store import check_index_exists
+    
+    index_loaded = check_index_exists()
+    
+    if not index_loaded:
+        return {
+            "module": "rag_intelligence",
+            "status": "unavailable",
+            "index_loaded": False,
+            "message": "FAISS index not found. RAG module requires document ingestion before use."
+        }
+    
+    return {
+        "module": "rag_intelligence",
+        "status": "available",
+        "index_loaded": True
+    }
 
 
 class RAGFeedbackRequest(BaseModel):

--- a/backend/app/modules/rag/vector_store.py
+++ b/backend/app/modules/rag/vector_store.py
@@ -43,9 +43,15 @@ def load_vector_store():
     if not os.path.exists(index_path):
         raise FileNotFoundError(
             f"FAISS index not found at '{index_path}'. "
-            "Call POST /api/v1/rag/ingest to build it first."
+            "The RAG module requires regulatory documents to be ingested first. "
+            "Please contact your administrator or check the documentation for setup instructions."
         )
     embeddings = get_embeddings()
     return FAISS.load_local(
         index_path, embeddings, allow_dangerous_deserialization=True
     )
+
+
+def check_index_exists():
+    """Check if FAISS index exists on disk."""
+    return os.path.exists(settings.FAISS_INDEX_PATH)


### PR DESCRIPTION
Closes #237

## Summary

Improves error handling when RAG module is queried without a FAISS index. Users now get clear, actionable error messages instead of generic 503 errors. The health check endpoint now indicates whether the RAG module is ready to use.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Screenshots (if UI change)

N/A - Backend only changes
