### PR TITLE
fix: add ignoreDeprecations to tsconfig

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",// Ignore TypeScript 7.0 baseUrl deprecation warnings
     "paths": {
       "@/*": ["src/*"]
     }


### PR DESCRIPTION
## Related Issue
Fixes #162

## Changes Made
- Added `ignoreDeprecations: "6.0"` under compilerOptions in frontend/tsconfig.json
- Added comment explaining why the option is used
- Silenced TypeScript baseUrl deprecation warning

## Result
- Project compiles successfully without new errors