### PR TITLE
Add skip and limit pagination to list endpoints

### DIFF
--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -50,22 +50,38 @@ _SORTABLE_FIELDS = {
     "created_at": AISystem.created_at,
 }
 
-
 @router.get("/", response_model=PaginatedResponse[AISystemResponse])
 def list_ai_systems(
-    sort_by: Optional[str] = Query("created_at", description="Sort field: name, risk_level, compliance_score, created_at"),
-    order: Optional[str] = Query("desc", description="Sort direction: asc, desc"),
-    page: int = Query(1, ge=1, description="Page number (1-indexed)"),
-    limit: int = Query(50, ge=1, le=100, description="Items per page"),
+    sort_by: Optional[str] = Query(
+        "created_at",
+        description="Sort field: name, risk_level, compliance_score, created_at"
+    ),
+    order: Optional[str] = Query(
+        "desc",
+        description="Sort direction: asc, desc"
+    ),
+    skip: int = Query(
+        0,
+        ge=0,
+        description="Number of records to skip"
+    ),
+    limit: int = Query(
+        20,
+        ge=1,
+        le=100,
+        description="Maximum records to return"
+    ),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """List all AI systems for the current user, with optional sorting and pagination."""
+    """List all AI systems for the current user with optional sorting and pagination."""
+
     if sort_by not in _SORTABLE_FIELDS:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid sort_by '{sort_by}'. Allowed: {', '.join(sorted(_SORTABLE_FIELDS))}",
         )
+
     if order not in ("asc", "desc"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -75,18 +91,26 @@ def list_ai_systems(
     column = _SORTABLE_FIELDS[sort_by]
     direction = asc(column) if order == "asc" else desc(column)
 
-    base_query = db.query(AISystem).filter(AISystem.owner_id == current_user.id)
+    base_query = db.query(AISystem).filter(
+        AISystem.owner_id == current_user.id
+    )
+
     total = base_query.count()
-    offset = (page - 1) * limit
 
     systems = (
         base_query
         .order_by(direction)
-        .offset(offset)
+        .offset(skip)
         .limit(limit)
         .all()
     )
-    return PaginatedResponse(items=systems, total=total, page=page, limit=limit)
+
+    return PaginatedResponse(
+        items=systems,
+        total=total,
+        page=(skip // limit) + 1,
+        limit=limit
+    )
 
 
 @router.post("/import", response_model=BulkImportResponse)

--- a/backend/app/api/v1/documents.py
+++ b/backend/app/api/v1/documents.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Query
-from fastapi.responses import FileResponse, StreamingResponse
+from sqlalchemy import asc, desc
 from sqlalchemy.orm import Session
 from typing import List
 from io import BytesIO
@@ -181,18 +181,25 @@ def create_document(
 
 @router.get("/", response_model=PaginatedResponse[DocumentResponse])
 def list_documents(
-    page: int = Query(1, ge=1, description="Page number (1-indexed)"),
-    limit: int = Query(50, ge=1, le=100, description="Items per page"),
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(20, ge=1, le=100, description="Maximum records to return"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
     """List all documents for the current user with pagination."""
+    
     base_query = db.query(Document).filter(Document.owner_id == current_user.id)
-    total = base_query.count()
-    offset = (page - 1) * limit
 
-    documents = base_query.offset(offset).limit(limit).all()
-    return PaginatedResponse(items=documents, total=total, page=page, limit=limit)
+    total = base_query.count()
+
+    documents = base_query.offset(skip).limit(limit).all()
+
+    return PaginatedResponse(
+        items=documents,
+        total=total,
+        page=(skip // limit) + 1,
+        limit=limit
+    )
 
 
 @router.get("/{document_id}", response_model=DocumentResponse)


### PR DESCRIPTION
## Summary

Closes #4

Added pagination support to the list endpoints by implementing `skip` and `limit` query parameters.

Updated endpoints:

* GET /api/v1/ai-systems
* GET /api/v1/documents

Implemented pagination using SQLAlchemy `offset()` and `limit()` methods and verified the changes successfully in Swagger UI.
