### PR TITLE
Refactor/guard batch validation

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -171,7 +171,7 @@ def get_guard_history(
 
 
 # Temporary in-memory config store
-user_guard_configs = {}
+user_guard_configs: dict[int, dict[str, float | str]] = {}
 
 VALID_SANITIZATION_LEVELS = {"low", "medium", "high"}
 
@@ -233,11 +233,12 @@ def update_guard_config(
 class BulkScanRequest(BaseModel):
     prompts: list[str]
 
-    def validate_prompts(self):
+    def validate_prompts(self) -> None:
         if len(self.prompts) > 50:
-            raise ValueError("Maximum 50 prompts allowed per batch request.")
-        return self
-
+            raise ValueError(
+                "Maximum 50 prompts allowed per batch request."
+            )
+    
 
 class BulkScanResponse(BaseModel):
     results: list[ScanResponse]
@@ -255,10 +256,14 @@ def bulk_scan_prompts(
     Processes sequentially to respect memory constraints.
     Returns a decision for each prompt.
     """
-    if len(request.prompts) > 50:
+
+    try:
+        # Schema validation instead of manual check
+        request.validate_prompts()
+    except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Maximum 50 prompts allowed per batch request."
+            detail=str(e),
         )
 
     limited, retry_after = _check_rate_limit(current_user.id)

--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -11,12 +11,12 @@ TODO for contributors (high difficulty):
 
 import time
 from fastapi import APIRouter, Depends, HTTPException, status
-Contributor note:
-  - POST /rag/ingest implemented: multipart PDF upload → document_loader → FAISS rebuild
-  - TODO: Pre-load the EU AI Act, GDPR, ISO 42001, and NIST AI RMF as source documents
-  - TODO: Integrate MLflow tracking from modules/rag/ml_flow.py
-  - TODO: Add streaming responses via SSE for long answers
-"""
+#Contributor note:
+#- POST /rag/ingest implemented: multipart PDF upload → document_loader → FAISS rebuild
+#- TODO: Pre-load the EU AI Act, GDPR, ISO 42001, and NIST AI RMF as source documents
+#- TODO: Integrate MLflow tracking from modules/rag/ml_flow.py
+#- TODO: Add streaming responses via SSE for long answers
+
 
 import os
 import shutil
@@ -35,7 +35,7 @@ from app.models.user import SubscriptionTier, User
 from app.modules.rag.document_loader import load_documents_from_paths
 from app.modules.rag.vector_store import create_vector_store
 from app.models.rag_query import RagQuery
-from typing import Optional
+
 
 router = APIRouter()
 
@@ -209,7 +209,7 @@ def query_knowledge_base(
             pass
 
         return RAGQueryResponse(answer=answer, sources=sources, answer_id=feedback.id)
-        return RAGQueryResponse(answer=result["result"], sources=sources, answer_id=answer_id)
+        
     except FileNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,


### PR DESCRIPTION
## Summary

Closes #483 

Refactored batch validation logic in `backend/app/api/v1/guard.py` by reusing the existing `validate_prompts()` method instead of performing duplicate manual validation inside the `/scan/batch` endpoint.

Also added a missing type hint for `user_guard_configs` to improve readability and type safety.

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] My code follows the project style
* [ ] I have added/updated tests where relevant
* [ ] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [ ] I have updated documentation if needed

## Screenshots (if UI change)

N/A