### PR TITLE
chore: add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.bat text eol=crlf


### PR DESCRIPTION
## Summary

Closes #2

Added a `.gitattributes` file to normalize line endings across platforms. 
This prevents CRLF/LF warnings on Windows and ensures consistent diffs 
for all contributors.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [x] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed