### PR TITLE
fix: improve auth error messages

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -22,7 +22,7 @@ def _get_credentials_exception() -> HTTPException:
     """Helper to return a standardized 401 Unauthorized exception."""
     return HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Could not validate credentials",
+        detail="Token has expired. Please log in again.",
         headers={"WWW-Authenticate": "Bearer"},
     )
 


### PR DESCRIPTION
## Summary
Updated authentication error handling in `backend/app/core/security.py` to return clearer and more actionable 401/403 responses.
Closes #5 

<!-- What does this PR do? 2-3 sentences. -->
Instead of generic messages like "Could not validate credentials", users now receive a more specific message:
"Token has expired. Please log in again."
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed


