### PR TITLE
ci: add pypi publish workflow for guard-sdk (Issue #137)

### DIFF
--- a/.github/workflows/publish-guard-sdk.yml
+++ b/.github/workflows/publish-guard-sdk.yml
@@ -1,0 +1,32 @@
+name: Publish aegisai-guard to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # for OIDC trusted publishing
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          
+      - name: Install build tools
+        run: pip install hatch
+        
+      - name: Build
+        run: hatch build
+        working-directory: guard-sdk/
+        
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: guard-sdk/dist/


### PR DESCRIPTION
## Description
This PR sets up automated PyPI publishing for the `aegisai-guard` package via GitHub Actions, fulfilling Issue #137.

## Changes Made
- Created `.github/workflows/publish-guard-sdk.yml` to automate the build and publish process.
- **Triggers:** The workflow is configured to run automatically whenever a tag matching `v*` (e.g., `v0.1.0`) is pushed to the repository.
- **Build System:** Uses `hatch` to build the distribution inside the `guard-sdk/` directory.
- **Publishing:** Uses OIDC trusted publishing (`pypa/gh-action-pypi-publish@release/v1`) meaning no long-lived tokens are required.

## Next Steps for Maintainers
Once this is merged, you will need to configure **PyPI Trusted Publishing** in the PyPI project settings (pointing to this GitHub repository) to authorize the workflow. 

After that, publishing a new version is as simple as:
```bash
git tag v0.1.0
git push origin v0.1.0
