### PR TITLE
Fix: register missing models and add back_populates relationships

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,4 +5,6 @@ from app.models.rag_feedback import RAGFeedback
 from app.models.audit_log import AISystemAuditLog
 from app.models.guard_scan_log import GuardScanLog
 from app.models.webhook import WebhookConfig
-__all__ = ["User", "AISystem", "RiskAssessment", "Document", "RAGFeedback", "AISystemAuditLog", "GuardScanLog", "WebhookConfig"]
+from app.models.notification import Notification                      
+from app.models.compliance_snapshot import ComplianceSnapshot
+__all__ = ["User", "AISystem", "RiskAssessment", "Document", "RAGFeedback", "AISystemAuditLog", "GuardScanLog", "WebhookConfig", "Notification", "ComplianceSnapshot"]

--- a/backend/app/models/ai_system.py
+++ b/backend/app/models/ai_system.py
@@ -50,7 +50,8 @@ class AISystem(Base):
     owner = relationship("User", back_populates="ai_systems")
     risk_assessments = relationship("RiskAssessment", back_populates="ai_system")
     documents = relationship("Document", back_populates="ai_system")
-
+    compliance_snapshots = relationship("ComplianceSnapshot", back_populates="ai_system")
+    
 
 class RiskAssessment(Base):
     __tablename__ = "risk_assessments"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -38,3 +38,4 @@ class User(Base):
     ai_systems = relationship("AISystem", back_populates="owner")
     documents = relationship("Document", back_populates="owner")
     webhook_configs = relationship("WebhookConfig", back_populates="user")
+    notifications    = relationship("Notification",    back_populates="user")


### PR DESCRIPTION

## Summary
Closes #280

Three models (`Notification`, `ComplianceSnapshot`) were never imported in `models/__init__.py`, so their tables were never created by `create_all()` on startup. Also added the missing `back_populates` relationships on `User` and `AISystem`.

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed