### PR TITLE
feat: add AI decision logging dashboard to Analytics

### DIFF
--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,17 +1,27 @@
-import { BarChart2, TrendingUp, AlertTriangle, ShieldCheck, Activity } from 'lucide-react'
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import {
-  LineChart,
-  Line,
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  Legend
+  BarChart2, TrendingUp, AlertTriangle, ShieldCheck,
+  Activity, CheckCircle, XCircle, Flag, Filter
+} from 'lucide-react'
+import {
+  LineChart, Line, BarChart, Bar,
+  XAxis, YAxis, CartesianGrid, Tooltip,
+  ResponsiveContainer, Legend
 } from 'recharts'
+import api from '../services/api'
 
+// ── Types ──────────────────────────────────────────────
+interface DecisionLog {
+  id: number
+  timestamp: string
+  prompt_preview: string
+  decision: 'allowed' | 'blocked' | 'flagged'
+  confidence: number
+  method: string
+}
+
+// ── Static chart data (replace with real API when available) ──
 const lineChartData = [
   { name: 'Jan', score: 65 },
   { name: 'Feb', score: 72 },
@@ -29,23 +39,67 @@ const barChartData = [
   { name: 'System E', risk: 20 },
 ]
 
-const summaryStats = [
-  { label: 'Total Systems', value: '12', icon: Activity, color: 'text-blue-600', bg: 'bg-blue-50' },
-  { label: 'Avg Score', value: '84%', icon: TrendingUp, color: 'text-green-600', bg: 'bg-green-50' },
-  { label: 'Compliant', value: '10', icon: ShieldCheck, color: 'text-emerald-600', bg: 'bg-emerald-50' },
-  { label: 'High Risk', value: '2', icon: AlertTriangle, color: 'text-red-600', bg: 'bg-red-50' },
-]
+// ── Decision badge ─────────────────────────────────────
+function DecisionBadge({ decision }: { decision: DecisionLog['decision'] }) {
+  if (decision === 'allowed')
+    return (
+      <span className="flex items-center gap-1 text-xs font-medium text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full">
+        <CheckCircle className="w-3 h-3" /> Allowed
+      </span>
+    )
+  if (decision === 'blocked')
+    return (
+      <span className="flex items-center gap-1 text-xs font-medium text-red-700 bg-red-50 px-2 py-0.5 rounded-full">
+        <XCircle className="w-3 h-3" /> Blocked
+      </span>
+    )
+  return (
+    <span className="flex items-center gap-1 text-xs font-medium text-yellow-700 bg-yellow-50 px-2 py-0.5 rounded-full">
+      <Flag className="w-3 h-3" /> Flagged
+    </span>
+  )
+}
 
+// ── Main component ─────────────────────────────────────
 export default function Analytics() {
+  const [filter, setFilter] = useState<'all' | 'allowed' | 'blocked' | 'flagged'>('all')
+
+  // Fetch guard audit logs — falls back to empty array gracefully
+  const { data: logs = [], isLoading } = useQuery<DecisionLog[]>({
+    queryKey: ['guard-logs'],
+    queryFn: async () => {
+      try {
+        const { data } = await api.get('/guard/logs')
+        return data
+      } catch {
+        return []
+      }
+    },
+  })
+
+  const filtered = filter === 'all' ? logs : logs.filter((l) => l.decision === filter)
+
+  const counts = {
+    allowed: logs.filter((l) => l.decision === 'allowed').length,
+    blocked: logs.filter((l) => l.decision === 'blocked').length,
+    flagged: logs.filter((l) => l.decision === 'flagged').length,
+  }
+
+  const summaryStats = [
+    { label: 'Total Scans', value: logs.length, icon: Activity, color: 'text-blue-600', bg: 'bg-blue-50' },
+    { label: 'Allowed', value: counts.allowed, icon: ShieldCheck, color: 'text-emerald-600', bg: 'bg-emerald-50' },
+    { label: 'Blocked', value: counts.blocked, icon: AlertTriangle, color: 'text-red-600', bg: 'bg-red-50' },
+    { label: 'Flagged', value: counts.flagged, icon: Flag, color: 'text-yellow-600', bg: 'bg-yellow-50' },
+  ]
+
   return (
     <div className="space-y-8">
-      {/* Header */}
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Analytics</h1>
-        <p className="text-gray-600">Compliance score trends and risk analysis</p>
+        <p className="text-gray-600">Compliance trends, risk analysis, and AI decision logs</p>
       </div>
 
-      {/* Summary stats row */}
+      {/* Summary Stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
         {summaryStats.map((stat) => (
           <div key={stat.label} className="bg-white rounded-xl border border-gray-200 p-6 flex items-center gap-4 shadow-sm">
@@ -60,9 +114,8 @@ export default function Analytics() {
         ))}
       </div>
 
-      {/* Charts area */}
+      {/* Charts */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Line Chart */}
         <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm min-w-0">
           <div className="flex items-center gap-2 mb-6">
             <TrendingUp className="w-5 h-5 text-primary-600" />
@@ -74,9 +127,7 @@ export default function Analytics() {
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e5e7eb" />
                 <XAxis dataKey="name" stroke="#6b7280" fontSize={12} tickLine={false} axisLine={false} />
                 <YAxis stroke="#6b7280" fontSize={12} tickLine={false} axisLine={false} />
-                <Tooltip
-                  contentStyle={{ backgroundColor: '#fff', borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)' }}
-                />
+                <Tooltip contentStyle={{ backgroundColor: '#fff', borderRadius: '8px', border: '1px solid #e5e7eb' }} />
                 <Legend iconType="circle" wrapperStyle={{ fontSize: '12px' }} />
                 <Line type="monotone" dataKey="score" name="Avg Score" stroke="#0ea5e9" strokeWidth={3} activeDot={{ r: 6 }} />
               </LineChart>
@@ -84,7 +135,6 @@ export default function Analytics() {
           </div>
         </div>
 
-        {/* Bar Chart */}
         <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm min-w-0">
           <div className="flex items-center gap-2 mb-6">
             <BarChart2 className="w-5 h-5 text-primary-600" />
@@ -96,16 +146,90 @@ export default function Analytics() {
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e5e7eb" />
                 <XAxis dataKey="name" stroke="#6b7280" fontSize={12} tickLine={false} axisLine={false} />
                 <YAxis stroke="#6b7280" fontSize={12} tickLine={false} axisLine={false} />
-                <Tooltip
-                  contentStyle={{ backgroundColor: '#fff', borderRadius: '8px', border: '1px solid #e5e7eb', boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)' }}
-                  cursor={{ fill: '#f3f4f6' }}
-                />
+                <Tooltip contentStyle={{ backgroundColor: '#fff', borderRadius: '8px', border: '1px solid #e5e7eb' }} cursor={{ fill: '#f3f4f6' }} />
                 <Legend iconType="circle" wrapperStyle={{ fontSize: '12px' }} />
                 <Bar dataKey="risk" name="Risk Score" fill="#f43f5e" radius={[4, 4, 0, 0]} maxBarSize={40} />
               </BarChart>
             </ResponsiveContainer>
           </div>
         </div>
+      </div>
+
+      {/* Decision Log Table */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+        <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
+          <div className="flex items-center gap-2">
+            <Activity className="w-5 h-5 text-primary-600" />
+            <h2 className="font-semibold text-gray-900">AI Decision Log</h2>
+          </div>
+          {/* Filter */}
+          <div className="flex items-center gap-2">
+            <Filter className="w-4 h-4 text-gray-400" />
+            {(['all', 'allowed', 'blocked', 'flagged'] as const).map((f) => (
+              <button
+                key={f}
+                onClick={() => setFilter(f)}
+                className={`text-xs px-3 py-1 rounded-full font-medium capitalize transition-colors ${
+                  filter === f
+                    ? 'bg-primary-600 text-white'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                {f}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-3">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="h-12 bg-gray-100 rounded-lg animate-pulse" />
+            ))}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-12 text-gray-400">
+            <Activity className="w-10 h-10 mx-auto mb-2 opacity-30" />
+            <p className="text-sm">
+              {logs.length === 0
+                ? 'No decision logs yet — scan a prompt in LLM Guard to populate this table.'
+                : 'No logs match this filter.'}
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-100 text-left text-xs text-gray-500 uppercase tracking-wide">
+                  <th className="pb-3 pr-4">Timestamp</th>
+                  <th className="pb-3 pr-4">Prompt Preview</th>
+                  <th className="pb-3 pr-4">Decision</th>
+                  <th className="pb-3 pr-4">Confidence</th>
+                  <th className="pb-3">Method</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {filtered.map((log) => (
+                  <tr key={log.id} className="hover:bg-gray-50 transition-colors">
+                    <td className="py-3 pr-4 text-gray-500 whitespace-nowrap">
+                      {new Date(log.timestamp).toLocaleString()}
+                    </td>
+                    <td className="py-3 pr-4 text-gray-800 max-w-xs truncate">
+                      {log.prompt_preview}
+                    </td>
+                    <td className="py-3 pr-4">
+                      <DecisionBadge decision={log.decision} />
+                    </td>
+                    <td className="py-3 pr-4 text-gray-600">
+                      {(log.confidence * 100).toFixed(1)}%
+                    </td>
+                    <td className="py-3 text-gray-500 capitalize">{log.method}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
Enhances the Analytics page with an interactive AI decision logging dashboard for better traceability of Guard scan decisions.

## Changes
- Updated `frontend/src/pages/Analytics.tsx`
- Added decision log table displaying allowed, blocked, and flagged actions
- Filter buttons to narrow logs by decision type
- Timestamps, prompt preview, confidence score, and method columns
- Summary stats row updated to reflect Guard scan counts
- Graceful empty state when no logs exist yet or backend endpoint unavailable
- Existing compliance score and risk distribution charts retained

## Alternatives Considered
- Simple log file viewer — rejected (poor usability)
- CLI-based inspection — rejected (not beginner-friendly)  
- External monitoring tools — rejected (unnecessary dependency)

Closes #447 