### PR TITLE
Dark mode layout feature added

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,6 +11,7 @@ import {
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react'
+import ThemeToggle from './ThemeToggle'
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: LayoutDashboard },
@@ -27,54 +28,66 @@ export default function Layout() {
   const [isCollapsed, setIsCollapsed] = useState(false)
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      
       {/* Sidebar */}
       <div
-        className={`fixed inset-y-0 left-0 bg-white border-r border-gray-200 transition-[width] duration-200 ${
-          isCollapsed ? 'w-20' : 'w-64'
-        }`}
+        className={`fixed inset-y-0 left-0 transition-[width] duration-200
+        bg-white border-r border-gray-200
+        dark:bg-gray-800 dark:border-gray-700
+        ${isCollapsed ? 'w-20' : 'w-64'}`}
       >
-        {/* Logo */}
-        <div className="flex items-center justify-between gap-2 px-4 py-4 border-b border-gray-200">
+
+        {/* Logo + Controls */}
+        <div className="flex items-center justify-between gap-2 px-4 py-4 border-b border-gray-200 dark:border-gray-700">
+          
           <div className="flex items-center gap-2">
-            <Shield className="w-8 h-8 text-primary-600" />
+            <Shield className="w-8 h-8 text-primary-600 dark:text-primary-400" />
             <span
-              className={`text-lg font-semibold text-gray-900 ${
+              className={`text-lg font-semibold text-gray-900 dark:text-white ${
                 isCollapsed ? 'sr-only' : ''
               }`}
             >
               AI Compliance
             </span>
           </div>
-          <button
-            type="button"
-            onClick={() => setIsCollapsed((prev) => !prev)}
-            className="p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
-            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          >
-            {isCollapsed ? (
-              <ChevronRight className="w-5 h-5" />
-            ) : (
-              <ChevronLeft className="w-5 h-5" />
-            )}
-          </button>
+
+          {/* Right controls */}
+          <div className="flex items-center gap-1">
+            <ThemeToggle />
+
+            <button
+              type="button"
+              onClick={() => setIsCollapsed((prev) => !prev)}
+              className="p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100
+                         dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-700"
+            >
+              {isCollapsed ? (
+                <ChevronRight className="w-5 h-5" />
+              ) : (
+                <ChevronLeft className="w-5 h-5" />
+              )}
+            </button>
+          </div>
         </div>
 
         {/* Navigation */}
         <nav className="flex flex-col gap-1 p-4">
           {navigation.map((item) => {
             const isActive = location.pathname === item.href
+
             return (
               <Link
                 key={item.name}
                 to={item.href}
                 title={item.name}
-                className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
-                  isActive
-                    ? 'bg-primary-50 text-primary-700'
-                    : 'text-gray-600 hover:bg-gray-100'
-                } ${isCollapsed ? 'justify-center' : ''}`}
+                className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors
+                  ${
+                    isActive
+                      ? 'bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                      : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
+                  }
+                  ${isCollapsed ? 'justify-center' : ''}`}
               >
                 <item.icon className="w-5 h-5" />
                 <span className={isCollapsed ? 'sr-only' : ''}>
@@ -86,25 +99,25 @@ export default function Layout() {
         </nav>
 
         {/* User section */}
-        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200">
+        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 dark:border-gray-700">
           <div
             className={`flex items-center ${
               isCollapsed ? 'justify-center' : 'justify-between'
             }`}
           >
             <div className={isCollapsed ? 'sr-only' : 'truncate'}>
-              <p className="text-sm font-medium text-gray-900 truncate">
+              <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
                 {displayName}
               </p>
-              <p className="text-xs text-gray-500 truncate">
+              <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
                 {companyName}
               </p>
             </div>
+
             <button
               onClick={logout}
-              className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100"
-              aria-label="Log out"
-              title="Log out"
+              className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100
+                         dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-700"
             >
               <LogOut className="w-5 h-5" />
             </button>
@@ -113,8 +126,10 @@ export default function Layout() {
       </div>
 
       {/* Main content */}
-      <div className={isCollapsed ? 'pl-20' : 'pl-64'}>
-        <main className="p-8">
+      <div
+        className={`${isCollapsed ? 'pl-20' : 'pl-64'} transition-all duration-200`}
+      >
+        <main className="p-8 bg-gray-50 dark:bg-gray-900 min-h-screen">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,36 +1,29 @@
 import { useState, useEffect } from 'react'
 import { Sun, Moon } from 'lucide-react'
 
-/**
- * ThemeToggle — light/dark mode toggle with localStorage persistence.
- *
- * TODO (good first issue):
- *   - On mount, read `localStorage.getItem('theme')` and apply the class
- *     `dark` to `document.documentElement` if the stored value is "dark".
- *   - On toggle, flip the class and persist the new value to localStorage.
- *   - In tailwind.config.js set `darkMode: 'class'` so Tailwind's `dark:`
- *     variant is driven by the class on <html>.
- *   - Add `dark:` variants to Layout.tsx sidebar and main background so
- *     switching theme visibly changes the UI.
- *   - Acceptance criteria: toggling dark mode persists across page refreshes.
- */
-
 export default function ThemeToggle() {
   const [isDark, setIsDark] = useState(() => {
-    // TODO (good first issue): read initial value from localStorage
-    return false
+    if (typeof window === 'undefined') return false
+    return localStorage.getItem('theme') === 'dark'
   })
 
   useEffect(() => {
-    // TODO (good first issue): apply / remove `dark` class on documentElement
-    // and persist to localStorage when isDark changes
+    const root = document.documentElement
+
+    if (isDark) {
+      root.classList.add('dark')
+      localStorage.setItem('theme', 'dark')
+    } else {
+      root.classList.remove('dark')
+      localStorage.setItem('theme', 'light')
+    }
   }, [isDark])
 
   return (
     <button
       type="button"
       onClick={() => setIsDark((d) => !d)}
-      className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100"
+      className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 dark:text-gray-300 dark:hover:text-white dark:hover:bg-gray-700"
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
       title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
     >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,3 +5,6 @@
 body {
   @apply bg-gray-50 text-gray-900;
 }
+html {
+  transition: background-color 0.3s, color 0.3s;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary

Closes #111 

Adds dark mode support to the main layout using Tailwind's dark class strategy. Includes a theme toggle with localStorage persistence and applies dark styles to sidebar, navigation, and main content.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots

<!-- Add before/after screenshots here -->
Light mode ==>
<img width="1536" height="727" alt="image" src="https://github.com/user-attachments/assets/6f28e6a8-9037-4986-a4e9-c3a4a7ea87c7" />
Dark mode with only layout.tsx changes ==>
<img width="1536" height="738" alt="image" src="https://github.com/user-attachments/assets/11cbad44-9110-4a3d-84e9-026339ede856" />

I’ve applied dark mode changes to the layout as discussed. Would you like me to extend the same styling across the rest of the components as well?

Dark mode  after dark mode addition on all components (not yet commited) ==>
<img width="1536" height="720" alt="image" src="https://github.com/user-attachments/assets/ca385e94-b3f0-4034-969a-fdb90afe1c84" />

