### PR TITLE
fix: resolve YAML syntax error in guard-scan workflow

### DIFF
--- a/.github/workflows/guard-scan.yml
+++ b/.github/workflows/guard-scan.yml
@@ -1,8 +1,8 @@
-# Guard Scan — scan prompt files in the repo against the AegisAI Guard API on every PR.
+# Guard Scan - scan prompt files in the repo against the AegisAI Guard API on every PR.
 # Copyright (C) 2024 Sarthak Doshi (github.com/SdSarthak)
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# TODO (high priority — implement):
+# TODO (high priority - implement):
 #   - This workflow is a scaffold. Implement the `scan` step to:
 #       1. Find all files matching `.prompts/**/*.txt` in the repo.
 #       2. POST each file's content to $AEGISAI_GUARD_URL/api/v1/guard/scan
@@ -54,22 +54,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           if [ -f guard-scan-report.json ]; then
-            COMMENT_BODY=$(python - <<'PY'
-import json
-
-with open('guard-scan-report.json', 'r', encoding='utf-8') as report_file:
-    report = json.load(report_file)
-
-blocked = report.get('blocked', [])
-if not blocked:
-    print('Guard scan failed, but no blocked prompt details were captured.')
-else:
-    lines = ['Guard Scan blocked the following prompt files:']
-    for item in blocked:
-        lines.append(f"- `{item['file']}`: {item['patterns']}")
-    print('\n'.join(lines))
-PY
-            )
+            COMMENT_BODY=$(python3 scripts/print_scan_comment.py)
             gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"
           else
             gh pr comment ${{ github.event.pull_request.number }} --body "Guard scan failed before a report could be written."

--- a/scripts/print_scan_comment.py
+++ b/scripts/print_scan_comment.py
@@ -1,0 +1,13 @@
+import json
+
+with open('guard-scan-report.json', 'r', encoding='utf-8') as f:
+    report = json.load(f)
+
+blocked = report.get('blocked', [])
+if not blocked:
+    print('Guard scan failed, but no blocked prompt details were captured.')
+else:
+    lines = ['Guard Scan blocked the following prompt files:']
+    for item in blocked:
+        lines.append(f"- `{item['file']}`: {item['patterns']}")
+    print('\n'.join(lines))


### PR DESCRIPTION
## Summary

Closes #403 

Fixed YAML syntax error on line 58 in `guard-scan.yml`.

## Changes
- Moved inline Python heredoc to a separate script `scripts/print_scan_comment.py`
- Replaced heredoc with `python3 scripts/print_scan_comment.py` in the workflow

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style (PEP 8 for Python)
- [x] I have not committed `.env` or any secrets

cc @SdSarthak fixes the YAML syntax error reported in the issue. Note: `AEGISAI_GUARD_URL` and `AEGISAI_API_TOKEN` secrets need to be set in repo settings for the workflow to run successfully.