### PR TITLE
fix(frontend): show error message in toolbar when document save fails

### DIFF
--- a/frontend/src/components/DocumentEditor.tsx
+++ b/frontend/src/components/DocumentEditor.tsx
@@ -20,10 +20,12 @@ export default function DocumentEditor({
   const [content, setContent] = useState(initialContent)
   const [showPreview, setShowPreview] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const [saveTimeout, setSaveTimeout] = useState<ReturnType<typeof setTimeout> | null>(null)
 
   const handleSave = useCallback(async () => {
     setIsSaving(true)
+    setSaveError(null)
     // Call PUT endpoint
     try {
       const response = await fetch(`/api/v1/documents/${documentId}`, {
@@ -37,9 +39,12 @@ export default function DocumentEditor({
 
       if (response.ok) {
         onSave?.(content)
+      } else {
+        setSaveError('Save failed. Your changes were not persisted.')
       }
     } catch (error) {
       console.error('Save failed:', error)
+      setSaveError('Save failed. Your changes were not persisted.')
     }
     setIsSaving(false)
   }, [content, documentId, onSave])
@@ -76,6 +81,7 @@ export default function DocumentEditor({
           {showPreview ? 'Edit' : 'Preview'}
         </button>
         <div className="flex items-center gap-3">
+          {saveError && <span className="text-sm text-red-600">{saveError}</span>}
           {isSaving && <span className="text-sm text-gray-500">Saving...</span>}
           <button
             type="button"


### PR DESCRIPTION
## Summary

When a document save failed in `DocumentEditor.tsx`, the error was only logged to `console.error`. The saving spinner disappeared with no UI feedback — users had no way to know their changes were lost.

This adds a `saveError` state and displays a red error message in the editor toolbar whenever a save request fails (both manual save and auto-save).

## Reproduction

1. Open a document, make an edit
2. Stop the backend (`docker stop aegisai_backend`)
3. Wait 2 seconds for auto-save, or click Save
4. No error shown — user believes save succeeded (**before** this fix)

## Changes

- `frontend/src/components/DocumentEditor.tsx` — add `saveError` state; set on network failure or non-ok response; render in toolbar

## Test Plan

- [ ] Stop backend, edit document, wait for auto-save — red "Save failed" message appears in toolbar
- [ ] Successful save — no error message shown

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)