### PR TITLE
feat: add backend status indicator to Dashboard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,8 +27,8 @@
         "zustand": "^4.5.0"
       },
       "devDependencies": {
-        "@types/react": "^18.2.48",
-        "@types/react-dom": "^18.2.18",
+        "@types/react": "^18.3.28",
+        "@types/react-dom": "^18.3.7",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "@typescript-eslint/parser": "^6.20.0",
         "@vitejs/plugin-react": "^4.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,8 +29,8 @@
     "zustand": "^4.5.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.48",
-    "@types/react-dom": "^18.2.18",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "@vitejs/plugin-react": "^4.2.1",

--- a/frontend/src/components/BackendStatus.tsx
+++ b/frontend/src/components/BackendStatus.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { checkHealth } from "../services/api";
+
+export default function BackendStatus() {
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ["backend-health"],
+    queryFn: checkHealth,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+    retry: 1,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-gray-400">
+        <span className="h-2.5 w-2.5 rounded-full bg-gray-400 animate-pulse" />
+        Checking backend…
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-red-500">
+        <span className="h-2.5 w-2.5 rounded-full bg-red-500" />
+        Backend Unreachable
+      </div>
+    );
+  }
+
+  const isHealthy = data?.status === "healthy";
+  const dbOk = data?.database === "connected";
+
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      <div className="flex items-center gap-1.5">
+        <span
+          className={`h-2.5 w-2.5 rounded-full ${
+            isHealthy ? "bg-green-500" : "bg-yellow-400"
+          }`}
+        />
+        <span className={isHealthy ? "text-green-600" : "text-yellow-500"}>
+          {isHealthy ? "Backend Healthy" : "Backend Degraded"}
+        </span>
+      </div>
+
+      {!dbOk && (
+        <div className="flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full bg-red-500" />
+          <span className="text-red-500 text-xs">DB Disconnected</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import { aiSystemsApi, documentsApi } from '../services/api'
 import { Bot, FileText, AlertTriangle, CheckCircle, Clock } from 'lucide-react'
+import BackendStatus from '../components/BackendStatus'
 
 export default function Dashboard() {
   const { data: systems = [] } = useQuery({
@@ -43,9 +44,12 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-        <p className="text-gray-600">Overview of your EU AI Act compliance status</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+          <p className="text-gray-600">Overview of your EU AI Act compliance status</p>
+        </div>
+        <BackendStatus />
       </div>
 
       {/* Stats */}
@@ -158,3 +162,5 @@ export default function Dashboard() {
     </div>
   )
 }
+
+

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -125,4 +125,18 @@ export const notificationsApi = {
     api.post('/notifications/read', { ids }),
 }
 
+
+// Health API — uses root URL, not /api/v1
+export interface HealthResponse {
+  status: "healthy" | "degraded";
+  database: "connected" | "disconnected";
+  version: string;
+  service: string;
+}
+
+export const checkHealth = async (): Promise<HealthResponse> => {
+  const response = await axios.get<HealthResponse>("/health"); // plain axios, not `api`
+  return response.data;
+};
+
 export default api


### PR DESCRIPTION
Closes #8

## What this does
- Pings `GET /health` on Dashboard load using React Query
- Shows green dot + "Backend Healthy" when status is healthy
- Shows yellow dot + "Backend Degraded" + red DB indicator when DB is disconnected
- Shows red dot + "Backend Unreachable" on network error
- Auto-refreshes every 60s, cached for 30s

## Files changed
- `frontend/src/services/api.ts` — added `HealthResponse` type + `checkHealth()`
- `frontend/src/components/BackendStatus.tsx` — new component
- `frontend/src/pages/Dashboard.tsx` — renders `<BackendStatus />` in header