### PR TITLE
fix(frontend): use BACKEND_URL env var for Vite proxy target

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     container_name: aegisai_frontend
     ports:
       - "5173:5173"
+    environment:
+      - BACKEND_URL=http://backend:8000
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: process.env.BACKEND_URL || 'http://localhost:8000',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

- Vite proxy target `http://localhost:8000` resolves to the frontend container itself when running inside Docker, causing all API calls to fail silently
- Added `BACKEND_URL` env var to `docker-compose.yml` set to `http://backend:8000` (Docker Compose service name)
- Updated `vite.config.ts` proxy to use `process.env.BACKEND_URL || 'http://localhost:8000'` — works in Docker and local dev

## Test plan

- [ ] Run `docker compose up -d` and verify registration/login works at http://localhost:5173
- [ ] Run `npm run dev` locally (without Docker) and verify proxy still works against `http://localhost:8000`
- [ ] Confirm backend logs show incoming requests after fix

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)