### PR TITLE
fix: prevent information exposure through verbose exception messages

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -13,6 +13,7 @@ import hashlib
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
 from threading import Lock
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse
@@ -29,7 +30,7 @@ from app.schemas.guard_scan_log import GuardScanLogResponse
 from app.schemas.pagination import PaginatedResponse
 
 router = APIRouter()
-
+logger = logging.getLogger(__name__)
 
 _RATE_LIMIT_REQUESTS = 60
 _RATE_LIMIT_WINDOW_SECONDS = 60
@@ -145,8 +146,11 @@ def scan_prompt(
             ),
         )
     except Exception as e:
+        logger.exception("Guard scan failed")
+
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An internal error occurred while processing the Guard scan."
         )
 
 
@@ -360,9 +364,10 @@ def bulk_scan_prompts(
             processed=len(results),
         )
     except Exception as e:
-        db.rollback()                                     
+        db.rollback()
+        logger.exception("Bulk guard scan failed")                                     
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal error occurred while processing the batch Guard scan."
         )
     


### PR DESCRIPTION
## Summary

Closes #226

This PR fixes an information exposure vulnerability in the Guard API endpoints caused by returning raw exception strings directly to API clients using `detail=str(e)`.

The update adds internal exception logging using Python's logging module while returning sanitized generic HTTP 500 responses to users. The fix has been applied consistently to both `/guard/scan` and `/guard/scan/batch` endpoints.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [ ] I have added/updated tests where relevant
* [ ] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [ ] I have updated documentation if needed

## Screenshots (if UI change)

N/A