### PR TITLE
fix(frontend): show actual backend error messages on auth failures

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -22,8 +22,11 @@ export default function Login() {
       const user = await authApi.getMe()
       setAuth(tokenData.access_token, user)
       navigate('/')
-    } catch {
-      setError('Invalid email or password')
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
+        'Login failed. Please check your credentials and try again.'
+      setError(message)
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -22,8 +22,11 @@ export default function Register() {
     try {
       await authApi.register(formData)
       navigate('/login')
-    } catch {
-      setError('Registration failed. Email may already be in use.')
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
+        'Registration failed. Please try again.'
+      setError(message)
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## Summary

- `Register.tsx` and `Login.tsx` catch blocks were swallowing all errors and showing a single hardcoded message regardless of the actual failure
- Both now extract `response.data.detail` from the backend API error (FastAPI's standard error shape)
- Falls back to a generic message if no detail is present (e.g. network failure)

## Changes

- `frontend/src/pages/Register.tsx` — parse actual error from axios response
- `frontend/src/pages/Login.tsx` — parse actual error from axios response

## Test plan

- [ ] Attempt registration with an already-registered email — should show `"Email already registered"` (from backend)
- [ ] Attempt login with wrong password — should show `"Incorrect email or password"` (from backend)
- [ ] Attempt registration/login with backend unreachable — should show generic fallback message

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)