### PR TITLE
feat: add guard audit copy exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- LLM Guard console with copy-to-clipboard exports for scan response payloads and raw audit metrics.
+
+---
+
 ## [0.1.0] — 2026-04-05
 
 ### Added

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Classification from './pages/Classification'
 import Documents from './pages/Documents'
 import Notifications from './pages/Notifications'
 import Analytics from './pages/Analytics'
+import GuardConsole from './pages/GuardConsole'
 import NotFound from './pages/NotFound'
 import { Toaster } from 'react-hot-toast'
 import RagChat from './pages/RagChat'
@@ -58,6 +59,7 @@ function App() {
           <Route path="ai-systems" element={<AISystems />} />
           <Route path="classification/:systemId?" element={<Classification />} />
           <Route path="documents" element={<Documents />} />
+          <Route path="guard" element={<GuardConsole />} />
           <Route path="rag-chat" element={<RagChat />} />
           <Route path="notifications" element={<Notifications />} />
           <Route path="rag-chat" element={<RagChat />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -10,6 +10,7 @@ import {
   MessageSquareText,
   LogOut,
   Shield,
+  ShieldCheck,
   ChevronLeft,
   ChevronRight,
   BarChart,
@@ -25,6 +26,7 @@ const navigation = [
   { name: 'AI Systems', href: '/ai-systems', icon: Bot },
   { name: 'Risk Classification', href: '/classification', icon: FileCheck },
   { name: 'Documents', href: '/documents', icon: FileText },
+  { name: 'LLM Guard', href: '/guard', icon: ShieldCheck },
   { name: 'Chatbot', href: '/rag-chat', icon: MessageSquareText },
 ]
 

--- a/frontend/src/pages/GuardConsole.tsx
+++ b/frontend/src/pages/GuardConsole.tsx
@@ -1,0 +1,342 @@
+import { useMemo, useState } from 'react'
+import {
+  Activity,
+  AlertCircle,
+  Gauge,
+  ListChecks,
+  Loader2,
+  Send,
+  ShieldCheck,
+} from 'lucide-react'
+import CopyButton from '../components/CopyButton'
+import { guardApi, type GuardScanResponse } from '../services/api'
+
+type GuardMetrics = {
+  decision: string
+  confidence: number
+  matchedPatternCount: number
+  matchedPatterns: string[]
+  hasSanitizedPrompt: boolean
+  scannedAt: string
+}
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2)
+}
+
+function buildMetrics(result: GuardScanResponse | null, scannedAt: string): GuardMetrics | null {
+  if (!result) {
+    return null
+  }
+
+  const matchedPatterns = result.matched_patterns ?? []
+
+  return {
+    decision: result.decision,
+    confidence: result.confidence,
+    matchedPatternCount: matchedPatterns.length,
+    matchedPatterns,
+    hasSanitizedPrompt: Boolean(result.sanitized_prompt),
+    scannedAt,
+  }
+}
+
+function decisionBadgeClass(decision: string): string {
+  switch (decision) {
+    case 'allow':
+      return 'bg-emerald-100 text-emerald-700 border-emerald-200'
+    case 'sanitize':
+      return 'bg-amber-100 text-amber-700 border-amber-200'
+    case 'block':
+      return 'bg-red-100 text-red-700 border-red-200'
+    default:
+      return 'bg-gray-100 text-gray-700 border-gray-200'
+  }
+}
+
+export default function GuardConsole() {
+  const [prompt, setPrompt] = useState('')
+  const [submittedPrompt, setSubmittedPrompt] = useState('')
+  const [result, setResult] = useState<GuardScanResponse | null>(null)
+  const [scannedAt, setScannedAt] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const metrics = useMemo(
+    () => buildMetrics(result, scannedAt),
+    [result, scannedAt]
+  )
+
+  const responsePayload = useMemo(
+    () => result ? formatJson(result) : '',
+    [result]
+  )
+
+  const rawMetrics = useMemo(
+    () => metrics ? formatJson(metrics) : '',
+    [metrics]
+  )
+
+  const handleScan = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const trimmedPrompt = prompt.trim()
+
+    if (!trimmedPrompt) {
+      setError('Enter a prompt before running the guard scan.')
+      setSubmittedPrompt('')
+      setResult(null)
+      setScannedAt('')
+      return
+    }
+
+    setSubmittedPrompt(trimmedPrompt)
+    setIsLoading(true)
+    setError(null)
+    setResult(null)
+    setScannedAt('')
+
+    try {
+      const data = await guardApi.scan(trimmedPrompt)
+      setResult(data)
+      setScannedAt(new Date().toISOString())
+    } catch (scanError: unknown) {
+      const message = scanError instanceof Error
+        ? scanError.message
+        : 'Unable to run the guard scan right now.'
+
+      setError(message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="p-3 bg-primary-50 rounded-xl">
+            <ShieldCheck className="w-6 h-6 text-primary-600" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">LLM Guard</h1>
+            <p className="text-gray-600">
+              Scan prompts and export audit-ready guard results.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <Activity className="w-4 h-4 text-primary-600" />
+          <span>Prompt injection defence</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_420px] gap-6">
+        <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <div className="px-5 py-4 border-b border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-900">Scan prompt</h2>
+          </div>
+
+          <form onSubmit={handleScan} className="p-5 space-y-4">
+            <label htmlFor="guard-prompt" className="sr-only">
+              Prompt to scan
+            </label>
+            <textarea
+              id="guard-prompt"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder="Paste the prompt you want LLM Guard to inspect..."
+              rows={10}
+              disabled={isLoading}
+              className="w-full resize-y rounded-xl border border-gray-300 px-4 py-3 text-sm text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500"
+            />
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs text-gray-500">
+                The backend stores a hash for audit history, not the raw prompt.
+              </p>
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isLoading ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Send className="w-4 h-4" />
+                )}
+                Run scan
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <aside className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <div className="px-5 py-4 border-b border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-900">Audit exports</h2>
+          </div>
+
+          <div className="p-5 space-y-4">
+            <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-200 p-4">
+              <div>
+                <p className="text-sm font-semibold text-gray-900">Response payload</p>
+                <p className="text-xs text-gray-500">Exact scan API response JSON</p>
+              </div>
+              <CopyButton
+                text={responsePayload}
+                label="Copy"
+                successMessage="Response payload copied!"
+                disabled={!result}
+              />
+            </div>
+
+            <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-200 p-4">
+              <div>
+                <p className="text-sm font-semibold text-gray-900">Raw metrics</p>
+                <p className="text-xs text-gray-500">Decision, confidence, patterns, timestamp</p>
+              </div>
+              <CopyButton
+                text={rawMetrics}
+                label="Copy"
+                successMessage="Raw metrics copied!"
+                disabled={!metrics}
+              />
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      {isLoading && (
+        <div className="bg-white rounded-xl border border-gray-200 p-5 shadow-sm">
+          <div className="flex items-center gap-3 text-gray-700">
+            <Loader2 className="w-5 h-5 animate-spin text-primary-600" />
+            <span className="text-sm font-medium">Running LLM Guard scan</span>
+          </div>
+        </div>
+      )}
+
+      {!isLoading && error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-5 text-red-800">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="w-5 h-5 mt-0.5 flex-shrink-0" />
+            <div>
+              <h2 className="font-semibold">Scan failed</h2>
+              <p className="text-sm mt-1">{error}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!isLoading && result && metrics && (
+        <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_420px] gap-6">
+          <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between px-5 py-4 border-b border-gray-200">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">Scan result</h2>
+                <p className="text-xs text-gray-500">
+                  Scanned {new Date(scannedAt).toLocaleString()}
+                </p>
+              </div>
+
+              <span
+                className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${decisionBadgeClass(result.decision)}`}
+              >
+                {result.decision}
+              </span>
+            </div>
+
+            <div className="p-5 space-y-5">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                  Reasoning
+                </h3>
+                <p className="text-sm leading-6 text-gray-700">{result.reasoning}</p>
+              </div>
+
+              {result.sanitized_prompt && (
+                <div>
+                  <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                    Sanitized prompt
+                  </h3>
+                  <pre className="whitespace-pre-wrap rounded-xl border border-gray-200 bg-gray-50 p-4 text-xs leading-6 text-gray-700">
+                    {result.sanitized_prompt}
+                  </pre>
+                </div>
+              )}
+
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                  Submitted prompt
+                </h3>
+                <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-xl border border-gray-200 bg-gray-50 p-4 text-xs leading-6 text-gray-700">
+                  {submittedPrompt}
+                </pre>
+              </div>
+            </div>
+          </section>
+
+          <aside className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+            <div className="px-5 py-4 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900">Metrics</h2>
+            </div>
+
+            <div className="p-5 space-y-4">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="rounded-xl border border-gray-200 p-4">
+                  <div className="flex items-center gap-2 text-xs font-medium text-gray-500">
+                    <Gauge className="w-4 h-4 text-primary-600" />
+                    Confidence
+                  </div>
+                  <p className="mt-2 text-2xl font-bold text-gray-900">
+                    {(metrics.confidence * 100).toFixed(1)}%
+                  </p>
+                </div>
+
+                <div className="rounded-xl border border-gray-200 p-4">
+                  <div className="flex items-center gap-2 text-xs font-medium text-gray-500">
+                    <ListChecks className="w-4 h-4 text-primary-600" />
+                    Patterns
+                  </div>
+                  <p className="mt-2 text-2xl font-bold text-gray-900">
+                    {metrics.matchedPatternCount}
+                  </p>
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                  Matched patterns
+                </h3>
+                {metrics.matchedPatterns.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {metrics.matchedPatterns.map((pattern) => (
+                      <span
+                        key={pattern}
+                        className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700"
+                      >
+                        {pattern}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">No regex patterns matched.</p>
+                )}
+              </div>
+
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                  Raw metrics JSON
+                </h3>
+                <pre className="max-h-80 overflow-auto rounded-xl border border-gray-200 bg-gray-950 p-4 text-xs leading-6 text-gray-100">
+                  {rawMetrics}
+                </pre>
+              </div>
+            </div>
+          </aside>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -157,4 +157,19 @@ export const ragApi = {
   },
 }
 
+export interface GuardScanResponse {
+  decision: 'allow' | 'sanitize' | 'block' | string
+  confidence: number
+  reasoning: string
+  sanitized_prompt?: string | null
+  matched_patterns?: string[]
+}
+
+export const guardApi = {
+  scan: async (prompt: string): Promise<GuardScanResponse> => {
+    const { data } = await api.post('/guard/scan', { prompt })
+    return data
+  },
+}
+
 export default api


### PR DESCRIPTION
## Summary
- add an LLM Guard console route for running prompt scans from the frontend
- add copy actions for the exact scan response payload and raw audit metrics JSON
- surface decision, confidence, matched patterns, sanitized prompt, and timestamped metrics in a reviewable UI
- update the changelog entry for the new Guard audit export workflow

Fixes #454

## Validation
- git diff --check
- static conflict/debug scan across touched frontend files

## Notes
- Full frontend build was not run because this environment has Node available but no npm binary or frontend node_modules installed.