### PR TITLE
fix(frontend): use axios instance in DocumentEditor to attach auth token

### DIFF
--- a/frontend/src/components/DocumentEditor.tsx
+++ b/frontend/src/components/DocumentEditor.tsx
@@ -3,6 +3,7 @@ import { Save, Eye, EyeOff } from 'lucide-react'
 import CodeMirror from '@uiw/react-codemirror'
 import { markdown } from '@codemirror/lang-markdown'
 import { marked } from 'marked'
+import api from '../services/api'
 
 interface DocumentEditorProps {
   documentId: number
@@ -24,20 +25,9 @@ export default function DocumentEditor({
 
   const handleSave = useCallback(async () => {
     setIsSaving(true)
-    // Call PUT endpoint
     try {
-      const response = await fetch(`/api/v1/documents/${documentId}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          // Add auth header if needed - check how other API calls are done in your app
-        },
-        body: JSON.stringify({ content })
-      })
-
-      if (response.ok) {
-        onSave?.(content)
-      }
+      await api.put(`/documents/${documentId}`, { content })
+      onSave?.(content)
     } catch (error) {
       console.error('Save failed:', error)
     }


### PR DESCRIPTION
## Summary

`DocumentEditor.tsx` used a raw `fetch()` call with no `Authorization` header, so every document save returned `401 Unauthorized`. This replaces the `fetch` with the existing `api` axios instance from `services/api.ts`, which attaches the `Bearer` token automatically via its request interceptor.

## Root Cause

`fetch()` has no knowledge of the app's auth state. The `api` axios instance already has a request interceptor that reads the token from Zustand store and sets `Authorization: Bearer <token>` on every request.

## Changes

- `frontend/src/components/DocumentEditor.tsx` — replace `fetch` with `api.put`; import `api` from `../services/api`

## Test Plan

- [ ] Login, open a generated document, edit content, click Save
- [ ] Check network tab — `PUT /api/v1/documents/{id}` should return `200`, not `401`

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)