### PR TITLE
fix(frontend): store token before calling getMe to fix 401 on login

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -19,8 +19,9 @@ export default function Login() {
 
     try {
       const tokenData = await authApi.login(email, password)
-      const user = await authApi.getMe()
-      setAuth(tokenData.access_token, user)
+      setAuth(tokenData.access_token, null)  
+      const user = await authApi.getMe()     
+      setAuth(tokenData.access_token, user)  
       navigate('/')
     } catch {
       setError('Invalid email or password')


### PR DESCRIPTION
## Summary
Closes #306

In `Login.tsx`, `getMe()` was called before the token was stored in the Zustand auth store. The axios interceptor reads the Bearer token from the store, so `getMe()` fired without authentication on fresh sessions, returning 401 Unauthorized.

**Fix:** Call `setAuth(token, null)` first to store the token, then call `getMe()`, then update with the full user object.

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style
- [x] I have not committed `.env` or any secrets

## Screenshots
Backend logs before fix:
POST /api/v1/auth/login  200 OK
GET  /api/v1/auth/me     401 Unauthorized

Backend logs after fix:
POST /api/v1/auth/login  200 OK
GET  /api/v1/auth/me     200 OK

## GSSoC '26
I am a GSSoC '26 contributor (@Thongramdhanapyari)
**GSSoC '26 Profile:** https://gssoc.girlscript.org/profile/7db6318c-a7c7-40f9-b4c0-d6127a7d07d2