### PR TITLE
feat: implement static onboarding wizard UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -79,6 +79,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -443,6 +444,7 @@
     "node_modules/@codemirror/view": {
       "version": "6.42.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1204,9 +1206,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1221,9 +1220,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1238,9 +1234,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1255,9 +1248,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1272,9 +1262,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1289,9 +1276,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1306,9 +1290,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1323,9 +1304,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1340,9 +1318,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1357,9 +1332,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1374,9 +1346,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1391,9 +1360,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1408,9 +1374,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1620,6 +1583,7 @@
       "version": "18.3.28",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1676,6 +1640,7 @@
       "version": "6.21.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1897,6 +1862,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2096,6 +2062,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2299,7 +2266,8 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -2596,6 +2564,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3259,6 +3228,7 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3682,6 +3652,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3871,6 +3842,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3881,6 +3853,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3892,6 +3865,7 @@
     "node_modules/react-hook-form": {
       "version": "7.72.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4376,6 +4350,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4436,6 +4411,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4517,6 +4493,7 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import Analytics from './pages/Analytics'
 import NotFound from './pages/NotFound'
 import { Toaster } from 'react-hot-toast'
 import RagChat from './pages/RagChat'
+import Onboarding from './pages/Onboarding'
 
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
@@ -45,6 +46,7 @@ function App() {
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/onboarding" element={<Onboarding />} />
         <Route
           path="/"
           element={

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,7 +46,6 @@ function App() {
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
-        <Route path="/onboarding" element={<Onboarding />} />
         <Route
           path="/"
           element={
@@ -63,6 +62,7 @@ function App() {
           <Route path="rag-chat" element={<RagChat />} />
           <Route path="notifications" element={<Notifications />} />
           <Route path="rag-chat" element={<RagChat />} />
+          <Route path="onboarding" element={<Onboarding />} />
 
         </Route>
         <Route path="*" element={<NotFound />} />

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -67,9 +67,10 @@ export default function Onboarding() {
     })
   }
 
-  const handleNext = () => {
+  const handleNext = async () => {
     if (isLastStep) {
-      console.log('Onboarding Data:', formData)
+      // TODO: Replace with actual API call
+      // await aiSystemsApi.create(formData)
       navigate('/')
     } else {
       setCurrentStep((s) => s + 1)

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -44,13 +44,32 @@ const STEPS = [
 export default function Onboarding() {
   const navigate = useNavigate()
   const [currentStep, setCurrentStep] = useState(0)
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    sector: '',
+    use_case: '',
+    documentType: '',
+  })
 
-  // TODO (help wanted): replace with real form state per step
   const isLastStep = currentStep === STEPS.length - 1
+
+  const handleChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement |
+      HTMLTextAreaElement |
+      HTMLSelectElement
+    >
+  ) => {
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value,
+    })
+  }
 
   const handleNext = () => {
     if (isLastStep) {
-      // TODO (help wanted): mark onboarding complete via API before navigating
+      console.log('Onboarding Data:', formData)
       navigate('/')
     } else {
       setCurrentStep((s) => s + 1)
@@ -106,10 +125,75 @@ export default function Onboarding() {
           </div>
           <p className="text-gray-600 text-sm">{STEPS[currentStep].description}</p>
 
-          {/* TODO (good first issue): add step-specific form fields here */}
-          <div className="mt-6 p-4 bg-gray-50 rounded-lg border border-dashed border-gray-300 text-center text-sm text-gray-400">
-            Step {currentStep + 1} form fields — implement me
-          </div>
+          {/* Step 1 */}
+          {currentStep === 0 && (
+            <div className="mt-6 space-y-4">
+              <input
+                type="text"
+                name="name"
+                placeholder="System Name"
+                value={formData.name}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              />
+              <textarea
+                name="description"
+                placeholder="Description"
+                value={formData.description}
+                onChange={handleChange}
+                rows={4}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              />
+              <input
+                type="text"
+                name="sector"
+                placeholder="Sector"
+                value={formData.sector}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              />
+              <input
+                type="text"
+                name="use_case"
+                placeholder="Use Case"
+                value={formData.use_case}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              />
+            </div>
+          )}
+          {/* Step 2 */}
+          {currentStep === 1 && (
+            <div className="mt-6 p-4 rounded-lg border border-primary-200 bg-primary-50">
+              <p className="text-sm text-gray-700">
+                Classification will run automatically.
+              </p>
+            </div>
+          )}
+          {/* Step 3 */}
+          {currentStep === 2 && (
+            <div className="mt-6">
+              <select
+                name="documentType"
+                value={formData.documentType}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              >
+                <option value="">
+                  Select document type
+                </option>
+                <option value="risk_assessment">
+                  Risk Assessment
+                </option>
+                <option value="compliance_report">
+                  Compliance Report
+                </option>
+                <option value="audit_document">
+                  Audit Documentation
+                </option>
+              </select>
+            </div>
+          )}
         </div>
 
         {/* Navigation */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -53,6 +53,10 @@ export const authApi = {
     const { data } = await api.get('/auth/me')
     return data
   },
+  updateMe: async (userData: Record<string, unknown>) => {
+    const { data } = await api.patch('/auth/me', userData)
+    return data
+  },
 }
 
 // AI Systems API


### PR DESCRIPTION
## Summary

Closes #112

<!-- What does this PR do? 2-3 sentences. -->
Implemented the static onboarding wizard UI in `frontend/src/pages/Onboarding.tsx`.

This PR adds a 3-step onboarding flow with step indicators, step-specific content, navigation controls, and a finish redirect to the dashboard route. No API integration was added as per the issue requirements.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI


## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)

<!-- Add before/after screenshots here -->
### Step 1 — Register AI System
Added form inputs for:
- System Name
- Description
- Sector
- Use Case
<img width="404" height="509" alt="image" src="https://github.com/user-attachments/assets/f22cbf2f-f212-4b4c-b526-100a96d04868" />


### Step 2 — Run Classification
Added a static message:
- Classification will run automatically.

<img width="384" height="294" alt="image" src="https://github.com/user-attachments/assets/81f1825b-21d1-4696-8043-7ac318e3dbd1" />


### Step 3 — Generate Document
-Added a static document type selector dropdown.

<img width="462" height="372" alt="image" src="https://github.com/user-attachments/assets/28360ba1-1b63-43cf-88f9-a1d63e96050e" />


### Additional Features
- Active/completed/pending step indicator styles
- Back/Next navigation handling
- Finish button redirects to `/`
- Console logging for onboarding form data


