### PR TITLE
Remove deprecated version key from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:15


### PR DESCRIPTION
## Summary

Removed the deprecated `version: '3.8'` key from `docker-compose.yml`.

Docker Compose v2 automatically detects the compose file format, so the `version` field is no longer required and causes the warning:

```bash
WARN[0000] docker-compose.yml: version is obsolete
```

This change cleans up terminal and CI/CD output without affecting functionality.

## Type of Change

*  Bug fix

## Related Issue

Closes #263
