### PR TITLE
fix: replace default Vite favicon with AegisAI branding

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EU AI Act Compliance Tool</title>
   </head>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6366f1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+</svg>


### PR DESCRIPTION
Closes #327

## Summary

* Replaced the default Vite favicon with an AegisAI-branded shield favicon
* Added a custom `favicon.svg` inside `frontend/public`
* Updated `frontend/index.html` to use the new favicon

## Result

The browser tab now reflects AegisAI branding consistently across the application.
