### PR TITLE
Dark mode applied to all pages according to theme

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2541,6 +2541,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -13,6 +13,7 @@ import {
   ChevronRight,
   BarChart,
 } from 'lucide-react'
+
 import NotificationBell from './NotificationBell'
 import ThemeToggle from './ThemeToggle'
 
@@ -35,10 +36,10 @@ export default function Layout() {
   const [isCollapsed, setIsCollapsed] = useState(false)
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-800 ">
       {/* Sidebar */}
       <div
-        className={`fixed inset-y-0 left-0 bg-white border-r border-gray-200 transition-[width] duration-200 z-40 ${
+        className={`fixed inset-y-0 left-0 bg-white dark:bg-gray-800 dark:text-gray-100 border-r border-gray-200 dark:border-gray-700 transition-[width] duration-200 z-40 ${
           isCollapsed ? 'w-20' : 'w-64'
         }`}
       >
@@ -47,7 +48,7 @@ export default function Layout() {
           <div className="flex items-center gap-2">
             <Shield className="w-8 h-8 text-primary-600" />
             <span
-              className={`text-lg font-semibold text-gray-900 ${
+              className={`text-lg font-semibold text-gray-900 dark:text-gray-50 ${
                 isCollapsed ? 'sr-only' : ''
               }`}
             >
@@ -57,7 +58,7 @@ export default function Layout() {
           <button
             type="button"
             onClick={() => setIsCollapsed((prev) => !prev)}
-            className="p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
+            className="p-2 text-gray-500 dark:text-gray-50 hover:text-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
             aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
             title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
@@ -81,7 +82,7 @@ export default function Layout() {
                 className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
                   isActive
                     ? 'bg-primary-50 text-primary-700'
-                    : 'text-gray-600 hover:bg-gray-100'
+                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700'
                 } ${isCollapsed ? 'justify-center' : ''}`}
               >
                 <item.icon className="w-5 h-5" />
@@ -94,7 +95,7 @@ export default function Layout() {
         </nav>
 
         {/* User section */}
-        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200">
+        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 dark:border-gray-700">
           <div
             className={`flex items-center ${
               isCollapsed ? 'justify-center' : 'justify-between'
@@ -129,7 +130,7 @@ export default function Layout() {
         }`}
       >
 
-        <header className="sticky top-0 z-30 flex items-center justify-end gap-1 px-8 py-3 bg-white/80 backdrop-blur-md border-b border-gray-200/60">
+        <header className="sticky top-0 z-30 flex items-center justify-end gap-1 px-8 py-3 bg-white/80 dark:bg-gray-800 backdrop-blur-md border-b border-gray-200/60">
           <NotificationBell />
           <ThemeToggle />
         </header>

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -102,7 +102,7 @@ export default function NotificationBell() {
       <button
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
-        className="relative p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+        className="relative p-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 rounded-lg hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
         aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
         aria-expanded={isOpen}
         aria-haspopup="true"
@@ -123,7 +123,7 @@ export default function NotificationBell() {
 
       {/* Dropdown panel */}
       <div
-        className={`absolute right-0 mt-2 w-80 sm:w-96 bg-white rounded-xl border border-gray-200 shadow-xl z-50 transition-all duration-200 ease-out origin-top-right ${
+        className={`absolute right-0 mt-2 w-80 sm:w-96 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700  dark:shadow-lg z-50 transition-all duration-200 ease-out origin-top-right ${
           isOpen
             ? 'opacity-100 translate-y-0 pointer-events-auto'
             : 'opacity-0 -translate-y-2 pointer-events-none'
@@ -132,9 +132,9 @@ export default function NotificationBell() {
         aria-label="Notifications panel"
       >
 
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-700">
           <div className="flex items-center gap-2">
-            <h3 className="text-sm font-semibold text-gray-900">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
               Notifications
             </h3>
             {unreadCount > 0 && (
@@ -146,7 +146,7 @@ export default function NotificationBell() {
           <button
             type="button"
             onClick={() => setIsOpen(false)}
-            className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors"
+            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
             aria-label="Close notifications"
           >
             <X className="w-4 h-4" />
@@ -166,7 +166,7 @@ export default function NotificationBell() {
                 key={notification.id}
                 type="button"
                 onClick={() => handleNotificationClick(notification.id)}
-                className={`w-full flex items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus:bg-gray-50 ${
+                className={`w-full flex items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus:bg-gray-50 dark:hover:bg-gray-600 ${
                   !notification.is_read ? 'bg-primary-50/40' : ''
                 }`}
                 role="menuitem"
@@ -213,7 +213,7 @@ export default function NotificationBell() {
           <Link
             to="/notifications"
             onClick={() => setIsOpen(false)}
-            className="block px-4 py-3 text-center text-sm font-medium text-primary-600 hover:text-primary-700 hover:bg-gray-50 transition-colors rounded-b-xl"
+            className="block px-4 py-3 text-center text-sm font-medium text-primary-600 hover:text-primary-700 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors rounded-b-xl"
           >
             View all notifications
           </Link>

--- a/frontend/src/pages/AISystems.tsx
+++ b/frontend/src/pages/AISystems.tsx
@@ -124,7 +124,7 @@ export default function AISystems() {
     <div className="space-y-8">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">AI Systems</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">AI Systems</h1>
           <p className="text-gray-600">Manage your AI systems for compliance tracking</p>
         </div>
         <button
@@ -137,7 +137,7 @@ export default function AISystems() {
       </div>
 
       {/* Search and Filters */}
-      <div className="flex flex-col md:flex-row gap-4 bg-white p-4 rounded-xl border border-gray-200 shadow-sm">
+      <div className="flex flex-col md:flex-row gap-4 bg-white dark:bg-gray-800 p-4 rounded-xl border border-gray-200 dark:border-gray-600 shadow-sm">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
           <input
@@ -145,7 +145,7 @@ export default function AISystems() {
             placeholder="Search AI systems..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none transition-all"
+            className="w-full pl-10 pr-4 py-2 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none transition-all bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
           />
         </div>
         <div className="flex flex-wrap gap-3">
@@ -154,7 +154,7 @@ export default function AISystems() {
             <select
               value={riskFilter}
               onChange={(e) => setRiskFilter(e.target.value)}
-              className="pl-9 pr-4 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
+              className="pl-9 pr-4 py-2 bg-white dark:bg-gray-800 dark:text-gray-400 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
             >
               <option value="">All Risk Levels</option>
               <option value="unacceptable">Unacceptable Risk</option>
@@ -168,7 +168,7 @@ export default function AISystems() {
             <select
               value={complianceFilter}
               onChange={(e) => setComplianceFilter(e.target.value)}
-              className="pl-9 pr-4 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
+              className="pl-9 pr-4 py-2 bg-white dark:bg-gray-800 dark:text-gray-400 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
             >
               <option value="">All Statuses</option>
               <option value="not_started">Not Started</option>
@@ -184,7 +184,7 @@ export default function AISystems() {
               id="sort-by-select"
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value)}
-              className="pl-9 pr-4 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
+              className="pl-9 pr-4 py-2 bg-white dark:bg-gray-800 dark:text-gray-400 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
             >
               <option value="created_at">Sort by Date</option>
               <option value="name">Sort by Name</option>
@@ -197,8 +197,9 @@ export default function AISystems() {
               id="sort-order-select"
               value={order}
               onChange={(e) => setOrder(e.target.value)}
-              className="px-3 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
-            >
+              className="px-3 py-2 bg-white dark:bg-gray-800 dark:text-gray-400 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
+            >`12345 90-= 90-\53
+            `
               <option value="desc">Descending</option>
               <option value="asc">Ascending</option>
             </select>
@@ -210,7 +211,7 @@ export default function AISystems() {
                 setRiskFilter('')
                 setComplianceFilter('')
               }}
-              className="flex items-center gap-1 px-3 py-2 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all text-sm font-medium"
+              className="flex items-center gap-1 px-3 py-2 text-gray-500 dark:text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900 rounded-lg transition-all text-sm font-medium"
             >
               <X className="w-4 h-4" />
               Clear
@@ -220,16 +221,16 @@ export default function AISystems() {
       </div>
 
       {isLoading ? (
-        <div className="text-center py-12 text-gray-500">Loading...</div>
+        <div className="text-center py-12 text-gray-500 dark:text-gray-400">Loading...</div>
       ) : filteredSystems.length === 0 ? (
-        <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
+        <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600">
           <Bot className="w-16 h-16 mx-auto mb-4 text-gray-300" />
-          <h3 className="text-lg font-medium text-gray-900">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white">
             {searchTerm || riskFilter || complianceFilter 
               ? 'No matching AI systems' 
               : 'No AI systems yet'}
           </h3>
-          <p className="text-gray-500 mt-1">
+          <p className="text-gray-500 dark:text-gray-400 mt-1">
             {searchTerm || riskFilter || complianceFilter 
               ? 'Try adjusting your filters or search term'
               : 'Add your first AI system to start tracking compliance'}
@@ -248,7 +249,7 @@ export default function AISystems() {
           {filteredSystems.map((system: AISystem) => (
             <div
               key={system.id}
-              className="bg-white rounded-xl border border-gray-200 p-6"
+              className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600 p-6"
             >
               <div className="flex items-start justify-between">
                 <div className="flex items-start gap-4">
@@ -256,9 +257,9 @@ export default function AISystems() {
                     <Bot className="w-6 h-6 text-primary-600" />
                   </div>
                   <div>
-                    <h3 className="font-semibold text-gray-900">{system.name}</h3>
+                    <h3 className="font-semibold text-gray-900 dark:text-white">{system.name}</h3>
                     {system.description && (
-                      <p className="text-gray-600 text-sm mt-1">{system.description}</p>
+                      <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">{system.description}</p>
                     )}
                     <div className="flex items-center gap-3 mt-2">
                       {system.sector && (
@@ -282,12 +283,12 @@ export default function AISystems() {
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <button className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100">
+                  <button className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600">
                     <Edit className="w-5 h-5" />
                   </button>
                   <button
                     onClick={() => setSystemToDelete(system)}
-                    className="p-2 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50"
+                    className="p-2 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50 dark:hover:bg-red-900"
                   >
                     <Trash2 className="w-5 h-5" />
                   </button>
@@ -353,13 +354,13 @@ export default function AISystems() {
       {/* Add Modal */}
       {showModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-xl p-6 w-full max-w-md">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          <div className="bg-white dark:bg-gray-800 dark:text-gray-400 rounded-xl p-6 w-full max-w-md">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
               Add AI System
             </h2>
             <form onSubmit={handleSubmit} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                   System Name *
                 </label>
                 <input
@@ -367,30 +368,30 @@ export default function AISystems() {
                   required
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
+                  className="mt-1 block w-full px-3 py-2 border dark:bg-gray-700 border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
                   placeholder="e.g., CV Screening AI"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                   Description
                 </label>
                 <textarea
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
+                  className="mt-1 block w-full px-3 py-2 border dark:bg-gray-700 border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
                   rows={3}
                   placeholder="Brief description of what your AI system does"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                   Sector
                 </label>
                 <select
                   value={formData.sector}
                   onChange={(e) => setFormData({ ...formData, sector: e.target.value })}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
+                  className="mt-1 block w-full px-3 py-2 border dark:bg-gray-700 border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
                 >
                   <option value="">Select sector...</option>
                   {sectors.map((s) => (
@@ -399,13 +400,13 @@ export default function AISystems() {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 ">
                   Use Case
                 </label>
                 <select
                   value={formData.use_case}
                   onChange={(e) => setFormData({ ...formData, use_case: e.target.value })}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
+                  className="mt-1 block w-full px-3 py-2 border dark:bg-gray-700 border-gray-300 rounded-lg focus:ring-primary-500 focus:border-primary-500"
                 >
                   <option value="">Select use case...</option>
                   {useCases.map((u) => (
@@ -417,7 +418,7 @@ export default function AISystems() {
                 <button
                   type="button"
                   onClick={() => setShowModal(false)}
-                  className="px-4 py-2 text-gray-700 hover:bg-gray-100 rounded-lg"
+                  className="px-4 py-2 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg"
                 >
                   Cancel
                 </button>

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -41,20 +41,20 @@ export default function Analytics() {
     <div className="space-y-8">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Analytics</h1>
-        <p className="text-gray-600">Compliance score trends and risk analysis</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Analytics</h1>
+        <p className="text-gray-600 dark:text-gray-300">Compliance score trends and risk analysis</p>
       </div>
 
       {/* Summary stats row */}
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
         {summaryStats.map((stat) => (
-          <div key={stat.label} className="bg-white rounded-xl border border-gray-200 p-6 flex items-center gap-4 shadow-sm">
+          <div key={stat.label} className="bg-white dark:bg-gray-700 rounded-xl border border-gray-200 dark:border-gray-600 p-6 flex items-center gap-4 shadow-sm">
             <div className={`shrink-0 p-3 rounded-lg ${stat.bg}`}>
               <stat.icon className={`w-6 h-6 ${stat.color}`} />
             </div>
             <div>
-              <p className="text-sm text-gray-500 font-medium">{stat.label}</p>
-              <p className="text-2xl font-bold text-gray-900 mt-1">{stat.value}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-300 font-medium">{stat.label}</p>
+              <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{stat.value}</p>
             </div>
           </div>
         ))}
@@ -63,10 +63,10 @@ export default function Analytics() {
       {/* Charts area */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Line Chart */}
-        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm min-w-0">
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600 p-6 shadow-sm min-w-0">
           <div className="flex items-center gap-2 mb-6">
             <TrendingUp className="w-5 h-5 text-primary-600" />
-            <h2 className="font-semibold text-gray-900">Compliance Score Timeline</h2>
+            <h2 className="font-semibold text-gray-900 dark:text-white">Compliance Score Timeline</h2>
           </div>
           <div className="h-72 w-full">
             <ResponsiveContainer width="100%" height="100%">
@@ -85,10 +85,10 @@ export default function Analytics() {
         </div>
 
         {/* Bar Chart */}
-        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm min-w-0">
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600 p-6 shadow-sm min-w-0">
           <div className="flex items-center gap-2 mb-6">
             <BarChart2 className="w-5 h-5 text-primary-600" />
-            <h2 className="font-semibold text-gray-900">Risk Distribution by System</h2>
+            <h2 className="font-semibold text-gray-900 dark:text-white">Risk Distribution by System</h2>
           </div>
           <div className="h-72 w-full">
             <ResponsiveContainer width="100%" height="100%">

--- a/frontend/src/pages/Classification.tsx
+++ b/frontend/src/pages/Classification.tsx
@@ -1,79 +1,79 @@
-import { useState } from 'react'
-import { useParams } from 'react-router-dom'
-import { useMutation } from '@tanstack/react-query'
-import { classificationApi } from '../services/api'
-import { AlertTriangle, CheckCircle, Info, XCircle } from 'lucide-react'
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { classificationApi } from "../services/api";
+import { AlertTriangle, CheckCircle, Info, XCircle } from "lucide-react";
 import ComplianceChecklist, {
   ChecklistItem,
-} from '../components/ComplianceChecklist'
+} from "../components/ComplianceChecklist";
 
 interface ClassificationResult {
-  risk_level: string
-  confidence: number
-  reasons: string[]
-  requirements: string[]
-  next_steps: string[]
+  risk_level: string;
+  confidence: number;
+  reasons: string[];
+  requirements: string[];
+  next_steps: string[];
 }
 
 const CHECKLIST_ITEMS: Record<string, ChecklistItem[]> = {
   high: [
     {
-      id: 'tech-doc',
-      label: 'Create Technical Documentation',
-      article: 'Article 11',
+      id: "tech-doc",
+      label: "Create Technical Documentation",
+      article: "Article 11",
       required: true,
     },
     {
-      id: 'risk-assessment',
-      label: 'Conduct Risk Assessment',
-      article: 'Article 9',
+      id: "risk-assessment",
+      label: "Conduct Risk Assessment",
+      article: "Article 9",
       required: true,
     },
     {
-      id: 'human-oversight',
-      label: 'Establish Human Oversight',
-      article: 'Article 14',
+      id: "human-oversight",
+      label: "Establish Human Oversight",
+      article: "Article 14",
       required: true,
     },
     {
-      id: 'conformity',
-      label: 'EU Declaration of Conformity',
-      article: 'Article 47',
+      id: "conformity",
+      label: "EU Declaration of Conformity",
+      article: "Article 47",
       required: true,
     },
     {
-      id: 'logging',
-      label: 'Implement automatic logging',
-      article: 'Article 12',
+      id: "logging",
+      label: "Implement automatic logging",
+      article: "Article 12",
       required: true,
     },
   ],
 
   limited: [
     {
-      id: 'transparency',
-      label: 'Disclose AI interaction to users',
-      article: 'Article 52',
+      id: "transparency",
+      label: "Disclose AI interaction to users",
+      article: "Article 52",
       required: true,
     },
   ],
 
   minimal: [
     {
-      id: 'best-practice',
-      label: 'Follow voluntary AI best practices',
+      id: "best-practice",
+      label: "Follow voluntary AI best practices",
       required: false,
     },
   ],
 
   unacceptable: [],
-}
+};
 
 export default function Classification() {
-  const { systemId } = useParams()
-  const [result, setResult] = useState<ClassificationResult | null>(null)
+  const { systemId } = useParams();
+  const [result, setResult] = useState<ClassificationResult | null>(null);
   const [formData, setFormData] = useState({
-    use_case_category: 'hr_recruitment',
+    use_case_category: "hr_recruitment",
     is_safety_component: false,
     affects_fundamental_rights: true,
     uses_biometric_data: false,
@@ -89,74 +89,80 @@ export default function Classification() {
     generates_synthetic_content: false,
     emotion_recognition: false,
     biometric_categorization: false,
-  })
+  });
 
   const classifyMutation = useMutation({
     mutationFn: () => {
       if (systemId) {
-        return classificationApi.classifyAndSave(parseInt(systemId), formData)
+        return classificationApi.classifyAndSave(parseInt(systemId), formData);
       }
-      return classificationApi.classify(formData)
+      return classificationApi.classify(formData);
     },
     onSuccess: (data) => {
-      setResult(data)
+      setResult(data);
     },
-  })
+  });
 
   const getRiskIcon = (level: string) => {
     switch (level) {
-      case 'unacceptable':
-        return <XCircle className="w-8 h-8 text-red-600" />
-      case 'high':
-        return <AlertTriangle className="w-8 h-8 text-orange-600" />
-      case 'limited':
-        return <Info className="w-8 h-8 text-yellow-600" />
+      case "unacceptable":
+        return <XCircle className="w-8 h-8 text-red-600" />;
+      case "high":
+        return <AlertTriangle className="w-8 h-8 text-orange-600" />;
+      case "limited":
+        return <Info className="w-8 h-8 text-yellow-600" />;
       default:
-        return <CheckCircle className="w-8 h-8 text-green-600" />
+        return <CheckCircle className="w-8 h-8 text-green-600" />;
     }
-  }
+  };
 
   const getRiskColor = (level: string) => {
     switch (level) {
-      case 'unacceptable':
-        return 'bg-red-50 border-red-200'
-      case 'high':
-        return 'bg-orange-50 border-orange-200'
-      case 'limited':
-        return 'bg-yellow-50 border-yellow-200'
+      case "unacceptable":
+        return "bg-red-50 border-red-200";
+      case "high":
+        return "bg-orange-50 border-orange-200";
+      case "limited":
+        return "bg-yellow-50 border-yellow-200";
       default:
-        return 'bg-green-50 border-green-200'
+        return "bg-green-50 border-green-200";
     }
-  }
+  };
 
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Risk Classification</h1>
-        <p className="text-gray-600">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          {" "}
+          Risk Classification
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300">
           Determine your AI system's risk level under EU AI Act
         </p>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Questionnaire */}
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
             Classification Questionnaire
           </h2>
 
           <form className="space-y-6">
             {/* Use Case Category */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Primary Use Case
               </label>
               <select
                 value={formData.use_case_category}
                 onChange={(e) =>
-                  setFormData({ ...formData, use_case_category: e.target.value })
+                  setFormData({
+                    ...formData,
+                    use_case_category: e.target.value,
+                  })
                 }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                className="w-full px-3 py-2 border dark:bg-gray-600 border-gray-300 rounded-lg"
               >
                 <option value="hr_recruitment">HR / Recruitment</option>
                 <option value="credit_scoring">Credit Scoring</option>
@@ -169,7 +175,7 @@ export default function Classification() {
 
             {/* High-Risk Indicators */}
             <div>
-              <h3 className="text-sm font-medium text-gray-900 mb-3">
+              <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-3">
                 High-Risk Indicators (Annex III)
               </h3>
               <div className="space-y-3">
@@ -185,7 +191,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>CV Screening / Candidate Ranking</strong>
                     <br />
                     AI filters CVs or ranks candidates for recruitment
@@ -204,7 +210,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Promotion/Termination Decisions</strong>
                     <br />
                     AI influences employment status decisions
@@ -223,7 +229,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Credit Worthiness Assessment</strong>
                     <br />
                     AI evaluates creditworthiness or credit scoring
@@ -242,7 +248,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Affects Fundamental Rights</strong>
                     <br />
                     Impacts employment, education, or essential services
@@ -261,7 +267,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Automated Decision Making</strong>
                     <br />
                     Makes decisions without meaningful human review
@@ -288,7 +294,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Direct Human Interaction</strong>
                     <br />
                     System interacts directly with users (chatbot, assistant)
@@ -307,7 +313,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Emotion Recognition</strong>
                     <br />
                     System detects or analyzes emotions
@@ -326,7 +332,7 @@ export default function Classification() {
                     }
                     className="mt-1"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-gray-600 dark:text-gray-300">
                     <strong>Synthetic Content Generation</strong>
                     <br />
                     Generates deepfakes, AI images, or synthetic media
@@ -341,7 +347,9 @@ export default function Classification() {
               disabled={classifyMutation.isPending}
               className="w-full py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
             >
-              {classifyMutation.isPending ? 'Classifying...' : 'Classify Risk Level'}
+              {classifyMutation.isPending
+                ? "Classifying..."
+                : "Classify Risk Level"}
             </button>
           </form>
         </div>
@@ -485,14 +493,14 @@ export default function Classification() {
               </div>
             </div>
           ) : (
-            <div className="bg-white rounded-2xl border border-gray-100 p-12 text-center shadow-sm">
+            <div className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-100 p-12 text-center shadow-sm">
               <div className="w-20 h-20 bg-gray-50 rounded-3xl flex items-center justify-center mx-auto mb-6">
-                <AlertTriangle className="w-10 h-10 text-gray-300" />
+                <AlertTriangle className="w-10 h-10 text-gray-300  dark:text-gray-300" />
               </div>
-              <h3 className="text-xl font-bold text-gray-900 mb-2">
+              <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
                 Ready for Classification
               </h3>
-              <p className="text-gray-500 max-w-sm mx-auto leading-relaxed">
+              <p className="text-gray-500 dark:text-gray-400 max-w-sm mx-auto leading-relaxed">
                 Complete the questionnaire to generate your AI Act risk profile and compliance roadmap.
               </p>
               <div className="mt-8 flex justify-center gap-2">
@@ -505,5 +513,5 @@ export default function Classification() {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Classification.tsx
+++ b/frontend/src/pages/Classification.tsx
@@ -116,18 +116,18 @@ export default function Classification() {
     }
   };
 
-  const getRiskColor = (level: string) => {
-    switch (level) {
-      case "unacceptable":
-        return "bg-red-50 border-red-200";
-      case "high":
-        return "bg-orange-50 border-orange-200";
-      case "limited":
-        return "bg-yellow-50 border-yellow-200";
-      default:
-        return "bg-green-50 border-green-200";
-    }
-  };
+  // const getRiskColor = (level: string) => {
+  //   switch (level) {
+  //     case "unacceptable":
+  //       return "bg-red-50 border-red-200";
+  //     case "high":
+  //       return "bg-orange-50 border-orange-200";
+  //     case "limited":
+  //       return "bg-yellow-50 border-yellow-200";
+  //     default:
+  //       return "bg-green-50 border-green-200";
+  //   }
+  // };
 
   return (
     <div className="space-y-8">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -48,8 +48,8 @@ export default function Dashboard() {
     <div className="space-y-8">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-          <p className="text-gray-600">Overview of your EU AI Act compliance status</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Dashboard</h1>
+          <p className="text-gray-600 dark:text-gray-300">Overview of your EU AI Act compliance status</p>
         </div>
         <BackendStatus />
       </div>
@@ -59,15 +59,15 @@ export default function Dashboard() {
         {stats.map((stat) => (
           <div
             key={stat.name}
-            className="bg-white rounded-xl shadow-sm border border-gray-200 p-6"
+            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6"
           >
             <div className="flex items-center gap-4">
               <div className={`p-3 rounded-lg ${stat.color}`}>
-                <stat.icon className="w-6 h-6 text-white" />
+                <stat.icon className="w-6 h-6 text-white dark:text-gray-700" />
               </div>
               <div>
-                <p className="text-sm text-gray-600">{stat.name}</p>
-                <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
+                <p className="text-sm text-gray-600 dark:text-gray-300">{stat.name}</p>
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">{stat.value}</p>
               </div>
             </div>
           </div>
@@ -75,26 +75,26 @@ export default function Dashboard() {
       </div>
 
       {/* Quick Actions */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Quick Actions</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Link
             to="/ai-systems"
-            className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
+            className="flex items-center gap-3 p-4 rounded-lg border text-gray-600 border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
           >
             <Bot className="w-5 h-5 text-primary-600" />
             <span className="font-medium">Add AI System</span>
           </Link>
           <Link
             to="/classification"
-            className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
+            className="flex items-center gap-3 p-4 rounded-lg border text-gray-600 border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
           >
             <AlertTriangle className="w-5 h-5 text-primary-600" />
             <span className="font-medium">Risk Classification</span>
           </Link>
           <Link
             to="/documents"
-            className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
+            className="flex items-center gap-3 p-4 rounded-lg border text-gray-600 border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-colors"
           >
             <FileText className="w-5 h-5 text-primary-600" />
             <span className="font-medium">Generate Documents</span>
@@ -103,8 +103,8 @@ export default function Dashboard() {
       </div>
 
       {/* Recent AI Systems */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Your AI Systems</h2>
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Your AI Systems</h2>
         {systems.length === 0 ? (
           <div className="text-center py-8 text-gray-500">
             <Bot className="w-12 h-12 mx-auto mb-3 text-gray-300" />
@@ -126,10 +126,10 @@ export default function Dashboard() {
             }) => (
               <div
                 key={system.id}
-                className="flex items-center justify-between p-4 rounded-lg border border-gray-200"
+                className="flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-gray-700"
               >
                 <div>
-                  <p className="font-medium text-gray-900">{system.name}</p>
+                  <p className="font-medium text-gray-900 dark:text-white">{system.name}</p>
                   <div className="flex items-center gap-2 mt-1">
                     {system.risk_level && (
                       <span

--- a/frontend/src/pages/Documents.tsx
+++ b/frontend/src/pages/Documents.tsx
@@ -107,15 +107,15 @@ export default function Documents() {
     <div className="space-y-8">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Documents</h1>
-          <p className="text-gray-600">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Documents</h1>
+          <p className="text-gray-600 dark:text-gray-400">
             Generate and manage compliance documentation
           </p>
         </div>
         <button
           onClick={() => setShowModal(true)}
           disabled={systems.length === 0}
-          className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
+          className="flex items-center gap-2 px-4 py-2 bg-primary-600 dark:bg-primary-500 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
         >
           <Plus className="w-5 h-5" />
           Generate Document
@@ -131,10 +131,10 @@ export default function Documents() {
       {isLoading ? (
         <div className="text-center py-12 text-gray-500">Loading...</div>
       ) : documents.length === 0 ? (
-        <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
+        <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
           <FileText className="w-16 h-16 mx-auto mb-4 text-gray-300" />
-          <h3 className="text-lg font-medium text-gray-900">No documents yet</h3>
-          <p className="text-gray-500 mt-1">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white">No documents yet</h3>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">
             Generate your first compliance document
           </p>
         </div>
@@ -143,7 +143,7 @@ export default function Documents() {
           {documents.map((doc: Document) => (
             <div
               key={doc.id}
-              className="bg-white rounded-xl border border-gray-200 p-6"
+              className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6"
             >
               <div className="flex items-start justify-between">
                 <div className="flex items-start gap-4">
@@ -151,7 +151,7 @@ export default function Documents() {
                     <FileText className="w-6 h-6 text-primary-600" />
                   </div>
                   <div>
-                    <h3 className="font-semibold text-gray-900">{doc.title}</h3>
+                    <h3 className="font-semibold text-gray-900 dark:text-white">{doc.title}</h3>
                     <div className="flex items-center gap-3 mt-2">
                       <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded">
                         {doc.document_type.replace(/_/g, ' ')}
@@ -250,8 +250,8 @@ export default function Documents() {
       {/* Generate Modal */}
       {showModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-xl p-6 w-full max-w-md">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          <div className="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-md">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
               Generate Document
             </h2>
             <div className="space-y-4">
@@ -312,7 +312,7 @@ export default function Documents() {
       {/* Editor Modal */}
       {editingDoc && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl w-full max-w-6xl h-[90vh]">
+          <div className="bg-white dark:bg-gray-800 rounded-xl w-full max-w-6xl h-[90vh]">
             <DocumentEditor
               documentId={editingDoc.id}
               initialContent={editingDoc.content || ''}

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -64,11 +64,11 @@ export default function Notifications() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Notifications</h1>
-          <p className="text-gray-600">Your recent compliance and system events</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Notifications</h1>
+          <p className="text-gray-600 dark:text-gray-500">Your recent compliance and system events</p>
         </div>
         {/* TODO (help wanted): wire to POST /notifications/read with all unread IDs */}
-        <button className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg border border-gray-200">
+        <button className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg border border-gray-200 dark:border-gray-600">
           <Check className="w-4 h-4" />
           Mark all read
         </button>
@@ -76,7 +76,7 @@ export default function Notifications() {
 
       {/* Notification list */}
       {notifications.length === 0 ? (
-        <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
+        <div className="text-center py-12 bg-white dark:bg-gray-500 rounded-xl border border-gray-200">
           <Bell className="w-16 h-16 mx-auto mb-4 text-gray-300" />
           <h3 className="text-lg font-medium text-gray-900">No notifications</h3>
           <p className="text-gray-500 mt-1">You're all caught up.</p>
@@ -86,7 +86,7 @@ export default function Notifications() {
           {notifications.map((n) => (
             <div
               key={n.id}
-              className={`bg-white rounded-xl border p-4 flex items-start gap-4 ${
+              className={`bg-white dark:bg-gray-600 rounded-xl border p-4 flex items-start gap-4 ${
                 n.is_read ? 'border-gray-200' : 'border-primary-200 bg-primary-50'
               }`}
             >
@@ -97,7 +97,7 @@ export default function Notifications() {
               />
               <div className="flex-1 min-w-0">
                 <p className="font-medium text-gray-900 text-sm">{n.title}</p>
-                <p className="text-gray-600 text-sm mt-0.5">{n.message}</p>
+                <p className="text-gray-600 dark:text-gray-200 text-sm mt-0.5">{n.message}</p>
                 <p className="text-gray-400 text-xs mt-1">
                   {new Date(n.created_at).toLocaleString()}
                 </p>

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -70,36 +70,36 @@ export default function RagChat() {
   }
 
   return (
-    <div className="h-[calc(100vh-2rem)] md:h-[calc(100vh-4rem)] flex flex-col bg-white rounded-xl border border-gray-200 overflow-hidden">
-      <div className="px-4 sm:px-6 py-4 border-b border-gray-200 bg-white">
+    <div className="h-[calc(100vh-2rem)] md:h-[calc(100vh-4rem)] flex flex-col bg-white  rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <div className="px-4 sm:px-6 py-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
         <div className="flex items-center gap-3">
           <div className="p-2 sm:p-3 bg-primary-50 rounded-xl">
             <Bot className="w-5 h-5 sm:w-6 sm:h-6 text-primary-600" />
           </div>
           <div>
-            <h1 className="text-xl sm:text-2xl font-bold text-gray-900">Chatbot</h1>
-            <p className="text-sm sm:text-base text-gray-600">
+            <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">Chatbot</h1>
+            <p className="text-sm sm:text-base text-gray-600 dark:text-gray-400">
               Ask regulatory and compliance questions with source-backed answers
             </p>
           </div>
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto bg-gray-50">
+      <div className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-700">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6 sm:space-y-8">
           {!submittedQuestion && !answer && !isLoading && !error && (
             <div className="min-h-[320px] sm:min-h-[420px] flex flex-col items-center justify-center text-center">
               <div className="p-3 sm:p-4 bg-primary-50 rounded-2xl mb-5">
                 <Sparkles className="w-8 h-8 sm:w-10 sm:h-10 text-primary-600" />
               </div>
-              <h2 className="text-xl sm:text-2xl font-semibold text-gray-900">
+              <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white">
                 How can I help with AI compliance?
               </h2>
-              <p className="text-sm sm:text-base text-gray-500 mt-2 max-w-xl">
+              <p className="text-sm sm:text-base text-gray-500 dark:text-gray-400 mt-2 max-w-xl">
                 Ask about EU AI Act risk classification, compliance documentation,
                 human oversight, or source-backed regulatory guidance.
               </p>
-              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 mt-6 sm:mt-8 w-full">
+              <div className=" grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 mt-6 sm:mt-8 w-full">
                 {[
                   'Does my system qualify as high-risk?',
                   'Which documents are needed for compliance?',
@@ -109,7 +109,7 @@ export default function RagChat() {
                     key={example}
                     type="button"
                     onClick={() => setQuestion(example)}
-                    className="text-left bg-white border border-gray-200 rounded-xl p-4 text-sm text-gray-700 hover:border-primary-200 hover:bg-primary-50 transition-colors"
+                    className="text-left bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-4 text-sm text-gray-700 dark:text-gray-300 hover:border-primary-200 hover:bg-primary-50 transition-colors"
                   >
                     {example}
                   </button>
@@ -133,12 +133,12 @@ export default function RagChat() {
 
               {isLoading && (
                 <div className="flex justify-start">
-                  <div className="w-full max-w-3xl bg-white border border-gray-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 shadow-sm">
+                  <div className="w-full max-w-3xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-800 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 shadow-sm">
                     <div className="flex items-center gap-3 mb-4">
-                      <div className="p-2 bg-primary-50 rounded-lg">
+                      <div className="p-2 bg-primary-50 dark:bg-gray-800 rounded-lg">
                         <Bot className="w-5 h-5 text-primary-600" />
                       </div>
-                      <div className="flex items-center gap-2 text-sm font-medium text-gray-900">
+                      <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
                         <Loader2 className="w-4 h-4 animate-spin text-primary-600" />
                         Searching knowledge base
                       </div>
@@ -173,30 +173,30 @@ export default function RagChat() {
 
               {!isLoading && !error && answer && (
                 <div className="flex justify-start">
-                  <div className="w-full max-w-3xl bg-white border border-gray-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 shadow-sm">
+                  <div className="w-full max-w-3xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-800 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 shadow-sm">
                     <div className="flex items-start gap-3">
-                      <div className="p-2 bg-primary-50 rounded-lg flex-shrink-0">
+                      <div className="p-2 bg-primary-50 dark:bg-gray-800 rounded-lg flex-shrink-0">
                         <Bot className="w-5 h-5 text-primary-600" />
                       </div>
                       <div className="space-y-5 min-w-0">
                         <p className="text-gray-700 leading-7">{answer.answer}</p>
                         <div className="border-t border-gray-100 pt-5">
-                          <h3 className="text-sm font-semibold text-gray-900 mb-3">
+                          <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
                             Source citations
                           </h3>
                           <div className="space-y-3">
                             {answer.sources.map((source) => (
                               <div
                                 key={source.title}
-                                className="bg-gray-50 border border-gray-200 rounded-lg p-4"
+                                className="bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg p-4"
                               >
                                 <div className="flex items-center gap-2 mb-2">
                                   <FileText className="w-4 h-4 text-primary-600" />
-                                  <h4 className="text-sm font-medium text-gray-900">
+                                  <h4 className="text-sm font-medium text-gray-900 dark:text-white">
                                     {source.title}
                                   </h4>
                                 </div>
-                                <p className="text-sm text-gray-600">{source.excerpt}</p>
+                                <p className="text-sm text-gray-600 dark:text-gray-300">{source.excerpt}</p>
                               </div>
                             ))}
                           </div>
@@ -211,10 +211,10 @@ export default function RagChat() {
         </div>
       </div>
 
-      <div className="border-t border-gray-200 bg-white px-4 sm:px-6 py-3 sm:py-4">
+      <div className="border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-700 px-4 sm:px-6 py-3 sm:py-4">
         <form onSubmit={handleAsk} className="max-w-4xl mx-auto">
-          <div className="flex items-end gap-2 sm:gap-3 bg-gray-50 border border-gray-300 rounded-2xl px-3 sm:px-4 py-3 focus-within:ring-2 focus-within:ring-primary-500 focus-within:border-primary-500">
-            <label htmlFor="rag-question" className="sr-only">
+          <div className="flex items-end gap-2 sm:gap-3 bg-gray-50 dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-2xl px-3 sm:px-4 py-3 focus-within:ring-2 focus-within:ring-primary-500 focus-within:border-primary-500">
+            <label htmlFor="rag-question" className="sr-only ">
               Question
             </label>
             <textarea
@@ -224,7 +224,7 @@ export default function RagChat() {
               placeholder="Ask a compliance question..."
               rows={1}
               disabled={isLoading}
-              className="min-w-0 flex-1 resize-none bg-transparent border-0 p-0 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-0 disabled:text-gray-500"
+              className="min-w-0 flex-1 resize-none bg-transparent border-0 p-0 text-sm text-gray-900 dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-0 disabled:text-gray-500"
             />
             <button
               type="submit"
@@ -241,11 +241,11 @@ export default function RagChat() {
             </button>
           </div>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 mt-2">
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               Try typing `error` to preview the error state. 
               {/* TODO: This statement is just for testing. Remove it after integration of API */}
             </p>
-            <p className="text-xs text-gray-400">
+            <p className="text-xs text-gray-400 dark:text-gray-300">
               Use this assistant to explore risk, documentation, and governance obligations.
             </p>
           </div>


### PR DESCRIPTION
## Reopening PR#278 
This PR adds dark mode support to remaining pages that were not fully covered previously
<img width="1536" height="863" alt="Screenshot 2026-05-16 142608" src="https://github.com/user-attachments/assets/722548b7-b1df-47d8-a6fd-9b705c18dd02" />
.

### Changes:

* Added Tailwind `dark:` variants to UI components
* Covered pages: Analytics, RagChat, AISystems, Classification, Dashboard, Documents, Notifications
* Ensured consistency with existing dark mode implementation

### Notes:

* No changes to logic or layout
* No modifications to theme toggle or global styles
* Rebased on latest `main` to resolve previous conflicts