### PR TITLE
docs: add module-level docstring to classification.py

### DIFF
--- a/backend/app/api/v1/classification.py
+++ b/backend/app/api/v1/classification.py
@@ -1,3 +1,92 @@
+"""
+classification.py — EU AI Act Risk Classification API
+======================================================
+
+This module exposes the REST API endpoints that classify AI systems under the
+EU AI Act risk framework. Classification is powered by an LLM (Gemini / OpenAI-
+compatible) that reasons over the system's metadata against the relevant EU AI
+Act articles and returns a structured risk verdict with a human-readable rationale.
+
+EU AI Act Legal Basis
+---------------------
+The classification logic maps to the following articles and annexes:
+
+- **Article 5  — Prohibited AI Practices**
+  AI systems that fall under Art. 5 are assigned the ``Unacceptable`` risk level
+  and cannot be deployed in the EU. Examples include social scoring by public
+  authorities and real-time remote biometric identification in public spaces.
+
+- **Article 6 + Annex III — High-Risk AI Systems**
+  Art. 6 defines the two-step test for high-risk classification:
+  (1) the system is a safety component of a product covered by Union harmonisation
+  legislation listed in Annex II, or is itself such a product; or
+  (2) the system falls within one of the eight domains listed in Annex III
+  (e.g., biometrics, critical infrastructure, education, employment, essential
+  private/public services, law enforcement, migration, justice).
+  Systems meeting either criterion are assigned the ``High`` risk level and must
+  comply with the full obligations in Chapter III (conformity assessment, technical
+  documentation, human oversight, etc.).
+
+- **Article 52 — Transparency Obligations for Certain AI Systems**
+  AI systems that interact with humans (chatbots), generate synthetic content
+  (deepfakes), or perform emotion recognition / biometric categorisation are
+  assigned the ``Limited`` risk level and must meet specific disclosure obligations.
+
+- **Minimal Risk (default)**
+  All other AI systems not captured by Art. 5, Art. 6, or Art. 52 are classified
+  as ``Minimal`` risk. No mandatory obligations apply, though voluntary codes of
+  conduct are encouraged.
+
+Risk Levels
+-----------
+AegisAI uses four risk levels, ordered from lowest to highest severity:
+
+1. ``Minimal``       — No mandatory EU AI Act obligations. Vast majority of AI
+                        applications (spam filters, AI in video games, etc.).
+2. ``Limited``       — Transparency obligations only (Art. 52). Must inform users
+                        they are interacting with AI.
+3. ``High``          — Full compliance regime (Art. 6 + Annex III). Requires
+                        technical documentation, conformity assessment, human
+                        oversight, and registration in the EU database.
+4. ``Unacceptable``  — Prohibited (Art. 5). Deployment in the EU is forbidden.
+
+Classification Flow
+-------------------
+1. Client submits AI system attributes (name, sector, use_case, intended_purpose,
+   capabilities, data types processed) to the classify endpoint.
+2. The endpoint builds a structured prompt embedding the system's metadata and the
+   relevant EU AI Act rules.
+3. The prompt is sent to the configured LLM (``app.modules.llm``) which returns a
+   JSON payload containing:
+   - ``risk_level``              — one of the four levels above
+   - ``classification_reasoning`` — plain-English rationale citing EU AI Act articles
+   - ``applicable_articles``     — list of articles that triggered the classification
+4. The response is validated via Pydantic and returned to the caller.
+5. In the ``/classify/{system_id}`` variant, the result is also persisted back to
+   the ``AISystem`` record in the database (``risk_level``, ``classification_reasoning``
+   fields on the ORM model).
+
+Endpoints
+---------
+- ``POST /classify``
+    Stateless classification — accepts a ``ClassifyRequest`` body and returns a
+    ``ClassifyResponse`` without touching the database. Useful for one-off checks
+    or external integrations.
+
+- ``POST /classify/{system_id}``
+    Persistent classification — loads the ``AISystem`` identified by ``system_id``
+    from the database, classifies it, and writes the result back. Requires the
+    caller to be the owner of the AI system (JWT-authenticated).
+
+Dependencies
+------------
+- ``app.modules.llm.client``           — LLM client (OpenAI-compatible)
+- ``app.models.ai_system.AISystem``    — ORM model updated by ``/classify/{system_id}``
+- ``app.schemas.classification.*``     — Pydantic request / response schemas
+- ``app.core.db.get_db``               — SQLAlchemy session dependency
+- ``app.core.security.get_current_user`` — JWT authentication dependency
+"""
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import List, Optional

--- a/backend/app/api/v1/documents.py
+++ b/backend/app/api/v1/documents.py
@@ -1,3 +1,72 @@
+"""
+documents.py — Compliance Document Generation API
+==================================================
+
+This module provides the REST API endpoints for generating, retrieving,
+and exporting EU AI Act compliance documents tied to registered AI systems.
+
+Document Generation Flow
+------------------------
+1. **Template Selection**: When a client calls POST /ai-systems/{system_id}/documents,
+   the endpoint selects a document template based on the requested ``doc_type``:
+
+   - ``technical_documentation`` — Annex IV Technical Documentation (EU AI Act Art. 11)
+   - ``risk_assessment``         — Risk Management System report (EU AI Act Art. 9)
+   - ``conformity_declaration``  — EU Declaration of Conformity (EU AI Act Art. 47)
+
+2. **Population from AISystem Metadata**: Each template is populated using fields
+   from the ``AISystem`` ORM model retrieved from the database:
+   - ``name``, ``version``, ``description``
+   - ``risk_level`` (Minimal / Limited / High / Unacceptable)
+   - ``sector``, ``use_case``, ``intended_purpose``
+   - ``owner_id`` (linked user / organisation)
+   - ``compliance_score``, ``classification_reasoning``
+
+3. **Persistence**: The generated document content and metadata are saved to the
+   ``documents`` table (see ``app/models/document.py``) with a foreign-key
+   reference back to the parent ``ai_systems`` row.
+
+PDF Export
+----------
+Completed documents can be exported as PDF via GET /documents/{doc_id}/export.
+The export layer renders the populated template to PDF using one of:
+
+- **WeasyPrint** — converts an HTML/CSS template to a print-quality PDF.
+  Preferred when full CSS styling and EU-branded layouts are required.
+- **ReportLab** — used as a fallback or for programmatic/table-heavy layouts
+  when WeasyPrint is not available in the deployment environment.
+
+The resulting PDF is streamed back to the client as an inline ``application/pdf``
+response so the browser can open or download it directly.
+
+Database Relationships
+----------------------
+Each ``Document`` record has a many-to-one relationship with ``AISystem``:
+
+    Document.ai_system_id  →  AISystem.id   (FK, NOT NULL)
+
+One AI system can have multiple versioned documents of different types.
+All documents are scoped to the authenticated user's tenant via the
+``AISystem.owner_id`` field — users can only generate or view documents
+for AI systems they own.
+
+Endpoints Summary
+-----------------
+- POST   /ai-systems/{system_id}/documents        — generate a new document
+- GET    /ai-systems/{system_id}/documents        — list all docs for a system
+- GET    /documents/{doc_id}                      — retrieve a single document
+- DELETE /documents/{doc_id}                      — delete a document
+- GET    /documents/{doc_id}/export               — export document as PDF
+
+Dependencies
+------------
+- ``app.models.ai_system.AISystem``   — source of all metadata used in templates
+- ``app.models.document.Document``    — ORM model for persisted documents
+- ``app.core.db.get_db``              — SQLAlchemy session dependency
+- ``app.core.security.get_current_user`` — JWT authentication dependency
+"""
+
+
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from fastapi.responses import FileResponse, StreamingResponse
 from sqlalchemy.orm import Session


### PR DESCRIPTION
## Summary
Closes #286 

Adds a module-level docstring to `backend/app/api/v1/classification.py`, which previously had no top-level description. The docstring documents the four EU AI Act risk levels (`Minimal`, `Limited`, `High`, `Unacceptable`), the legal articles that power the classification logic (Art. 5, Art. 6, Art. 52, and Annex III), and both endpoints (`POST /classify` for stateless checks and `POST /classify/{system_id}` for persisting results to the `AISystem` record in the database).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [X] `pytest backend/tests/` passes locally
- [X] I have not committed `.env` or any secrets
- [X] I have updated documentation if needed