### PR TITLE
test: add basic tests for /health and / endpoints

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,49 @@
+"""
+Tests for root and health endpoints.
+"""
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import OperationalError
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_root_returns_expected_keys():
+    response = client.get("/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["project"] == "AegisAI"
+    assert "version" in data
+    assert "docs" in data
+    assert "modules" in data
+
+
+def test_root_modules_are_correct():
+    response = client.get("/")
+    data = response.json()
+    assert set(data["modules"]) == {"compliance", "guard", "rag"}
+
+
+def test_health_when_db_is_up():
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "healthy"
+    assert data["database"] == "connected"
+    assert data["service"] == "AegisAI Backend"
+    assert "version" in data
+
+
+def test_health_when_db_is_down():
+    with patch("app.main.engine") as mock_engine:
+        mock_engine.connect.side_effect = OperationalError(
+            "connection refused", {}, None
+        )
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "degraded"
+    assert data["database"] == "disconnected"


### PR DESCRIPTION
## Summary
Closes #532 

Adds basic pytest coverage for the `/` and `/health` endpoints in `backend/tests/test_main.py`. Tests cover the happy path and a mocked DB-down scenario for the health check.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Tests
- [ ] Infra / CI

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)
N/A — no UI changes