### PR TITLE
chore: replace default Vite favicon with AegisAI shield logo

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/aegis-favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EU AI Act Compliance Tool</title>
   </head>

--- a/frontend/public/aegis-favicon.svg
+++ b/frontend/public/aegis-favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10"/>
+</svg>


### PR DESCRIPTION
## Summary

Closes #327

This PR replaces the default Vite favicon with a shield SVG matching the AegisAI branding. I created the `aegis-favicon.svg` asset in the `frontend/public` directory and updated the `<link>` tag in `index.html` to point to it.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)
<img width="1710" height="1112" alt="Screenshot 2026-05-16 at 12 18 13 PM" src="https://github.com/user-attachments/assets/9c0ed627-d051-4443-8a1d-a6bd303556c6" />
