### PR TITLE
feat: add RAG-based compliance report generator

### DIFF
--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -353,3 +353,28 @@ def get_ai_system_history(
         }
         for log in history
     ]
+
+@router.post("/{system_id}/generate-report")
+def generate_report_endpoint(
+    system_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    system = db.query(AISystem).filter(
+        AISystem.id == system_id,
+        AISystem.owner_id == current_user.id
+    ).first()
+
+    if not system:
+        raise HTTPException(status_code=404, detail="System not found")
+
+    from app.modules.rag.report_generator import generate_report
+
+    report = generate_report(
+        metadata=system.name,
+        risk=str(system.risk_level),
+        answers=system.description or "No description provided"
+    )
+
+    return {"report": report}
+

--- a/backend/app/modules/rag/report_generator.py
+++ b/backend/app/modules/rag/report_generator.py
@@ -1,0 +1,102 @@
+from openai import OpenAI
+import numpy as np
+
+# init client
+client = OpenAI()
+
+
+def get_embedding(text):
+    response = client.embeddings.create(
+        model="text-embedding-3-small",
+        input=text
+    )
+    return response.data[0].embedding
+
+
+
+def split_text(text, chunk_size=200):
+    words = text.split()
+    chunks = []
+
+    for i in range(0, len(words), chunk_size):
+        chunk = " ".join(words[i:i+chunk_size])
+        chunks.append(chunk)
+
+    return chunks
+
+
+
+def create_vector_store(text):
+    chunks = split_text(text)
+
+    store = []
+    for chunk in chunks:
+        emb = get_embedding(chunk)
+        store.append({
+            "text": chunk,
+            "embedding": emb
+        })
+
+    return store
+
+
+
+def cosine_similarity(a, b):
+    return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
+
+
+
+def retrieve_relevant(query, store, top_k=3):
+    query_emb = get_embedding(query)
+
+    scores = []
+    for item in store:
+        score = cosine_similarity(query_emb, item["embedding"])
+        scores.append((score, item["text"]))
+
+    scores.sort(reverse=True)
+
+    return [text for _, text in scores[:top_k]]
+
+
+def load_context():
+    try:
+        with open("regulations.txt", "r", encoding="utf-8") as f:
+            return f.read()
+    except:
+        return "General compliance regulations apply."
+
+
+def generate_report(metadata, risk, answers, context=None):
+    if context is None:
+        context = load_context()
+
+    store = create_vector_store(context)
+
+    query = f"{metadata} {risk} {answers}"
+    relevant_chunks = retrieve_relevant(query, store)
+
+    final_context = "\n".join(relevant_chunks)
+
+    prompt = f"""
+    You are a compliance expert.
+
+    System Metadata: {metadata}
+    Risk Classification: {risk}
+    Questionnaire Answers: {answers}
+
+    Regulatory Context:
+    {final_context}
+
+    Write a professional compliance report with:
+    - Overview
+    - Risk Analysis
+    - Recommendations
+    """
+
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": prompt}]
+    )
+
+    return response.choices[0].message.content

--- a/backend/app/modules/rag/requirements.txt
+++ b/backend/app/modules/rag/requirements.txt
@@ -1,0 +1,1 @@
+AI systems handling sensitive personal data must follow strict compliance standards. High-risk systems require regular audits and transparency.


### PR DESCRIPTION
## Summary

Closes #81

Implemented a Retrieval-Augmented Generation (RAG) based compliance report generator. Added a new API endpoint that generates structured reports using contextual regulatory data instead of static templates.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style
- [ ] I have added/updated tests where relevant
- [ ] pytest backend/tests/ passes locally
- [x] I have not committed .env or any secrets

## Additional Notes

- Added RAG pipeline with embeddings and semantic retrieval
- New endpoint: /{system_id}/generate-report
- Structured output (Overview, Risk Analysis, Recommendations)
- Uses lightweight in-memory vector store (can be extended further)
