### PR TITLE
fix: correct YAML indentation in guard-scan workflow

### DIFF
--- a/.github/workflows/guard-scan.yml
+++ b/.github/workflows/guard-scan.yml
@@ -52,25 +52,27 @@ jobs:
         if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ -f guard-scan-report.json ]; then
-            COMMENT_BODY=$(python - <<'PY'
-import json
+               run: |
+           if [ -f guard-scan-report.json ]; then
+                COMMENT_BODY=$(python - <<'PY'
+                import json
 
-with open('guard-scan-report.json', 'r', encoding='utf-8') as report_file:
-    report = json.load(report_file)
+                with open('guard-scan-report.json', 'r', encoding='utf-8') as report_file:
+                    report = json.load(report_file)
 
-blocked = report.get('blocked', [])
-if not blocked:
-    print('Guard scan failed, but no blocked prompt details were captured.')
-else:
-    lines = ['Guard Scan blocked the following prompt files:']
-    for item in blocked:
-        lines.append(f"- `{item['file']}`: {item['patterns']}")
-    print('\n'.join(lines))
-PY
-            )
-            gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"
-          else
-            gh pr comment ${{ github.event.pull_request.number }} --body "Guard scan failed before a report could be written."
-          fi
+                blocked = report.get('blocked', [])
+
+                if not blocked:
+                    print('Guard scan failed, but no blocked prompt details were captured.')
+                else:
+                    lines = ['Guard Scan blocked the following prompt files:']
+                    for item in blocked:
+                        lines.append(f"- `{item['file']}`: {item['patterns']}`")
+                    print('\n'.join(lines))
+                PY
+                )
+
+                gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"
+              else
+                gh pr comment ${{ github.event.pull_request.number }} --body "Guard scan failed before a report could be written."
+              fi


### PR DESCRIPTION
## Summary

Fixed YAML indentation issue in `guard-scan.yml`.

Closes #403

## Type of Change

- [x] Bug fix