### PR TITLE
refactor: remove duplicate batch validation logic

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -171,7 +171,7 @@ def get_guard_history(
 
 
 # Temporary in-memory config store
-user_guard_configs = {}
+user_guard_configs: dict[int, dict[str, float | str]] = {}
 
 VALID_SANITIZATION_LEVELS = {"low", "medium", "high"}
 
@@ -233,11 +233,12 @@ def update_guard_config(
 class BulkScanRequest(BaseModel):
     prompts: list[str]
 
-    def validate_prompts(self):
+    def validate_prompts(self) -> None:
         if len(self.prompts) > 50:
-            raise ValueError("Maximum 50 prompts allowed per batch request.")
-        return self
-
+            raise ValueError(
+                "Maximum 50 prompts allowed per batch request."
+            )
+    
 
 class BulkScanResponse(BaseModel):
     results: list[ScanResponse]
@@ -255,10 +256,14 @@ def bulk_scan_prompts(
     Processes sequentially to respect memory constraints.
     Returns a decision for each prompt.
     """
-    if len(request.prompts) > 50:
+
+    try:
+        # Schema validation instead of manual check
+        request.validate_prompts()
+    except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Maximum 50 prompts allowed per batch request."
+            detail=str(e),
         )
 
     limited, retry_after = _check_rate_limit(current_user.id)


### PR DESCRIPTION
# Summary  
Closes issue #483  

Refactored batch validation logic in backend/app/api/v1/guard.py by reusing the existing validate_prompts() method instead of performing duplicate manual validation inside the /scan/batch endpoint.

Also added a missing type hint for user_guard_configs to improve readability and type safety.

# Type of Change  
- [x] Refactor 

# Checklist  
- [x] I have read CONTRIBUTING.md  
- [x] My code follows the project style  
- [x] I have not committed .env or any secrets  

Screenshots (if UI change)  
N/A