### PR TITLE
fix: clean RAG API syntax and remove duplicate return

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -11,12 +11,12 @@ TODO for contributors (high difficulty):
 
 import time
 from fastapi import APIRouter, Depends, HTTPException, status
-Contributor note:
-  - POST /rag/ingest implemented: multipart PDF upload → document_loader → FAISS rebuild
-  - TODO: Pre-load the EU AI Act, GDPR, ISO 42001, and NIST AI RMF as source documents
-  - TODO: Integrate MLflow tracking from modules/rag/ml_flow.py
-  - TODO: Add streaming responses via SSE for long answers
-"""
+#Contributor note:
+#- POST /rag/ingest implemented: multipart PDF upload → document_loader → FAISS rebuild
+#- TODO: Pre-load the EU AI Act, GDPR, ISO 42001, and NIST AI RMF as source documents
+#- TODO: Integrate MLflow tracking from modules/rag/ml_flow.py
+#- TODO: Add streaming responses via SSE for long answers
+
 
 import os
 import shutil
@@ -35,7 +35,7 @@ from app.models.user import SubscriptionTier, User
 from app.modules.rag.document_loader import load_documents_from_paths
 from app.modules.rag.vector_store import create_vector_store
 from app.models.rag_query import RagQuery
-from typing import Optional
+
 
 router = APIRouter()
 
@@ -209,7 +209,7 @@ def query_knowledge_base(
             pass
 
         return RAGQueryResponse(answer=answer, sources=sources, answer_id=feedback.id)
-        return RAGQueryResponse(answer=result["result"], sources=sources, answer_id=answer_id)
+        
     except FileNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,


### PR DESCRIPTION
## Summary
Fixes minor bugs and cleanup issues in the `/rag` API module.

This PR:
- Removes a duplicate return statement in the `/rag/query` endpoint
- Cleans up duplicate/unused imports
- Fixes formatting of the contributor note comment block to ensure valid Python syntax

These changes improve code correctness and prevent potential runtime or linting issues.

## Type of Change

- [x] Bug fix
- [x] Refactor (small cleanup)
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style
- [x] I have not committed secrets or .env files
- [x] I have tested the endpoint locally
- [ ] `pytest backend/tests/` passes locally 


## Screenshots (if UI change)

N/A