### PR TITLE
feat: wire RagChat to real RAG API

### DIFF
--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { AlertCircle, Bot, FileText, Loader2, Send, Sparkles, User } from 'lucide-react'
 import CopyButton from '../components/CopyButton'
+import { ragApi } from '../services/api'
 
 interface RagSource {
   title: string
@@ -35,6 +36,7 @@ export default function RagChat() {
     e.preventDefault()
 
     const trimmedQuestion = question.trim()
+
     if (!trimmedQuestion) {
       setError('Please enter a question before asking.')
       setSubmittedQuestion('')
@@ -49,34 +51,26 @@ export default function RagChat() {
     setAnswer(null)
 
     try {
-      // TODO: Replace this simulated response with the real RAG API call in the follow-up issue.
-      // Suggested integration point:
-      // const { data } = await api.post('/api/v1/rag/query', { question: trimmedQuestion })
-      // setAnswer({ answer: data.answer, sources: data.sources })
-      await new Promise((resolve) => setTimeout(resolve, 900)) // TODO (#73): replace with actual POST /api/v1/rag/query call
-
-      if (trimmedQuestion.toLowerCase().includes('error')) {
-        throw new Error('Simulated RAG service failure. Try another question.')
-      }
+      // ✅ REAL API CALL
+      const data = await ragApi.query(trimmedQuestion)
 
       setAnswer({
-        answer:
-          'Based on the available compliance knowledge base, this question appears related to EU AI Act risk classification and documentation obligations. Once API wiring is added, this panel will show grounded answers generated from indexed regulatory sources.',
-        sources: [
-          {
-            title: 'EU AI Act - Risk Classification Guidance',
-            excerpt:
-              'High-risk AI systems require risk management, technical documentation, logging, transparency, human oversight, accuracy, robustness, and cybersecurity controls.',
-          },
-          {
-            title: 'AegisAI Compliance Knowledge Base',
-            excerpt:
-              'RAG responses should include source citations so users can verify which documents informed the generated answer.',
-          },
-        ],
+        answer: data.answer,
+        sources: data.sources || [],
       })
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unable to generate an answer right now.')
+    } catch (err: any) {
+      // ✅ ERROR HANDLING
+      if (err.response?.status === 503) {
+        setError('Index not ready. Please try again later.')
+      } else if (err.response?.status === 401) {
+        setError('Unauthorized. Please login again.')
+      } else {
+        setError(
+          err?.response?.data?.detail ||
+            err.message ||
+            'Unable to generate an answer right now.'
+        )
+      }
     } finally {
       setIsLoading(false)
     }
@@ -196,17 +190,21 @@ export default function RagChat() {
                           <h3 className="text-sm font-semibold text-gray-900">
                             Generated answer
                           </h3>
+
                           <CopyButton
                             text={buildAnswerExport(answer)}
                             label="Copy Answer"
                             successMessage="Answer copied!"
                           />
                         </div>
+
                         <p className="text-gray-700 leading-7">{answer.answer}</p>
+
                         <div className="border-t border-gray-100 pt-5">
                           <h3 className="text-sm font-semibold text-gray-900 mb-3">
                             Source citations
                           </h3>
+
                           <div className="space-y-3">
                             {answer.sources.map((source) => (
                               <div
@@ -215,11 +213,15 @@ export default function RagChat() {
                               >
                                 <div className="flex items-center gap-2 mb-2">
                                   <FileText className="w-4 h-4 text-primary-600" />
+
                                   <h4 className="text-sm font-medium text-gray-900">
                                     {source.title}
                                   </h4>
                                 </div>
-                                <p className="text-sm text-gray-600">{source.excerpt}</p>
+
+                                <p className="text-sm text-gray-600">
+                                  {source.excerpt}
+                                </p>
                               </div>
                             ))}
                           </div>
@@ -240,6 +242,7 @@ export default function RagChat() {
             <label htmlFor="rag-question" className="sr-only">
               Question
             </label>
+
             <textarea
               id="rag-question"
               value={question}
@@ -249,6 +252,7 @@ export default function RagChat() {
               disabled={isLoading}
               className="min-w-0 flex-1 resize-none bg-transparent border-0 p-0 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-0 disabled:text-gray-500"
             />
+
             <button
               type="submit"
               disabled={isLoading}
@@ -263,11 +267,12 @@ export default function RagChat() {
               )}
             </button>
           </div>
+
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 mt-2">
             <p className="text-xs text-gray-500">
-              Try typing `error` to preview the error state. 
-              {/* TODO: This statement is just for testing. Remove it after integration of API */}
+              Ask compliance questions and get source-backed answers.
             </p>
+
             <p className="text-xs text-gray-400">
               Use this assistant to explore risk, documentation, and governance obligations.
             </p>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -125,7 +125,6 @@ export const notificationsApi = {
     api.post('/notifications/read', { ids }),
 }
 
-
 // Health API — uses root URL, not /api/v1
 export interface HealthResponse {
   status: "healthy" | "degraded";
@@ -135,8 +134,22 @@ export interface HealthResponse {
 }
 
 export const checkHealth = async (): Promise<HealthResponse> => {
-  const response = await axios.get<HealthResponse>("/health"); // plain axios, not `api`
-  return response.data;
-};
+  const response = await axios.get<HealthResponse>("/health")
+  return response.data
+}
+
+/* ============================
+   ✅ RAG API (ADD THIS ONLY)
+   ============================ */
+
+export const ragApi = {
+  query: async (question: string) => {
+    const { data } = await api.post('/rag/query', {
+      question,
+    })
+
+    return data
+  },
+}
 
 export default api


### PR DESCRIPTION
## Summary

Closes #489

Connected the `/rag-chat` page to the real backend RAG API endpoint instead of using simulated responses. Added API integration, loading/error handling, and rendering of real answers and sources from the backend.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [ ] I have added/updated tests where relevant
* [ ] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [ ] I have updated documentation if needed

## Screenshots (if UI change)

Frontend now:

* Sends `POST /api/v1/rag/query`
* Displays real API answer and sources
* Handles loading states
* Handles `503` index-not-ready errors properly

Backend server was not running locally, so full end-to-end testing could not be completed.
