### PR TITLE
fix: handle bcrypt password length validation

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -29,7 +29,13 @@ def _get_credentials_exception() -> HTTPException:
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verify a plain password against its hashed version."""
-    return pwd_context.verify(plain_password, hashed_password)
+    if len(plain_password.encode("utf-8")) > 72:
+        return False
+
+    try:
+        return pwd_context.verify(plain_password, hashed_password)
+    except ValueError:
+        return False
 
 
 def get_password_hash(password: str) -> str:


### PR DESCRIPTION
## Summary

Closes #419

Handled bcrypt password length limitation gracefully by adding defensive validation before password verification. This prevents runtime exceptions for passwords longer than 72 bytes and ensures authentication flows fail consistently instead of crashing.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [ ] I have added/updated tests where relevant
* [ ] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [ ] I have updated documentation if needed

## Changes Made

* Added password byte-length validation before bcrypt verification
* Prevented runtime `ValueError` exceptions for passwords longer than 72 bytes
* Added graceful fallback handling using `try/except`
* Ensured authentication verification returns consistent behavior