### PR TITLE
 feat: add RagQuery model and GET /rag/history endpoint #65

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -17,6 +17,7 @@ from app.models.user import User
 from app.core.database import get_db
 from sqlalchemy.orm import Session
 from app.models.rag_feedback import RAGFeedback
+from app.models.rag_query import RagQuery
 from app.models.user import SubscriptionTier
 from typing import Optional
 
@@ -69,6 +70,13 @@ def query_knowledge_base(
             source_chunks=sources,
         )
         db.add(feedback)
+        rag_query = RagQuery(
+            user_id=current_user.id,
+            question=request.question,
+            answer_summary=str(result.get("result", ""))[:200],
+            source_count=len(sources),
+        )
+        db.add(rag_query)
         db.commit()
         db.refresh(feedback)
         answer_id = feedback.id
@@ -171,3 +179,36 @@ def get_low_quality_chunks(
             low_quality.append({"chunk": chunk, "thumbs_down": c["thumbs_down"], "total": c["total"], "ratio": ratio})
 
     return {"threshold": threshold, "low_quality_chunks": low_quality}
+
+
+@router.get("/history")
+def get_rag_history(
+    page: int = 1,
+    page_size: int = 10,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return paginated list of the current user's past RAG queries."""
+    offset = (page - 1) * page_size
+    queries = (
+        db.query(RagQuery)
+        .filter(RagQuery.user_id == current_user.id)
+        .order_by(RagQuery.created_at.desc())
+        .offset(offset)
+        .limit(page_size)
+        .all()
+    )
+    return {
+        "page": page,
+        "page_size": page_size,
+        "results": [
+            {
+                "id": q.id,
+                "question": q.question,
+                "answer_summary": q.answer_summary,
+                "source_count": q.source_count,
+                "created_at": q.created_at,
+            }
+            for q in queries
+        ],
+    }

--- a/backend/app/models/rag_query.py
+++ b/backend/app/models/rag_query.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, String, Integer, DateTime, Text, ForeignKey
+from datetime import datetime
+import uuid
+from app.core.database import Base
+
+
+class RagQuery(Base):
+    __tablename__ = "rag_queries"
+
+    id = Column(String(64), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String(64), ForeignKey("users.id"), nullable=False)
+    question = Column(Text, nullable=False)
+    answer_summary = Column(String(200), nullable=True)
+    source_count = Column(Integer, default=0)
+    created_at = Column(DateTime, default=datetime.utcnow)


### PR DESCRIPTION
## Summary

Closes #65

Implements persistent storage for RAG queries by introducing a new RagQuery model linked to the authenticated user. Each query made via POST /rag/query is now saved with a truncated answer summary and source count. A new paginated GET /api/v1/rag/history endpoint lets users retrieve their past questions in reverse chronological order.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [ ] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)

<!-- Add before/after screenshots here -->
