### PR TITLE
interface(documents): add copy-to-clipboard support for document preview

### DIFF
--- a/frontend/src/pages/Documents.tsx
+++ b/frontend/src/pages/Documents.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { aiSystemsApi, documentsApi } from '../services/api'
-import { FileText, Download, Trash2, Plus, Edit } from 'lucide-react'
+import { FileText, Download, Trash2, Plus, Edit, Copy, Check } from 'lucide-react'
 import DocumentEditor from '../components/DocumentEditor'
 
 interface Document {
@@ -26,6 +26,21 @@ export default function Documents() {
   const [selectedType, setSelectedType] = useState('technical_documentation')
   const [editingDoc, setEditingDoc] = useState<Document | null>(null)
   const [documentToDelete, setDocumentToDelete] = useState<Document | null>(null)
+  const [copiedDocId, setCopiedDocId] = useState<number | null>(null)
+
+  const handleCopy = async (docId: number, content: string) => {
+    try {
+      await navigator.clipboard.writeText(content)
+
+      setCopiedDocId(docId)
+
+      setTimeout(() => {
+        setCopiedDocId(null)
+      }, 2000)
+    } catch (error) {
+      console.error('Failed to copy content:', error)
+    }
+  }
 
   const { data: documentsData, isLoading } = useQuery({
     queryKey: ['documents'],
@@ -179,6 +194,19 @@ export default function Documents() {
                   >
                     <Edit className="w-5 h-5" />
                   </button>
+
+                  <button
+                    onClick={() => handleCopy(doc.id, doc.content || '')}
+                    className="p-2 text-gray-400 hover:text-green-600 rounded-lg hover:bg-green-50"
+                    title={copiedDocId === doc.id ? 'Copied!' : 'Copy Markdown'}
+                  >
+                    {copiedDocId === doc.id ? (
+                      <Check className="w-5 h-5" />
+                    ) : (
+                      <Copy className="w-5 h-5" />
+                    )}
+                  </button>
+
                   <button
                     onClick={() => {
                       // Download as text file
@@ -195,6 +223,7 @@ export default function Documents() {
                   >
                     <Download className="w-5 h-5" />
                   </button>
+
                   <button
                     onClick={() => setDocumentToDelete(doc)}
                     className="p-2 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50"


### PR DESCRIPTION
## Description

This PR adds a copy-to-clipboard feature to the document content preview section in `Documents.tsx`.

## Changes Made

* Added a copy icon button to the document preview actions
* Implemented clipboard copy functionality using the Clipboard API
* Added temporary visual feedback using a success/check icon state after copying
* Maintained consistency with the existing frontend UI and styling

## Impact

This enhancement improves usability by allowing users to quickly copy generated Markdown document content for reuse, sharing, or editing.

## Technical Details

* Added local copy state management using `useState`
* Implemented asynchronous clipboard handling with `navigator.clipboard.writeText`
* Added temporary success feedback reset using `setTimeout`
* Integrated Lucide `Copy` and `Check` icons for better UX

## Files Modified

* `frontend/src/pages/Documents.tsx`

## Issue Reference

Fixes #16 
