### PR TITLE
docs: add CHANGELOG contribution guide and PR check workflow

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,14 @@
+name: Changelog Check
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check CHANGELOG updated
+        run: |
+          git diff --name-only origin/${{ github.base_ref }} | grep CHANGELOG.md \
+          || echo "::warning::Please update CHANGELOG.md in your PR"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,17 @@ pytest tests/ -v --cov=app
 
 ---
 
+## Updating the Changelog
+
+When submitting a PR, add a line to `CHANGELOG.md` under the `[Unreleased]` section using this format:
+
+- **Added** `<new features>`
+- **Fixed** `<bug fixes>`
+- **Changed** `<changes to existing functionality>`
+- **Removed** `<removed features>`
+
+---
+
 ## Commit Style
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/):


### PR DESCRIPTION
## Summary
Closes #337

Added a CHANGELOG contribution guide to CONTRIBUTING.md and a GitHub 
Actions workflow that warns contributors if they haven't updated 
CHANGELOG.md in their PR.

## Type of Change
- [x] Documentation update
- [x] Infra / CI

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have not committed .env or any secrets
- [x] I have updated documentation if needed

## Screenshots (if UI change)
N/A - documentation and CI changes only