### PR TITLE
Dark mode applied to all pages according to theme

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,6 @@
         "react-hook-form": "^7.49.3",
         "react-hot-toast": "^2.6.0",
         "react-router-dom": "^6.21.3",
-        "recharts": "^2.12.0",
         "tailwind-merge": "^2.2.1",
         "zod": "^3.22.4",
         "zustand": "^4.5.0"
@@ -1666,69 +1665,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2559,12 +2495,6 @@
         }
       }
     },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
-      "license": "MIT"
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2619,16 +2549,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -2957,27 +2877,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-equals": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
-      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -3455,15 +3360,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3679,12 +3575,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3871,6 +3761,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4219,23 +4110,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -4334,12 +4208,6 @@
         "react-dom": ">=16"
       }
     },
-    "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4382,37 +4250,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/react-smooth": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
-      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-equals": "^5.0.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4434,38 +4271,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/recharts": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
-      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0",
-        "eventemitter3": "^4.0.1",
-        "lodash": "^4.17.21",
-        "react-is": "^18.3.1",
-        "react-smooth": "^4.0.4",
-        "recharts-scale": "^0.4.4",
-        "tiny-invariant": "^1.3.1",
-        "victory-vendor": "^36.6.8"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/recharts-scale": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
-      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
-      "license": "MIT",
-      "dependencies": {
-        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/resolve": {
@@ -4820,12 +4625,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -5003,28 +4802,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/victory-vendor": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
-      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
-      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -85,7 +85,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1693,7 +1692,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1758,7 +1756,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2002,7 +1999,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2238,7 +2234,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2480,8 +2475,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2692,7 +2686,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3452,7 +3445,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3965,7 +3957,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4164,7 +4155,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4177,7 +4167,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4191,7 +4180,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4678,7 +4666,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4751,7 +4738,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4823,7 +4809,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,6 +11,7 @@ import {
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react'
+
 import NotificationBell from './NotificationBell'
 import ThemeToggle from './ThemeToggle'
 
@@ -31,10 +32,10 @@ export default function Layout() {
   const [isCollapsed, setIsCollapsed] = useState(false)
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-800 ">
       {/* Sidebar */}
       <div
-        className={`fixed inset-y-0 left-0 bg-white border-r border-gray-200 transition-[width] duration-200 z-40 ${
+        className={`fixed inset-y-0 left-0 bg-white dark:bg-gray-800 dark:text-gray-100 border-r border-gray-200 dark:border-gray-700 transition-[width] duration-200 z-40 ${
           isCollapsed ? 'w-20' : 'w-64'
         }`}
       >
@@ -43,7 +44,7 @@ export default function Layout() {
           <div className="flex items-center gap-2">
             <Shield className="w-8 h-8 text-primary-600" />
             <span
-              className={`text-lg font-semibold text-gray-900 ${
+              className={`text-lg font-semibold text-gray-900 dark:text-gray-50 ${
                 isCollapsed ? 'sr-only' : ''
               }`}
             >
@@ -53,7 +54,7 @@ export default function Layout() {
           <button
             type="button"
             onClick={() => setIsCollapsed((prev) => !prev)}
-            className="p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
+            className="p-2 text-gray-500 dark:text-gray-50 hover:text-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
             aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
             title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
@@ -77,7 +78,7 @@ export default function Layout() {
                 className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
                   isActive
                     ? 'bg-primary-50 text-primary-700'
-                    : 'text-gray-600 hover:bg-gray-100'
+                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700'
                 } ${isCollapsed ? 'justify-center' : ''}`}
               >
                 <item.icon className="w-5 h-5" />
@@ -90,7 +91,7 @@ export default function Layout() {
         </nav>
 
         {/* User section */}
-        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200">
+        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 dark:border-gray-700">
           <div
             className={`flex items-center ${
               isCollapsed ? 'justify-center' : 'justify-between'
@@ -125,7 +126,7 @@ export default function Layout() {
         }`}
       >
 
-        <header className="sticky top-0 z-30 flex items-center justify-end gap-1 px-8 py-3 bg-white/80 backdrop-blur-md border-b border-gray-200/60">
+        <header className="sticky top-0 z-30 flex items-center justify-end gap-1 px-8 py-3 bg-white/80 dark:bg-gray-800 backdrop-blur-md border-b border-gray-200/60">
           <NotificationBell />
           <ThemeToggle />
         </header>

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -102,7 +102,7 @@ export default function NotificationBell() {
       <button
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
-        className="relative p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+        className="relative p-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 rounded-lg hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
         aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
         aria-expanded={isOpen}
         aria-haspopup="true"
@@ -123,7 +123,7 @@ export default function NotificationBell() {
 
       {/* Dropdown panel */}
       <div
-        className={`absolute right-0 mt-2 w-80 sm:w-96 bg-white rounded-xl border border-gray-200 shadow-xl z-50 transition-all duration-200 ease-out origin-top-right ${
+        className={`absolute right-0 mt-2 w-80 sm:w-96 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700  dark:shadow-lg z-50 transition-all duration-200 ease-out origin-top-right ${
           isOpen
             ? 'opacity-100 translate-y-0 pointer-events-auto'
             : 'opacity-0 -translate-y-2 pointer-events-none'
@@ -132,9 +132,9 @@ export default function NotificationBell() {
         aria-label="Notifications panel"
       >
 
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-700">
           <div className="flex items-center gap-2">
-            <h3 className="text-sm font-semibold text-gray-900">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
               Notifications
             </h3>
             {unreadCount > 0 && (
@@ -146,7 +146,7 @@ export default function NotificationBell() {
           <button
             type="button"
             onClick={() => setIsOpen(false)}
-            className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors"
+            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
             aria-label="Close notifications"
           >
             <X className="w-4 h-4" />
@@ -166,7 +166,7 @@ export default function NotificationBell() {
                 key={notification.id}
                 type="button"
                 onClick={() => handleNotificationClick(notification.id)}
-                className={`w-full flex items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus:bg-gray-50 ${
+                className={`w-full flex items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus:bg-gray-50 dark:hover:bg-gray-600 ${
                   !notification.is_read ? 'bg-primary-50/40' : ''
                 }`}
                 role="menuitem"
@@ -213,7 +213,7 @@ export default function NotificationBell() {
           <Link
             to="/notifications"
             onClick={() => setIsOpen(false)}
-            className="block px-4 py-3 text-center text-sm font-medium text-primary-600 hover:text-primary-700 hover:bg-gray-50 transition-colors rounded-b-xl"
+            className="block px-4 py-3 text-center text-sm font-medium text-primary-600 hover:text-primary-700 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors rounded-b-xl"
           >
             View all notifications
           </Link>

--- a/frontend/src/pages/AISystems.tsx
+++ b/frontend/src/pages/AISystems.tsx
@@ -121,7 +121,7 @@ export default function AISystems() {
     <div className="space-y-8">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">AI Systems</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">AI Systems</h1>
           <p className="text-gray-600">Manage your AI systems for compliance tracking</p>
         </div>
         <button
@@ -134,7 +134,7 @@ export default function AISystems() {
       </div>
 
       {/* Search and Filters */}
-      <div className="flex flex-col md:flex-row gap-4 bg-white p-4 rounded-xl border border-gray-200 shadow-sm">
+      <div className="flex flex-col md:flex-row gap-4 bg-white dark:bg-gray-800 p-4 rounded-xl border border-gray-200 dark:border-gray-600 shadow-sm">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
           <input
@@ -142,7 +142,7 @@ export default function AISystems() {
             placeholder="Search AI systems..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none transition-all"
+            className="w-full pl-10 pr-4 py-2 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none transition-all bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
           />
         </div>
         <div className="flex flex-wrap gap-3">
@@ -151,7 +151,7 @@ export default function AISystems() {
             <select
               value={riskFilter}
               onChange={(e) => setRiskFilter(e.target.value)}
-              className="pl-9 pr-4 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
+              className="pl-9 pr-4 py-2 bg-white dark:bg-gray-800 dark:text-gray-400 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
             >
               <option value="">All Risk Levels</option>
               <option value="unacceptable">Unacceptable Risk</option>
@@ -165,7 +165,7 @@ export default function AISystems() {
             <select
               value={complianceFilter}
               onChange={(e) => setComplianceFilter(e.target.value)}
-              className="pl-9 pr-4 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
+              className="pl-9 pr-4 py-2 bg-white dark:bg-gray-800 dark:text-gray-400 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
             >
               <option value="">All Statuses</option>
               <option value="not_started">Not Started</option>
@@ -181,7 +181,7 @@ export default function AISystems() {
               id="sort-by-select"
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value)}
-              className="pl-9 pr-4 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
+              className="pl-9 pr-4 py-2 bg-white dark:bg-gray-800 dark:text-gray-400 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
             >
               <option value="created_at">Sort by Date</option>
               <option value="name">Sort by Name</option>
@@ -194,8 +194,9 @@ export default function AISystems() {
               id="sort-order-select"
               value={order}
               onChange={(e) => setOrder(e.target.value)}
-              className="px-3 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
-            >
+              className="px-3 py-2 bg-white dark:bg-gray-800 dark:text-gray-400 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
+            >`12345 90-= 90-\53
+            `
               <option value="desc">Descending</option>
               <option value="asc">Ascending</option>
             </select>
@@ -207,7 +208,7 @@ export default function AISystems() {
                 setRiskFilter('')
                 setComplianceFilter('')
               }}
-              className="flex items-center gap-1 px-3 py-2 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all text-sm font-medium"
+              className="flex items-center gap-1 px-3 py-2 text-gray-500 dark:text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900 rounded-lg transition-all text-sm font-medium"
             >
               <X className="w-4 h-4" />
               Clear
@@ -217,16 +218,16 @@ export default function AISystems() {
       </div>
 
       {isLoading ? (
-        <div className="text-center py-12 text-gray-500">Loading...</div>
+        <div className="text-center py-12 text-gray-500 dark:text-gray-400">Loading...</div>
       ) : filteredSystems.length === 0 ? (
-        <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
+        <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600">
           <Bot className="w-16 h-16 mx-auto mb-4 text-gray-300" />
-          <h3 className="text-lg font-medium text-gray-900">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white">
             {searchTerm || riskFilter || complianceFilter 
               ? 'No matching AI systems' 
               : 'No AI systems yet'}
           </h3>
-          <p className="text-gray-500 mt-1">
+          <p className="text-gray-500 dark:text-gray-400 mt-1">
             {searchTerm || riskFilter || complianceFilter 
               ? 'Try adjusting your filters or search term'
               : 'Add your first AI system to start tracking compliance'}
@@ -245,7 +246,7 @@ export default function AISystems() {
           {filteredSystems.map((system: AISystem) => (
             <div
               key={system.id}
-              className="bg-white rounded-xl border border-gray-200 p-6"
+              className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600 p-6"
             >
               <div className="flex items-start justify-between">
                 <div className="flex items-start gap-4">
@@ -253,9 +254,9 @@ export default function AISystems() {
                     <Bot className="w-6 h-6 text-primary-600" />
                   </div>
                   <div>
-                    <h3 className="font-semibold text-gray-900">{system.name}</h3>
+                    <h3 className="font-semibold text-gray-900 dark:text-white">{system.name}</h3>
                     {system.description && (
-                      <p className="text-gray-600 text-sm mt-1">{system.description}</p>
+                      <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">{system.description}</p>
                     )}
                     <div className="flex items-center gap-3 mt-2">
                       {system.sector && (
@@ -279,12 +280,12 @@ export default function AISystems() {
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <button className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100">
+                  <button className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600">
                     <Edit className="w-5 h-5" />
                   </button>
                   <button
                     onClick={() => deleteMutation.mutate(system.id)}
-                    className="p-2 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50"
+                    className="p-2 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50 dark:hover:bg-red-900"
                   >
                     <Trash2 className="w-5 h-5" />
                   </button>
@@ -318,13 +319,13 @@ export default function AISystems() {
       {/* Add Modal */}
       {showModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-xl p-6 w-full max-w-md">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          <div className="bg-white dark:bg-gray-800 dark:text-gray-400 rounded-xl p-6 w-full max-w-md">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
               Add AI System
             </h2>
             <form onSubmit={handleSubmit} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                   System Name *
                 </label>
                 <input
@@ -332,30 +333,30 @@ export default function AISystems() {
                   required
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
+                  className="mt-1 block w-full px-3 py-2 border dark:bg-gray-700 border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
                   placeholder="e.g., CV Screening AI"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                   Description
                 </label>
                 <textarea
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
+                  className="mt-1 block w-full px-3 py-2 border dark:bg-gray-700 border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
                   rows={3}
                   placeholder="Brief description of what your AI system does"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                   Sector
                 </label>
                 <select
                   value={formData.sector}
                   onChange={(e) => setFormData({ ...formData, sector: e.target.value })}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
+                  className="mt-1 block w-full px-3 py-2 border dark:bg-gray-700 border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
                 >
                   <option value="">Select sector...</option>
                   {sectors.map((s) => (
@@ -364,13 +365,13 @@ export default function AISystems() {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 ">
                   Use Case
                 </label>
                 <select
                   value={formData.use_case}
                   onChange={(e) => setFormData({ ...formData, use_case: e.target.value })}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
+                  className="mt-1 block w-full px-3 py-2 border dark:bg-gray-700 border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
                 >
                   <option value="">Select use case...</option>
                   {useCases.map((u) => (
@@ -382,7 +383,7 @@ export default function AISystems() {
                 <button
                   type="button"
                   onClick={() => setShowModal(false)}
-                  className="px-4 py-2 text-gray-700 hover:bg-gray-100 rounded-lg"
+                  className="px-4 py-2 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg"
                 >
                   Cancel
                 </button>

--- a/frontend/src/pages/Classification.tsx
+++ b/frontend/src/pages/Classification.tsx
@@ -1,79 +1,79 @@
-import { useState } from 'react'
-import { useParams } from 'react-router-dom'
-import { useMutation } from '@tanstack/react-query'
-import { classificationApi } from '../services/api'
-import { AlertTriangle, CheckCircle, Info, XCircle } from 'lucide-react'
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { classificationApi } from "../services/api";
+import { AlertTriangle, CheckCircle, Info, XCircle } from "lucide-react";
 import ComplianceChecklist, {
   ChecklistItem,
-} from '../components/ComplianceChecklist'
+} from "../components/ComplianceChecklist";
 
 interface ClassificationResult {
-  risk_level: string
-  confidence: number
-  reasons: string[]
-  requirements: string[]
-  next_steps: string[]
+  risk_level: string;
+  confidence: number;
+  reasons: string[];
+  requirements: string[];
+  next_steps: string[];
 }
 
 const CHECKLIST_ITEMS: Record<string, ChecklistItem[]> = {
   high: [
     {
-      id: 'tech-doc',
-      label: 'Create Technical Documentation',
-      article: 'Article 11',
+      id: "tech-doc",
+      label: "Create Technical Documentation",
+      article: "Article 11",
       required: true,
     },
     {
-      id: 'risk-assessment',
-      label: 'Conduct Risk Assessment',
-      article: 'Article 9',
+      id: "risk-assessment",
+      label: "Conduct Risk Assessment",
+      article: "Article 9",
       required: true,
     },
     {
-      id: 'human-oversight',
-      label: 'Establish Human Oversight',
-      article: 'Article 14',
+      id: "human-oversight",
+      label: "Establish Human Oversight",
+      article: "Article 14",
       required: true,
     },
     {
-      id: 'conformity',
-      label: 'EU Declaration of Conformity',
-      article: 'Article 47',
+      id: "conformity",
+      label: "EU Declaration of Conformity",
+      article: "Article 47",
       required: true,
     },
     {
-      id: 'logging',
-      label: 'Implement automatic logging',
-      article: 'Article 12',
+      id: "logging",
+      label: "Implement automatic logging",
+      article: "Article 12",
       required: true,
     },
   ],
 
   limited: [
     {
-      id: 'transparency',
-      label: 'Disclose AI interaction to users',
-      article: 'Article 52',
+      id: "transparency",
+      label: "Disclose AI interaction to users",
+      article: "Article 52",
       required: true,
     },
   ],
 
   minimal: [
     {
-      id: 'best-practice',
-      label: 'Follow voluntary AI best practices',
+      id: "best-practice",
+      label: "Follow voluntary AI best practices",
       required: false,
     },
   ],
 
   unacceptable: [],
-}
+};
 
 export default function Classification() {
-  const { systemId } = useParams()
-  const [result, setResult] = useState<ClassificationResult | null>(null)
+  const { systemId } = useParams();
+  const [result, setResult] = useState<ClassificationResult | null>(null);
   const [formData, setFormData] = useState({
-    use_case_category: 'hr_recruitment',
+    use_case_category: "hr_recruitment",
     is_safety_component: false,
     affects_fundamental_rights: true,
     uses_biometric_data: false,
@@ -89,72 +89,78 @@ export default function Classification() {
     generates_synthetic_content: false,
     emotion_recognition: false,
     biometric_categorization: false,
-  })
+  });
 
   const classifyMutation = useMutation({
     mutationFn: () => {
       if (systemId) {
-        return classificationApi.classifyAndSave(parseInt(systemId), formData)
+        return classificationApi.classifyAndSave(parseInt(systemId), formData);
       }
-      return classificationApi.classify(formData)
+      return classificationApi.classify(formData);
     },
     onSuccess: (data) => {
-      setResult(data)
+      setResult(data);
     },
-  })
+  });
 
   const getRiskIcon = (level: string) => {
     switch (level) {
-      case 'unacceptable':
-        return <XCircle className="w-8 h-8 text-red-600" />
-      case 'high':
-        return <AlertTriangle className="w-8 h-8 text-orange-600" />
-      case 'limited':
-        return <Info className="w-8 h-8 text-yellow-600" />
+      case "unacceptable":
+        return <XCircle className="w-8 h-8 text-red-600" />;
+      case "high":
+        return <AlertTriangle className="w-8 h-8 text-orange-600" />;
+      case "limited":
+        return <Info className="w-8 h-8 text-yellow-600" />;
       default:
-        return <CheckCircle className="w-8 h-8 text-green-600" />
+        return <CheckCircle className="w-8 h-8 text-green-600" />;
     }
-  }
+  };
 
   const getRiskColor = (level: string) => {
     switch (level) {
-      case 'unacceptable':
-        return 'bg-red-50 border-red-200'
-      case 'high':
-        return 'bg-orange-50 border-orange-200'
-      case 'limited':
-        return 'bg-yellow-50 border-yellow-200'
+      case "unacceptable":
+        return "bg-red-50 border-red-200";
+      case "high":
+        return "bg-orange-50 border-orange-200";
+      case "limited":
+        return "bg-yellow-50 border-yellow-200";
       default:
-        return 'bg-green-50 border-green-200'
+        return "bg-green-50 border-green-200";
     }
-  }
+  };
 
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Risk Classification</h1>
-        <p className="text-gray-600">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          {" "}
+          Risk Classification
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300">
           Determine your AI system's risk level under EU AI Act
         </p>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Questionnaire */}
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
             Classification Questionnaire
           </h2>
 
           <form className="space-y-6">
             {/* Use Case Category */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Primary Use Case
               </label>
               <select
                 value={formData.use_case_category}
                 onChange={(e) =>
-                  setFormData({ ...formData, use_case_category: e.target.value })
+                  setFormData({
+                    ...formData,
+                    use_case_category: e.target.value,
+                  })
                 }
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg"
               >
@@ -169,7 +175,7 @@ export default function Classification() {
 
             {/* High-Risk Indicators */}
             <div>
-              <h3 className="text-sm font-medium text-gray-900 mb-3">
+              <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-3">
                 High-Risk Indicators (Annex III)
               </h3>
               <div className="space-y-3">
@@ -185,7 +191,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>CV Screening / Candidate Ranking</strong>
                     <br />
                     AI filters CVs or ranks candidates for recruitment
@@ -204,7 +210,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Promotion/Termination Decisions</strong>
                     <br />
                     AI influences employment status decisions
@@ -223,7 +229,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Credit Worthiness Assessment</strong>
                     <br />
                     AI evaluates creditworthiness or credit scoring
@@ -242,7 +248,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Affects Fundamental Rights</strong>
                     <br />
                     Impacts employment, education, or essential services
@@ -261,7 +267,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Automated Decision Making</strong>
                     <br />
                     Makes decisions without meaningful human review
@@ -288,7 +294,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Direct Human Interaction</strong>
                     <br />
                     System interacts directly with users (chatbot, assistant)
@@ -307,7 +313,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Emotion Recognition</strong>
                     <br />
                     System detects or analyzes emotions
@@ -326,7 +332,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Synthetic Content Generation</strong>
                     <br />
                     Generates deepfakes, AI images, or synthetic media
@@ -341,7 +347,9 @@ export default function Classification() {
               disabled={classifyMutation.isPending}
               className="w-full py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
             >
-              {classifyMutation.isPending ? 'Classifying...' : 'Classify Risk Level'}
+              {classifyMutation.isPending
+                ? "Classifying..."
+                : "Classify Risk Level"}
             </button>
           </form>
         </div>
@@ -349,14 +357,16 @@ export default function Classification() {
         {/* Results */}
         <div>
           {result ? (
-            <div className={`rounded-xl border p-6 ${getRiskColor(result.risk_level)}`}>
+            <div
+              className={`rounded-xl border p-6 ${getRiskColor(result.risk_level)}`}
+            >
               <div className="flex items-center gap-4 mb-6">
                 {getRiskIcon(result.risk_level)}
                 <div>
                   <h2 className="text-xl font-bold text-gray-900 capitalize">
                     {result.risk_level} Risk
                   </h2>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
                     Confidence: {Math.round(result.confidence * 100)}%
                   </p>
                 </div>
@@ -364,10 +374,15 @@ export default function Classification() {
 
               {/* Reasons */}
               <div className="mb-6">
-                <h3 className="font-medium text-gray-900 mb-2">Classification Reasons</h3>
+                <h3 className="font-medium text-gray-900 mb-2">
+                  Classification Reasons
+                </h3>
                 <ul className="space-y-2">
                   {result.reasons.map((reason, i) => (
-                    <li key={i} className="text-sm text-gray-600 flex items-start gap-2">
+                    <li
+                      key={i}
+                      className="text-sm text-gray-600 dark:text-gray-300 flex items-start gap-2"
+                    >
                       <span className="text-gray-400">•</span>
                       {reason}
                     </li>
@@ -377,10 +392,15 @@ export default function Classification() {
 
               {/* Requirements */}
               <div className="mb-6">
-                <h3 className="font-medium text-gray-900 mb-2">Compliance Requirements</h3>
+                <h3 className="font-medium text-gray-900 mb-2">
+                  Compliance Requirements
+                </h3>
                 <ul className="space-y-2">
                   {result.requirements.map((req, i) => (
-                    <li key={i} className="text-sm text-gray-600 flex items-start gap-2">
+                    <li
+                      key={i}
+                      className="text-sm text-gray-600 dark:text-gray-300 flex items-start gap-2"
+                    >
                       <CheckCircle className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
                       {req}
                     </li>
@@ -394,7 +414,10 @@ export default function Classification() {
                 <h3 className="font-medium text-gray-900 mb-2">Next Steps</h3>
                 <ol className="space-y-2">
                   {result.next_steps.map((step, i) => (
-                    <li key={i} className="text-sm text-gray-600 flex items-start gap-2">
+                    <li
+                      key={i}
+                      className="text-sm text-gray-600 dark:text-gray-300 flex items-start gap-2"
+                    >
                       <span className="w-5 h-5 bg-primary-100 text-primary-700 rounded-full flex items-center justify-center text-xs flex-shrink-0">
                         {i + 1}
                       </span>
@@ -405,7 +428,7 @@ export default function Classification() {
               </div>
 
               {/* Compliance Checklist */}
-              {result.risk_level !== 'unacceptable' && (
+              {result.risk_level !== "unacceptable" && (
                 <div className="mt-6">
                   <h3 className="font-medium text-gray-900 mb-3">
                     Compliance Checklist
@@ -415,10 +438,10 @@ export default function Classification() {
                     systemId={Number(systemId || 0)}
                     riskLevel={
                       result.risk_level as
-                      | 'minimal'
-                      | 'limited'
-                      | 'high'
-                      | 'unacceptable'
+                        | "minimal"
+                        | "limited"
+                        | "high"
+                        | "unacceptable"
                     }
                     items={CHECKLIST_ITEMS[result.risk_level] || []}
                   />
@@ -426,19 +449,19 @@ export default function Classification() {
               )}
             </div>
           ) : (
-            <div className="bg-gray-50 rounded-xl border border-gray-200 p-8 text-center">
+            <div className="bg-gray-50 dark:bg-gray-800 rounded-xl border border-gray-200 p-8 text-center">
               <AlertTriangle className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-gray-900">
+              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-300">
                 Complete the Questionnaire
               </h3>
-              <p className="text-gray-500 mt-2">
-                Answer the questions to determine your AI system's risk classification
-                under the EU AI Act.
+              <p className="text-gray-500 dark:text-gray-400 mt-2">
+                Answer the questions to determine your AI system's risk
+                classification under the EU AI Act.
               </p>
             </div>
           )}
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -44,8 +44,8 @@ export default function Dashboard() {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-        <p className="text-gray-600">Overview of your EU AI Act compliance status</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Dashboard</h1>
+        <p className="text-gray-600 dark:text-gray-300">Overview of your EU AI Act compliance status</p>
       </div>
 
       {/* Stats */}
@@ -53,15 +53,15 @@ export default function Dashboard() {
         {stats.map((stat) => (
           <div
             key={stat.name}
-            className="bg-white rounded-xl shadow-sm border border-gray-200 p-6"
+            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6"
           >
             <div className="flex items-center gap-4">
               <div className={`p-3 rounded-lg ${stat.color}`}>
-                <stat.icon className="w-6 h-6 text-white" />
+                <stat.icon className="w-6 h-6 text-white dark:text-gray-700" />
               </div>
               <div>
-                <p className="text-sm text-gray-600">{stat.name}</p>
-                <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
+                <p className="text-sm text-gray-600 dark:text-gray-300">{stat.name}</p>
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">{stat.value}</p>
               </div>
             </div>
           </div>
@@ -69,26 +69,26 @@ export default function Dashboard() {
       </div>
 
       {/* Quick Actions */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Quick Actions</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Link
             to="/ai-systems"
-            className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
+            className="flex items-center gap-3 p-4 rounded-lg border text-gray-600 border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
           >
             <Bot className="w-5 h-5 text-primary-600" />
             <span className="font-medium">Add AI System</span>
           </Link>
           <Link
             to="/classification"
-            className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
+            className="flex items-center gap-3 p-4 rounded-lg border text-gray-600 border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
           >
             <AlertTriangle className="w-5 h-5 text-primary-600" />
             <span className="font-medium">Risk Classification</span>
           </Link>
           <Link
             to="/documents"
-            className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
+            className="flex items-center gap-3 p-4 rounded-lg border text-gray-600 border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
           >
             <FileText className="w-5 h-5 text-primary-600" />
             <span className="font-medium">Generate Documents</span>
@@ -97,8 +97,8 @@ export default function Dashboard() {
       </div>
 
       {/* Recent AI Systems */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Your AI Systems</h2>
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Your AI Systems</h2>
         {systems.length === 0 ? (
           <div className="text-center py-8 text-gray-500">
             <Bot className="w-12 h-12 mx-auto mb-3 text-gray-300" />
@@ -120,10 +120,10 @@ export default function Dashboard() {
             }) => (
               <div
                 key={system.id}
-                className="flex items-center justify-between p-4 rounded-lg border border-gray-200"
+                className="flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-gray-700"
               >
                 <div>
-                  <p className="font-medium text-gray-900">{system.name}</p>
+                  <p className="font-medium text-gray-900 dark:text-white">{system.name}</p>
                   <div className="flex items-center gap-2 mt-1">
                     {system.risk_level && (
                       <span

--- a/frontend/src/pages/Documents.tsx
+++ b/frontend/src/pages/Documents.tsx
@@ -105,15 +105,15 @@ export default function Documents() {
     <div className="space-y-8">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Documents</h1>
-          <p className="text-gray-600">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Documents</h1>
+          <p className="text-gray-600 dark:text-gray-400">
             Generate and manage compliance documentation
           </p>
         </div>
         <button
           onClick={() => setShowModal(true)}
           disabled={systems.length === 0}
-          className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
+          className="flex items-center gap-2 px-4 py-2 bg-primary-600 dark:bg-primary-500 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
         >
           <Plus className="w-5 h-5" />
           Generate Document
@@ -129,10 +129,10 @@ export default function Documents() {
       {isLoading ? (
         <div className="text-center py-12 text-gray-500">Loading...</div>
       ) : documents.length === 0 ? (
-        <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
+        <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
           <FileText className="w-16 h-16 mx-auto mb-4 text-gray-300" />
-          <h3 className="text-lg font-medium text-gray-900">No documents yet</h3>
-          <p className="text-gray-500 mt-1">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white">No documents yet</h3>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">
             Generate your first compliance document
           </p>
         </div>
@@ -141,7 +141,7 @@ export default function Documents() {
           {documents.map((doc: Document) => (
             <div
               key={doc.id}
-              className="bg-white rounded-xl border border-gray-200 p-6"
+              className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6"
             >
               <div className="flex items-start justify-between">
                 <div className="flex items-start gap-4">
@@ -149,7 +149,7 @@ export default function Documents() {
                     <FileText className="w-6 h-6 text-primary-600" />
                   </div>
                   <div>
-                    <h3 className="font-semibold text-gray-900">{doc.title}</h3>
+                    <h3 className="font-semibold text-gray-900 dark:text-white">{doc.title}</h3>
                     <div className="flex items-center gap-3 mt-2">
                       <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded">
                         {doc.document_type.replace(/_/g, ' ')}
@@ -216,8 +216,8 @@ export default function Documents() {
       {/* Generate Modal */}
       {showModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-xl p-6 w-full max-w-md">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          <div className="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-md">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
               Generate Document
             </h2>
             <div className="space-y-4">
@@ -278,7 +278,7 @@ export default function Documents() {
       {/* Editor Modal */}
       {editingDoc && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl w-full max-w-6xl h-[90vh]">
+          <div className="bg-white dark:bg-gray-800 rounded-xl w-full max-w-6xl h-[90vh]">
             <DocumentEditor
               documentId={editingDoc.id}
               initialContent={editingDoc.content || ''}

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -64,11 +64,11 @@ export default function Notifications() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Notifications</h1>
-          <p className="text-gray-600">Your recent compliance and system events</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Notifications</h1>
+          <p className="text-gray-600 dark:text-gray-500">Your recent compliance and system events</p>
         </div>
         {/* TODO (help wanted): wire to POST /notifications/read with all unread IDs */}
-        <button className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg border border-gray-200">
+        <button className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg border border-gray-200 dark:border-gray-600">
           <Check className="w-4 h-4" />
           Mark all read
         </button>
@@ -76,7 +76,7 @@ export default function Notifications() {
 
       {/* Notification list */}
       {notifications.length === 0 ? (
-        <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
+        <div className="text-center py-12 bg-white dark:bg-gray-500 rounded-xl border border-gray-200">
           <Bell className="w-16 h-16 mx-auto mb-4 text-gray-300" />
           <h3 className="text-lg font-medium text-gray-900">No notifications</h3>
           <p className="text-gray-500 mt-1">You're all caught up.</p>
@@ -86,7 +86,7 @@ export default function Notifications() {
           {notifications.map((n) => (
             <div
               key={n.id}
-              className={`bg-white rounded-xl border p-4 flex items-start gap-4 ${
+              className={`bg-white dark:bg-gray-600 rounded-xl border p-4 flex items-start gap-4 ${
                 n.is_read ? 'border-gray-200' : 'border-primary-200 bg-primary-50'
               }`}
             >
@@ -97,7 +97,7 @@ export default function Notifications() {
               />
               <div className="flex-1 min-w-0">
                 <p className="font-medium text-gray-900 text-sm">{n.title}</p>
-                <p className="text-gray-600 text-sm mt-0.5">{n.message}</p>
+                <p className="text-gray-600 dark:text-gray-200 text-sm mt-0.5">{n.message}</p>
                 <p className="text-gray-400 text-xs mt-1">
                   {new Date(n.created_at).toLocaleString()}
                 </p>


### PR DESCRIPTION
## Summary
Add dark mode support to remaining pages

This PR adds dark mode support to pages not yet covered in #228.

Changes:
- Applied dark variants to text, background, border, and hover styles
- Covered: Classification, Documents (and other uncovered pages)

Note:
- Does not modify theme toggle or global styles (already handled in #216)
- Built on latest main branch to avoid conflicts

## Screenshots 

<img width="1536" height="701" alt="Screenshot 2026-05-14 091648" src="https://github.com/user-attachments/assets/c23b7a8d-8038-45f4-9bb5-b47865ab9eaa" />
<img width="1533" height="685" alt="Screenshot 2026-05-14 091637" src="https://github.com/user-attachments/assets/fe318b48-f2c1-4df7-8eeb-42c03a319c2c" />
<img width="1532" height="743" alt="Screenshot 2026-05-14 091629" src="https://github.com/user-attachments/assets/6ca8fbaf-9324-4d0a-a156-613499ed2d3b" />

