### PR TITLE
docs: add module-level docstring to document model

### DIFF
--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -1,3 +1,13 @@
+"""
+Defines database models and enums for compliance documents.
+
+This module contains:
+- SQLAlchemy models for generated compliance documents
+- Document type and status enumerations
+- Metadata and lifecycle tracking fields
+- Relationships between documents and AI system records
+"""
+
 from sqlalchemy import Column, Integer, String, Text, DateTime, Enum, ForeignKey
 from sqlalchemy.orm import relationship
 from datetime import datetime


### PR DESCRIPTION
## Summary

Closes #288

Added a module-level docstring to `backend/app/models/document.py` describing:

* Document ORM models
* Document type and status enums
* Relationships between documents and AI system records

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [x] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [ ] I have added/updated tests where relevant
* [ ] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [x] I have updated documentation if needed

## Screenshots (if UI change)

N/A
