### PR TITLE
fix(rag): enforce tenant isolation and harden vector store loading

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from app.core.security import get_current_user
 from app.models.user import User
 from app.core.database import get_db
+from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
 from app.models.rag_feedback import RAGFeedback
 from app.models.user import SubscriptionTier
@@ -31,6 +32,30 @@ class RAGQueryResponse(BaseModel):
     answer: str
     sources: list[str] = []
     answer_id: Optional[str] = None
+
+
+def _ensure_rag_feedback_owner_column(db: Session) -> None:
+    """
+    Backfill-compatible schema guard for deployments that created rag_feedback
+    before owner_id existed.
+    """
+    from app.core.database import Base
+
+    bind = db.get_bind()
+    Base.metadata.create_all(bind=bind)
+
+    inspector = inspect(bind)
+    tables = set(inspector.get_table_names())
+    if "rag_feedback" not in tables:
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("rag_feedback")}
+    if "owner_id" in columns:
+        return
+
+    db.execute(text("ALTER TABLE rag_feedback ADD COLUMN owner_id INTEGER"))
+    db.execute(text("UPDATE rag_feedback SET owner_id = 0 WHERE owner_id IS NULL"))
+    db.commit()
 
 
 @router.post("/query", response_model=RAGQueryResponse)
@@ -54,16 +79,11 @@ def query_knowledge_base(
         source_docs = result.get("source_documents", [])
         sources = [str(doc.metadata.get("source", "")) for doc in source_docs]
 
-        # Ensure tables exist on this DB bind (useful for test DB overrides)
-        from app.core.database import Base
-        try:
-            Base.metadata.create_all(bind=db.get_bind())
-        except Exception:
-            # best-effort: ignore if bind not available
-            pass
+        _ensure_rag_feedback_owner_column(db)
 
         # Persist an initial RAGFeedback row to capture the answer and contributing chunks
         feedback = RAGFeedback(
+            owner_id=current_user.id,
             question=request.question,
             answer=str(result.get("result", "")),
             source_chunks=sources,
@@ -73,7 +93,9 @@ def query_knowledge_base(
         db.refresh(feedback)
         answer_id = feedback.id
 
-        return RAGQueryResponse(answer=result["result"], sources=sources, answer_id=answer_id)
+        return RAGQueryResponse(
+            answer=result["result"], sources=sources, answer_id=answer_id
+        )
     except FileNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -90,22 +112,18 @@ def query_knowledge_base(
 def rag_health():
     """Check if the RAG module is available."""
     from app.modules.rag.vector_store import check_index_exists
-    
+
     index_loaded = check_index_exists()
-    
+
     if not index_loaded:
         return {
             "module": "rag_intelligence",
             "status": "unavailable",
             "index_loaded": False,
-            "message": "FAISS index not found. RAG module requires document ingestion before use."
+            "message": "FAISS index not found. RAG module requires document ingestion before use.",
         }
-    
-    return {
-        "module": "rag_intelligence",
-        "status": "available",
-        "index_loaded": True
-    }
+
+    return {"module": "rag_intelligence", "status": "available", "index_loaded": True}
 
 
 class RAGFeedbackRequest(BaseModel):
@@ -120,7 +138,15 @@ def rag_feedback(
     db: Session = Depends(get_db),
 ):
     """Record a thumbs-up or thumbs-down for a previously returned answer."""
-    fb = db.query(RAGFeedback).filter(RAGFeedback.id == payload.answer_id).first()
+    _ensure_rag_feedback_owner_column(db)
+    fb = (
+        db.query(RAGFeedback)
+        .filter(
+            RAGFeedback.id == payload.answer_id,
+            RAGFeedback.owner_id == current_user.id,
+        )
+        .first()
+    )
     if not fb:
         raise HTTPException(status_code=404, detail="Answer not found")
     if payload.vote == "up":
@@ -151,15 +177,16 @@ def get_low_quality_chunks(
         raise HTTPException(status_code=403, detail="Admin access required")
 
     # Aggregate counts per chunk
+    _ensure_rag_feedback_owner_column(db)
     counts: dict[str, dict[str, int]] = {}
-    rows = db.query(RAGFeedback).all()
+    rows = db.query(RAGFeedback).filter(RAGFeedback.owner_id == current_user.id).all()
     for r in rows:
         total = (r.thumbs_up or 0) + (r.thumbs_down or 0)
-        for chunk in (r.source_chunks or []):
+        for chunk in r.source_chunks or []:
             if chunk not in counts:
                 counts[chunk] = {"thumbs_up": 0, "thumbs_down": 0, "total": 0}
-            counts[chunk]["thumbs_up"] += (r.thumbs_up or 0)
-            counts[chunk]["thumbs_down"] += (r.thumbs_down or 0)
+            counts[chunk]["thumbs_up"] += r.thumbs_up or 0
+            counts[chunk]["thumbs_down"] += r.thumbs_down or 0
             counts[chunk]["total"] += total
 
     low_quality = []
@@ -168,6 +195,13 @@ def get_low_quality_chunks(
             continue
         ratio = c["thumbs_down"] / c["total"]
         if ratio > threshold:
-            low_quality.append({"chunk": chunk, "thumbs_down": c["thumbs_down"], "total": c["total"], "ratio": ratio})
+            low_quality.append(
+                {
+                    "chunk": chunk,
+                    "thumbs_down": c["thumbs_down"],
+                    "total": c["total"],
+                    "ratio": ratio,
+                }
+            )
 
     return {"threshold": threshold, "low_quality_chunks": low_quality}

--- a/backend/app/models/rag_feedback.py
+++ b/backend/app/models/rag_feedback.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, JSON
+from sqlalchemy import Column, Integer, String, DateTime, JSON, ForeignKey
 from datetime import datetime
 import uuid
 from app.core.database import Base
@@ -8,6 +8,7 @@ class RAGFeedback(Base):
     __tablename__ = "rag_feedback"
 
     id = Column(String(64), primary_key=True, default=lambda: str(uuid.uuid4()))
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     question = Column(String(2000), nullable=True)
     answer = Column(String(4000), nullable=True)
     thumbs_up = Column(Integer, default=0)

--- a/backend/app/modules/rag/vector_store.py
+++ b/backend/app/modules/rag/vector_store.py
@@ -15,6 +15,25 @@ def get_embeddings():
     )
 
 
+def _resolve_index_path() -> str:
+    index_path = settings.FAISS_INDEX_PATH
+    if not index_path:
+        raise ValueError("FAISS index path is not configured.")
+    resolved_path = os.path.abspath(index_path)
+    if os.path.islink(resolved_path):
+        raise ValueError("FAISS index path must not be a symlink.")
+    return resolved_path
+
+
+def _validate_index_artifacts(index_path: str) -> None:
+    for filename in ("index.faiss", "index.pkl"):
+        artifact_path = os.path.join(index_path, filename)
+        if not os.path.exists(artifact_path):
+            raise FileNotFoundError(f"FAISS artifact not found at '{artifact_path}'.")
+        if os.path.islink(artifact_path):
+            raise ValueError(f"FAISS artifact must not be a symlink: '{artifact_path}'.")
+
+
 def create_vector_store(file_paths: list[str]):
     """
     Build a FAISS index from a list of local PDF paths and persist it to disk.
@@ -28,7 +47,8 @@ def create_vector_store(file_paths: list[str]):
     documents = load_documents_from_paths(file_paths)
     embeddings = get_embeddings()
     vector_store = FAISS.from_documents(documents, embeddings)
-    vector_store.save_local(settings.FAISS_INDEX_PATH)
+    index_path = _resolve_index_path()
+    vector_store.save_local(index_path)
     return vector_store
 
 
@@ -39,19 +59,28 @@ def load_vector_store():
     Raises:
         FileNotFoundError: if the index has not been created yet
     """
-    index_path = settings.FAISS_INDEX_PATH
+    index_path = _resolve_index_path()
     if not os.path.exists(index_path):
         raise FileNotFoundError(
             f"FAISS index not found at '{index_path}'. "
             "The RAG module requires regulatory documents to be ingested first. "
             "Please contact your administrator or check the documentation for setup instructions."
         )
+    _validate_index_artifacts(index_path)
     embeddings = get_embeddings()
     return FAISS.load_local(
-        index_path, embeddings, allow_dangerous_deserialization=True
+        index_path,
+        embeddings,
+        # Current langchain FAISS persistence requires pickle to load metadata;
+        # strict path/artifact validation above reduces deserialization risk.
+        allow_dangerous_deserialization=True,
     )
 
 
 def check_index_exists():
     """Check if FAISS index exists on disk."""
-    return os.path.exists(settings.FAISS_INDEX_PATH)
+    try:
+        index_path = _resolve_index_path()
+    except ValueError:
+        return False
+    return os.path.exists(index_path)

--- a/backend/tests/integration/test_rag_feedback.py
+++ b/backend/tests/integration/test_rag_feedback.py
@@ -3,12 +3,15 @@ from fastapi.testclient import TestClient
 from unittest.mock import patch
 import importlib
 from sqlalchemy import create_engine
+from sqlalchemy import inspect
+from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
 from app.main import app
 from app.core.database import Base, get_db
 from app.core.security import get_current_user
 from app.models.user import User, SubscriptionTier
+from app.api.v1 import rag as rag_api
 
 
 class DummyDoc:
@@ -51,7 +54,10 @@ def client():
 
 def test_query_feedback_and_low_quality_flow(client):
     # Mock the QA chain to return controlled result and sources
-    fake_result = {"result": "Test answer", "source_documents": [DummyDoc("doc1.pdf#chunk1"), DummyDoc("doc2.pdf#chunk2")]}
+    fake_result = {
+        "result": "Test answer",
+        "source_documents": [DummyDoc("doc1.pdf#chunk1"), DummyDoc("doc2.pdf#chunk2")],
+    }
 
     # Provide a lightweight fake retrieval_chain module (avoid heavy langchain imports)
     import types, sys
@@ -73,13 +79,29 @@ def test_query_feedback_and_low_quality_flow(client):
     answer_id = data["answer_id"]
 
     # Submit a thumbs-down for that answer
-    resp2 = client.post("/api/v1/rag/feedback", json={"answer_id": answer_id, "vote": "down"})
+    resp2 = client.post(
+        "/api/v1/rag/feedback", json={"answer_id": answer_id, "vote": "down"}
+    )
     assert resp2.status_code == 200
+
+    # A different user should not be able to modify feedback
+    def _other_user():
+        u = User()
+        u.id = 2
+        u.email = "other@example.com"
+        u.subscription_tier = SubscriptionTier.FREE
+        return u
+
+    app.dependency_overrides[get_current_user] = _other_user
+    resp_denied = client.post(
+        "/api/v1/rag/feedback", json={"answer_id": answer_id, "vote": "down"}
+    )
+    assert resp_denied.status_code == 404
 
     # Now query low-quality-chunks as admin: override current_user to be admin
     def _admin_user():
         u = User()
-        u.id = 2
+        u.id = 1
         u.email = "admin@example.com"
         u.subscription_tier = SubscriptionTier.SCALE
         return u
@@ -93,3 +115,105 @@ def test_query_feedback_and_low_quality_flow(client):
     # Should contain our two chunks (since total feedback for the answer was 1 down)
     chunks = {c["chunk"] for c in out["low_quality_chunks"]}
     assert "doc1.pdf#chunk1" in chunks or "doc2.pdf#chunk2" in chunks
+
+    # A different scale user should not see another tenant's feedback
+    def _other_admin_user():
+        u = User()
+        u.id = 3
+        u.email = "scale-other@example.com"
+        u.subscription_tier = SubscriptionTier.SCALE
+        return u
+
+    app.dependency_overrides[get_current_user] = _other_admin_user
+    resp4 = client.get("/api/v1/rag/low-quality-chunks?threshold=0.0")
+    assert resp4.status_code == 200
+    out_other = resp4.json()
+    assert out_other["low_quality_chunks"] == []
+
+
+def test_query_handles_legacy_rag_feedback_schema(client):
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE rag_feedback"))
+        conn.execute(
+            text(
+                """
+                CREATE TABLE rag_feedback (
+                    id VARCHAR(64) PRIMARY KEY,
+                    question VARCHAR(2000),
+                    answer VARCHAR(4000),
+                    thumbs_up INTEGER,
+                    thumbs_down INTEGER,
+                    source_chunks JSON,
+                    created_at DATETIME
+                )
+                """
+            )
+        )
+
+    def _override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    def _fake_user():
+        u = User()
+        u.id = 1
+        u.email = "tenant@example.com"
+        u.subscription_tier = SubscriptionTier.FREE
+        return u
+
+    app.dependency_overrides[get_current_user] = _fake_user
+
+    import types, sys
+
+    mod = types.ModuleType("app.modules.rag.retrieval_chain")
+
+    def _fake_get_qa_chain():
+        return lambda payload: {
+            "result": "Legacy schema answer",
+            "source_documents": [DummyDoc("legacy.pdf#chunk1")],
+        }
+
+    mod.get_qa_chain = _fake_get_qa_chain
+    sys.modules["app.modules.rag.retrieval_chain"] = mod
+
+    resp = client.post("/api/v1/rag/query", json={"question": "Legacy table?"})
+    assert resp.status_code == 200
+
+
+def test_legacy_rag_feedback_table_gets_owner_column():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE rag_feedback (
+                    id VARCHAR(64) PRIMARY KEY,
+                    question VARCHAR(2000),
+                    answer VARCHAR(4000),
+                    thumbs_up INTEGER,
+                    thumbs_down INTEGER,
+                    source_chunks JSON,
+                    created_at DATETIME
+                )
+                """
+            )
+        )
+
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+    try:
+        rag_api._ensure_rag_feedback_owner_column(db)
+        db.commit()
+    finally:
+        db.close()
+
+    cols = [c["name"] for c in inspect(engine).get_columns("rag_feedback")]
+    assert "owner_id" in cols

--- a/backend/tests/test_retrieval_chain.py
+++ b/backend/tests/test_retrieval_chain.py
@@ -38,6 +38,8 @@ class TestVectorStore:
         # Assertions
         assert result == mock_vs
         mock_load_local.assert_called_once()
+        _, kwargs = mock_load_local.call_args
+        assert kwargs["allow_dangerous_deserialization"] is True
 
 
 class TestRetrievalChain:


### PR DESCRIPTION
## Summary

Closes #223

This PR fixes a multi-tenant data isolation issue in the RAG module and hardens FAISS index loading. RAG feedback is now tenant-scoped (`owner_id`) and RAG endpoints only read/update feedback for the current user, preventing cross-company disclosure via low-quality chunk analytics.
It also adds strict FAISS index path/artifact validation and updates tests to cover tenant boundaries and legacy-schema compatibility.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Screenshots (if UI change)

<!-- Add before/after screenshots here -->
