### PR TITLE
fix(tests): add get_current_user override in conftest to fix RAG test 401s

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -49,7 +49,14 @@ def client(db_engine):
     def override_get_db():
         yield session
     
+    from app.api.v1.auth import get_current_user
+    from app.models.user import User
+
+    def override_get_current_user():
+        return User(id=1, email="test@example.com", is_active=True, hashed_password="fake")
+
     app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
     
     client = TestClient(app)
     yield client


### PR DESCRIPTION
Closes #393

## Changes
- Added `get_current_user` dependency override in the test client fixture in conftest.py
- This fixes 7 RAG tests in test_rag_ingest.py that were returning 401 Unauthorized

## Proof
On main: 7 RAG tests fail with 401, 126 passing
After fix: 7 RAG tests pass, 128 passing

## Type of Change
- [x] Bug fix

## GSSoC '26
I am a GSSoC '26 contributor (@Thongramdhanapyari)