### PR TITLE
Add delete confirmation dialogs

### DIFF
--- a/frontend/src/pages/AISystems.tsx
+++ b/frontend/src/pages/AISystems.tsx
@@ -28,6 +28,7 @@ export default function AISystems() {
   const [complianceFilter, setComplianceFilter] = useState('')
   const [sortBy, setSortBy] = useState('created_at')
   const [order, setOrder] = useState('desc')
+  const [systemToDelete, setSystemToDelete] = useState<AISystem | null>(null)
 
   const { data: systems = [], isLoading } = useQuery({
     queryKey: ['ai-systems', sortBy, order],
@@ -47,6 +48,7 @@ export default function AISystems() {
     mutationFn: aiSystemsApi.delete,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['ai-systems'] })
+      setSystemToDelete(null)
     },
   })
 
@@ -283,7 +285,7 @@ export default function AISystems() {
                     <Edit className="w-5 h-5" />
                   </button>
                   <button
-                    onClick={() => deleteMutation.mutate(system.id)}
+                    onClick={() => setSystemToDelete(system)}
                     className="p-2 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50"
                   >
                     <Trash2 className="w-5 h-5" />
@@ -312,6 +314,38 @@ export default function AISystems() {
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+
+      {/* Delete Confirmation Modal */}
+      {systemToDelete && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl p-6 w-full max-w-md">
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">
+              Delete AI System
+            </h2>
+            <p className="text-gray-600">
+              Are you sure you want to delete {systemToDelete.name}? This cannot be undone.
+            </p>
+            <div className="flex justify-end gap-3 pt-6">
+              <button
+                type="button"
+                onClick={() => setSystemToDelete(null)}
+                className="px-4 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteMutation.mutate(systemToDelete.id)}
+                disabled={deleteMutation.isPending}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/Documents.tsx
+++ b/frontend/src/pages/Documents.tsx
@@ -25,6 +25,7 @@ export default function Documents() {
   const [selectedSystem, setSelectedSystem] = useState<number | null>(null)
   const [selectedType, setSelectedType] = useState('technical_documentation')
   const [editingDoc, setEditingDoc] = useState<Document | null>(null)
+  const [documentToDelete, setDocumentToDelete] = useState<Document | null>(null)
 
   const { data: documents = [], isLoading } = useQuery({
     queryKey: ['documents'],
@@ -48,6 +49,7 @@ export default function Documents() {
     mutationFn: documentsApi.delete,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['documents'] })
+      setDocumentToDelete(null)
     },
   })
 
@@ -192,7 +194,7 @@ export default function Documents() {
                     <Download className="w-5 h-5" />
                   </button>
                   <button
-                    onClick={() => deleteMutation.mutate(doc.id)}
+                    onClick={() => setDocumentToDelete(doc)}
                     className="p-2 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50"
                   >
                     <Trash2 className="w-5 h-5" />
@@ -210,6 +212,38 @@ export default function Documents() {
               )}
             </div>
           ))}
+        </div>
+      )}
+
+
+      {/* Delete Confirmation Modal */}
+      {documentToDelete && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl p-6 w-full max-w-md">
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">
+              Delete Document
+            </h2>
+            <p className="text-gray-600">
+              Are you sure you want to delete {documentToDelete.title}? This cannot be undone.
+            </p>
+            <div className="flex justify-end gap-3 pt-6">
+              <button
+                type="button"
+                onClick={() => setDocumentToDelete(null)}
+                className="px-4 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteMutation.mutate(documentToDelete.id)}
+                disabled={deleteMutation.isPending}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
Adds confirmation modals before deleting AI systems or documents so the delete request is only sent after the user confirms the irreversible action. Both pages now keep the existing delete behavior behind a styled Cancel/Delete dialog and close the dialog after a successful deletion. Verified with `npm ci --prefix frontend`, `npm run build --prefix frontend`, and `git diff --check`.
