### PR TITLE
feat(frontend): display relative updated time on AI system cards

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@uiw/react-codemirror": "^4.25.9",
         "axios": "^1.6.7",
         "clsx": "^2.1.0",
+        "date-fns": "^4.1.0",
         "lucide-react": "^0.314.0",
         "marked": "^18.0.3",
         "react": "^18.2.0",
@@ -2660,6 +2661,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@uiw/react-codemirror": "^4.25.9",
     "axios": "^1.6.7",
     "clsx": "^2.1.0",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.314.0",
     "marked": "^18.0.3",
     "react": "^18.2.0",

--- a/frontend/src/pages/AISystems.tsx
+++ b/frontend/src/pages/AISystems.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { aiSystemsApi } from '../services/api'
 import { Bot, Plus, Trash2, Edit, Search, Filter, ArrowUpDown, X } from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
 
 interface AISystem {
   id: number
@@ -12,6 +13,7 @@ interface AISystem {
   risk_level: string | null
   compliance_status: string
   compliance_score: number
+  updated_at: string
 }
 
 export default function AISystems() {
@@ -257,6 +259,15 @@ export default function AISystems() {
                     {system.description && (
                       <p className="text-gray-600 text-sm mt-1">{system.description}</p>
                     )}
+
+                    {system.updated_at && (
+                      <p className="text-xs text-gray-400 mt-2">
+                        Updated{' '}
+                        {formatDistanceToNow(new Date(system.updated_at), {
+                          addSuffix: true,
+                        })}
+                      </p>
+                    )}    
                     <div className="flex items-center gap-3 mt-2">
                       {system.sector && (
                         <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded">


### PR DESCRIPTION
## Related Issue

Closes #22 

## Description

This PR enhances the AI Systems dashboard by displaying the `updated_at` field as a human-readable relative time string (e.g. `3 days ago`, `2 hours ago`) on each AI System card.

The implementation uses `date-fns` for lightweight and consistent date formatting.

## Changes Made

* Added `date-fns` dependency for relative date formatting
* Extended the `AISystem` interface to include the `updated_at` field
* Displayed relative update timestamps on AI System cards
* Added conditional rendering to safely handle missing timestamps

## UI Improvement

Users can now quickly identify recently updated AI systems, improving visibility and overall dashboard usability.

## Type of Change

* [x] Enhancement

## Checklist

* Code follows the project structure and conventions
*  No unrelated files included in the PR
*  Tested locally
*  Issue linked properly
