### PR TITLE
Add loading skeletons for dashboard and documents #256

### DIFF
--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,17 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-gray-200 dark:bg-gray-700', className)}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,17 +2,20 @@ import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import { aiSystemsApi, documentsApi } from '../services/api'
 import { Bot, FileText, AlertTriangle, CheckCircle, Clock } from 'lucide-react'
+import { Skeleton } from '../components/Skeleton'
 
 export default function Dashboard() {
-  const { data: systems = [] } = useQuery({
+  const { data: systems = [], isLoading: isLoadingSystems } = useQuery({
     queryKey: ['ai-systems'],
     queryFn: () => aiSystemsApi.list(),
   })
 
-  const { data: documents = [] } = useQuery({
+  const { data: documents = [], isLoading: isLoadingDocs } = useQuery({
     queryKey: ['documents'],
     queryFn: documentsApi.list,
   })
+
+  const isLoading = isLoadingSystems || isLoadingDocs
 
   const stats = [
     {
@@ -61,7 +64,11 @@ export default function Dashboard() {
               </div>
               <div>
                 <p className="text-sm text-gray-600">{stat.name}</p>
-                <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
+                {isLoading ? (
+                  <Skeleton className="h-8 w-12 mt-1" />
+                ) : (
+                  <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
+                )}
               </div>
             </div>
           </div>
@@ -99,7 +106,22 @@ export default function Dashboard() {
       {/* Recent AI Systems */}
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <h2 className="text-lg font-semibold text-gray-900 mb-4">Your AI Systems</h2>
-        {systems.length === 0 ? (
+        {isLoading ? (
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex items-center justify-between p-4 rounded-lg border border-gray-200">
+                <div className="space-y-2 flex-1">
+                  <Skeleton className="h-5 w-1/3" />
+                  <div className="flex gap-2">
+                    <Skeleton className="h-4 w-16" />
+                    <Skeleton className="h-4 w-24" />
+                  </div>
+                </div>
+                <Skeleton className="h-4 w-12 ml-4" />
+              </div>
+            ))}
+          </div>
+        ) : systems.length === 0 ? (
           <div className="text-center py-8 text-gray-500">
             <Bot className="w-12 h-12 mx-auto mb-3 text-gray-300" />
             <p>No AI systems registered yet</p>
@@ -122,8 +144,16 @@ export default function Dashboard() {
                 key={system.id}
                 className="flex items-center justify-between p-4 rounded-lg border border-gray-200"
               >
-                <div>
-                  <p className="font-medium text-gray-900">{system.name}</p>
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-lg bg-gray-50 flex items-center justify-center overflow-hidden flex-shrink-0 border border-gray-100">
+                    {(system as any).image_url ? (
+                      <img src={(system as any).image_url} alt={system.name} className="w-full h-full object-cover" />
+                    ) : (
+                      <Bot className="w-5 h-5 text-gray-400" />
+                    )}
+                  </div>
+                  <div>
+                    <p className="font-medium text-gray-900">{system.name}</p>
                   <div className="flex items-center gap-2 mt-1">
                     {system.risk_level && (
                       <span

--- a/frontend/src/pages/Documents.tsx
+++ b/frontend/src/pages/Documents.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { aiSystemsApi, documentsApi } from '../services/api'
 import { FileText, Download, Trash2, Plus, Edit } from 'lucide-react'
 import DocumentEditor from '../components/DocumentEditor'
+import { Skeleton } from '../components/Skeleton'
 
 interface Document {
   id: number
@@ -127,7 +128,30 @@ export default function Documents() {
       )}
 
       {isLoading ? (
-        <div className="text-center py-12 text-gray-500">Loading...</div>
+        <div className="grid gap-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-white rounded-xl border border-gray-200 p-6">
+              <div className="flex items-start justify-between">
+                <div className="flex items-start gap-4 flex-1">
+                  <Skeleton className="w-12 h-12 rounded-lg" />
+                  <div className="space-y-2 flex-1">
+                    <Skeleton className="h-5 w-1/4" />
+                    <div className="flex gap-2">
+                      <Skeleton className="h-4 w-20" />
+                      <Skeleton className="h-4 w-16" />
+                      <Skeleton className="h-4 w-24" />
+                    </div>
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <Skeleton className="h-9 w-9 rounded-lg" />
+                  <Skeleton className="h-9 w-9 rounded-lg" />
+                  <Skeleton className="h-9 w-9 rounded-lg" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
       ) : documents.length === 0 ? (
         <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
           <FileText className="w-16 h-16 mx-auto mb-4 text-gray-300" />


### PR DESCRIPTION
This PR adds loading skeletons to the Dashboard and Documents pages to improve perceived performance during data fetching. Fixes #256.