### PR TITLE
add backend healthcheck and frontend service dependency (Docker)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     gcc \
     libpq-dev \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       - ./backend:/app
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
@@ -39,6 +44,9 @@ services:
       - "5173:5173"
     environment:
       - BACKEND_URL=http://backend:8000
+    depends_on:
+      backend:
+        condition: service_healthy
     volumes:
       - ./frontend:/app
       - /app/node_modules


### PR DESCRIPTION
This PR is submitted under GSSoC 2026.

This PR fixes a startup race condition in the Docker Compose setup where the frontend container could start before the backend service was fully ready to accept connections.

### Changes Made

* Added a healthcheck to the `backend` service using `curl`
* Added `depends_on` with `condition: service_healthy` for the `frontend`
* Installed `curl` in the backend Docker image to support healthchecks

### Result

The startup flow is now:

```text
db → backend → frontend
```

This ensures the frontend starts only after the backend becomes healthy, preventing failed API calls during initial application startup.

Fixes #264
