### PR TITLE
fix(rag): remove unreachable duplicate return in query endpoint

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -204,7 +204,7 @@ def query_knowledge_base(
             pass
 
         return RAGQueryResponse(answer=answer, sources=sources, answer_id=feedback.id)
-        return RAGQueryResponse(answer=result["result"], sources=sources, answer_id=answer_id)
+        
     except FileNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,


### PR DESCRIPTION
## Summary

Removes an unreachable duplicate return statement in the RAG query endpoint.
The second return was dead code and referenced an undefined variable, making it incorrect and unnecessary.
No functional changes are introduced.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style 
- [x] I have not committed `.env` or any secrets


## Screenshots (if UI change)
N/A
