### PR TITLE
feat(guard): add GuardScanLog SQLAlchemy model and Pydantic schema

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,4 +3,5 @@ from app.models.ai_system import AISystem, RiskAssessment
 from app.models.document import Document
 from app.models.rag_feedback import RAGFeedback
 from app.models.audit_log import AISystemAuditLog
-__all__ = ["User", "AISystem", "RiskAssessment", "Document", "RAGFeedback"]
+from app.models.guard_scan_log import GuardScanLog
+__all__ = ["User", "AISystem", "RiskAssessment", "Document", "RAGFeedback", "GuardScanLog"]

--- a/backend/app/models/guard_scan_log.py
+++ b/backend/app/models/guard_scan_log.py
@@ -1,0 +1,30 @@
+"""
+GuardScanLog model — records every prompt scan decision made by the LLM Guard.
+Copyright (C) 2024 Sarthak Doshi (github.com/SdSarthak)
+SPDX-License-Identifier: AGPL-3.0-only
+
+Prompts are stored as SHA-256 hashes only — never raw text — to protect user privacy.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey, JSON
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class GuardScanLog(Base):
+    __tablename__ = "guard_scan_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+
+    prompt_hash = Column(String(64), nullable=False)  # SHA-256 hex digest
+    decision = Column(String(16), nullable=False)      # allow | sanitize | block
+    confidence = Column(Float, nullable=False)
+    matched_patterns = Column(JSON, default=list)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    user = relationship("User")

--- a/backend/app/schemas/guard_scan_log.py
+++ b/backend/app/schemas/guard_scan_log.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, Field
+from typing import List, Any
+from datetime import datetime
+
+
+class GuardScanLogCreate(BaseModel):
+    user_id: int
+    prompt_hash: str = Field(..., min_length=64, max_length=64, description="SHA-256 hex digest of the scanned prompt")
+    decision: str = Field(..., pattern="^(allow|sanitize|block)$")
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    matched_patterns: List[Any] = []
+
+
+class GuardScanLogResponse(BaseModel):
+    id: int
+    user_id: int
+    prompt_hash: str
+    decision: str
+    confidence: float
+    matched_patterns: List[Any]
+    created_at: datetime
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary

Closes #38

Adds the `GuardScanLog` SQLAlchemy ORM model and matching Pydantic schemas to support audit logging of LLM Guard prompt scan decisions. Prompts are stored as SHA-256 hashes only, never raw text, to protect user privacy. The table is auto-created on startup via `Base.metadata.create_all`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)

N/A . backend model/schema only, no UI changes.