### PR TITLE
fix: update relative doc links to absolute GitHub URLs (fixes #499)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![React](https://img.shields.io/badge/React-18-61DAFB?logo=react)](https://react.dev)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-[Getting Started](docs/getting-started.md) · [Architecture](docs/architecture.md) · [API Reference](docs/api-reference.md) · [Guard Module](docs/guard-module.md) · [RAG Module](docs/rag-module.md) · [Regulations](docs/regulations.md) · [Report a Bug](https://github.com/SdSarthak/AegisAI/issues)
+[Getting Started](https://github.com/SdSarthak/AegisAI/blob/main/docs/getting-started.md)· [Architecture](https://github.com/SdSarthak/AegisAI/blob/main/docs/architecture.md) · [API Reference](https://github.com/SdSarthak/AegisAI/blob/main/docs/api-reference.md) · [Guard Module](https://github.com/SdSarthak/AegisAI/blob/main/docs/guard-module.md) · [RAG Module](https://github.com/SdSarthak/AegisAI/blob/main/docs/rag-module.md) · [Regulations](https://github.com/SdSarthak/AegisAI/blob/main/docs/regulations.md) · [Report a Bug](https://github.com/SdSarthak/AegisAI/issues)
 
 </div>
 
@@ -93,7 +93,7 @@ LLM_BASE_URL=http://localhost:11434/v1
 LLM_MODEL=llama3.2
 ```
 
-Then `docker compose up -d`. See [Getting Started](docs/getting-started.md) for all provider options.
+Then `docker compose up -d`. See [Getting Started](https://github.com/SdSarthak/AegisAI/blob/main/docs/getting-started.md) for all provider options.
 
 ---
 


### PR DESCRIPTION
## Summary
Closes #499
Updates the broken relative documentation links in README.md to absolute GitHub URLs so they work correctly on the live FastAPI server interface.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Screenshots (if UI change)
No UI change — documentation link fix only.
<!-- Add before/after screenshots here -->
