### PR TITLE
fix: clean guard info endpoint implementation

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -27,6 +27,7 @@ from app.api.v1.notifications import create_notification
 from app.models.notification import NotificationType
 from app.schemas.guard_scan_log import GuardScanLogResponse
 from app.schemas.pagination import PaginatedResponse
+from app.modules.guard import guard_config
 
 router = APIRouter()
 
@@ -161,6 +162,27 @@ class GuardConfigRequest(BaseModel):
     malicious_threshold: float
     suspicious_threshold: float
 
+@router.get("/info", tags=["LLM Guard"])
+def guard_info():
+    """Return diagnostic information about the Guard module."""
+
+    try:
+        import torch
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+    except ImportError:
+        device = "cpu"
+
+    from pathlib import Path
+
+    model_path = Path(guard_config.get_trained_model_path()).name
+
+    return {
+        "module": "llm_guard",
+        "status": "available",
+        "device": device,
+        "model_name": model_path or "pretrained-fallback",
+        "sanitization_level": guard_config.SANITIZATION_LEVEL,
+    }
 
 @router.get("/history", response_model=PaginatedResponse[GuardScanLogResponse])
 def get_guard_history(


### PR DESCRIPTION
## Summary
Adds a diagnostic `/guard/info` endpoint for the LLM Guard module.


Closes #29 

<!-- What does this PR do? 2-3 sentences. -->
This endpoint exposes runtime information such as:
- device availability (`cpu` / `cuda`)
- configured sanitization level
- active model name/path

Also cleans up the endpoint to avoid hardcoded model values and returns only the model directory name instead of the full local filesystem path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [x] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed


