### PR TITLE
feat: Add browser extension for sensitive prompt detection

### DIFF
--- a/backend/extension/content.js
+++ b/backend/extension/content.js
@@ -1,0 +1,87 @@
+const secretPatterns = [
+  {
+    name: "OpenAI API Key",
+    regex: /sk-[a-zA-Z0-9]{20,}/g,
+  },
+  {
+    name: "Email Address",
+    regex: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+  },
+  {
+    name: "Phone Number",
+    regex: /\b\d{10}\b/g,
+  },
+  {
+    name: "AWS Access Key",
+    regex: /AKIA[0-9A-Z]{16}/g,
+  },
+  {
+    name: "JWT Token",
+    regex: /eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9._-]+\.[a-zA-Z0-9._-]+/g,
+  },
+];
+
+function detectSecrets(text) {
+  const detected = [];
+
+  secretPatterns.forEach((pattern) => {
+    if (pattern.regex.test(text)) {
+      detected.push(pattern.name);
+    }
+  });
+
+  return detected;
+}
+
+function showWarning(detectedItems) {
+  let existingWarning = document.getElementById(
+    "aegisai-secret-warning"
+  );
+
+  if (existingWarning) {
+    existingWarning.remove();
+  }
+
+  const warningBox = document.createElement("div");
+  warningBox.id = "aegisai-secret-warning";
+
+  warningBox.innerHTML = `
+    <strong>⚠ Sensitive Information Detected</strong><br>
+    Detected:
+    <ul>
+      ${detectedItems.map((item) => `<li>${item}</li>`).join("")}
+    </ul>
+    Remove sensitive data before submitting your prompt.
+  `;
+
+  document.body.appendChild(warningBox);
+}
+
+function removeWarning() {
+  const warning = document.getElementById(
+    "aegisai-secret-warning"
+  );
+
+  if (warning) {
+    warning.remove();
+  }
+}
+
+document.addEventListener("input", (event) => {
+  const target = event.target;
+
+  if (
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "INPUT"
+  ) {
+    const text = target.value;
+
+    const detectedSecrets = detectSecrets(text);
+
+    if (detectedSecrets.length > 0) {
+      showWarning(detectedSecrets);
+    } else {
+      removeWarning();
+    }
+  }
+});

--- a/backend/extension/manifest.json
+++ b/backend/extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "AegisAI Prompt Protector",
+  "version": "1.0",
+  "description": "Detects sensitive information in prompts before sending to AI models.",
+  "permissions": ["activeTab"],
+  "host_permissions": ["<all_urls>"],
+
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "css": ["styles.css"]
+    }
+  ],
+
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/backend/extension/popup.html
+++ b/backend/extension/popup.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>AegisAI Prompt Protector</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+
+<body>
+  <div class="popup-container">
+    <h2>AegisAI Prompt Protector</h2>
+
+    <p>
+      This extension scans prompts for:
+    </p>
+
+    <ul>
+      <li>API Keys</li>
+      <li>Email Addresses</li>
+      <li>Phone Numbers</li>
+      <li>JWT Tokens</li>
+      <li>AWS Secrets</li>
+    </ul>
+
+    <div class="status">
+      Protection Active ✅
+    </div>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/backend/extension/popup.js
+++ b/backend/extension/popup.js
@@ -1,0 +1,1 @@
+console.log("AegisAI Prompt Protector Loaded");

--- a/backend/extension/styles.css
+++ b/backend/extension/styles.css
@@ -1,0 +1,51 @@
+#aegisai-secret-warning {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  width: 320px;
+
+  background: #fff3cd;
+  color: #856404;
+
+  border: 2px solid #ffeeba;
+
+  padding: 15px;
+  border-radius: 10px;
+
+  z-index: 999999;
+
+  font-family: Arial, sans-serif;
+
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+#aegisai-secret-warning ul {
+  margin-top: 8px;
+  padding-left: 20px;
+}
+
+.popup-container {
+  width: 280px;
+  padding: 15px;
+  font-family: Arial, sans-serif;
+}
+
+.popup-container h2 {
+  color: #2563eb;
+  margin-bottom: 10px;
+}
+
+.popup-container ul {
+  padding-left: 20px;
+}
+
+.status {
+  margin-top: 15px;
+  padding: 10px;
+
+  background: #d1fae5;
+  color: #065f46;
+
+  border-radius: 8px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary

Closes #201 

This PR adds an MVP browser extension for detecting sensitive information inside prompts before they are submitted to AI platforms.

The extension scans user input in real time and displays a warning banner when potentially sensitive data is detected, such as:

OpenAI API keys
Email addresses
Phone numbers
AWS access keys
JWT tokens

The goal is to help prevent accidental exposure of sensitive information while interacting with LLM platforms.

## Type of Change

- [ ] Bug fix
- [ x ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [ x ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ x ] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [ x ] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)

<!-- Add before/after screenshots here -->
