### PR TITLE
feat: restore static templates as RAG generation fallback

### DIFF
--- a/backend/app/api/v1/documents.py
+++ b/backend/app/api/v1/documents.py
@@ -273,32 +273,37 @@ def generate_document(
     # Get latest risk assessment if available
     from app.models.ai_system import RiskAssessment
 
-    assessment = (
-        db.query(RiskAssessment)
-        .filter(RiskAssessment.ai_system_id == ai_system.id)
-        .order_by(RiskAssessment.assessed_at.desc())
-        .first()
-    )
-
-    # Fill template
-    from datetime import datetime
-
-    content = template.format(
-        system_name=ai_system.name,
-        version=ai_system.version or "1.0",
-        use_case=ai_system.use_case or "Not specified",
-        sector=ai_system.sector or "Not specified",
-        description=ai_system.description or "No description provided",
-        risk_level=(
-            ai_system.risk_level.value if ai_system.risk_level else "Not assessed"
-        ),
-        date=datetime.utcnow().strftime("%Y-%m-%d"),
-        company_name=current_user.company_name or "Not specified",
-        classification_reasons="See risk assessment details",
-        recommendations="Based on risk assessment",
-        requirements="See applicable requirements above",
-        next_steps="Complete all checklist items",
-    )
+    assessment = db.query(RiskAssessment).filter(
+        RiskAssessment.ai_system_id == ai_system.id
+    ).order_by(RiskAssessment.assessed_at.desc()).first()
+    
+    try:
+        content = generate_compliance_narrative(
+            document_type=request.document_type,
+            ai_system=ai_system,
+            risk_assessment=assessment,
+            company_name=current_user.company_name
+        )
+    except Exception as e:
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.warning(f"LLM generation failed, falling back to template: {str(e)}")
+        
+        from datetime import datetime
+        content = template.format(
+            system_name=ai_system.name,
+            version=ai_system.version or "1.0",
+            use_case=ai_system.use_case or "Not specified",
+            sector=ai_system.sector or "Not specified",
+            description=ai_system.description or "No description provided",
+            risk_level=ai_system.risk_level.value if ai_system.risk_level else "Not assessed",
+            date=datetime.utcnow().strftime("%Y-%m-%d"),
+            company_name=current_user.company_name or "Not specified",
+            classification_reasons="See risk assessment details",
+            recommendations="Based on risk assessment",
+            requirements="See applicable requirements above",
+            next_steps="Complete all checklist items"
+        )
 
     # Create document
     document = Document(

--- a/backend/app/modules/llm/document_generator.py
+++ b/backend/app/modules/llm/document_generator.py
@@ -1,0 +1,58 @@
+from app.modules.llm.llm_client import LLMClient
+from app.modules.rag.vector_store import load_vector_store
+
+def generate_compliance_narrative(document_type, ai_system, risk_assessment, company_name):
+    """
+    Generates a professional compliance narrative using LLM + RAG.
+    """
+    # 1. Build the search query based on system context
+    query = f"EU AI Act requirements for {document_type.value} regarding an AI system used for {ai_system.use_case} in the {ai_system.sector} sector."
+    
+    # 2. Retrieve context using RAG
+    try:
+        vector_store = load_vector_store()
+        docs = vector_store.similarity_search(query, k=5)
+        rag_context = "\n\n".join([doc.page_content for doc in docs])
+    except FileNotFoundError:
+        # Fallback if the vector store hasn't been initialized yet
+        rag_context = "No specific regulation context available in the vector store."
+    
+    # 3. Build the prompt
+    system_prompt = (
+        "You are an expert legal compliance officer specializing in the EU AI Act. "
+        "Write a formal, comprehensive, and professional narrative compliance document. "
+        "Do NOT output a simple filled-in template or form. The output should read like "
+        "a professional legal assessment grounded in the actual regulation text."
+    )
+    
+    risk_assessment_details = "None available"
+    if risk_assessment:
+        risk_level = risk_assessment.risk_level.value if hasattr(risk_assessment.risk_level, 'value') else str(risk_assessment.risk_level)
+        risk_assessment_details = f"Assessed Risk Level: {risk_level}\nFindings: {risk_assessment.findings}\nRecommendations: {risk_assessment.recommendations}"
+
+    prompt = f"""
+    Please write a {document_type.value} report for the following AI system.
+    
+    === SYSTEM CONTEXT ===
+    - Name: {ai_system.name}
+    - Company: {company_name or "Not Specified"}
+    - Version: {ai_system.version or "1.0"}
+    - Use Case: {ai_system.use_case or "Not Specified"}
+    - Sector: {ai_system.sector or "Not Specified"}
+    - Declared Risk Level: {ai_system.risk_level.value if ai_system.risk_level else "Not assessed"}
+    - Description: {ai_system.description or "No description provided"}
+    
+    === RISK ASSESSMENT DETAILS ===
+    {risk_assessment_details}
+    
+    === RELEVANT EU AI ACT REGULATION (RAG CONTEXT) ===
+    {rag_context}
+    
+    Ensure the document is structured logically with headings, bullet points where appropriate, and a concluding statement.
+    """
+    
+    # 4. Call the LLM
+    client = LLMClient()
+    final_document = client.call(prompt=prompt, system_prompt=system_prompt,max_tokens=2500)
+    
+    return final_document


### PR DESCRIPTION
Closes #81

## Summary

- Re-introduce `DOCUMENT_TEMPLATES` in documents.py for safety
- Wrap `generate_compliance_narrative` in a try/except block
- Fall back to structured formatting if the LLM/RAG process fails
- Resolve regression that broke the /generate endpoint

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)
