### PR TITLE
fix: add bcrypt password length validation

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -28,29 +28,42 @@ def _get_credentials_exception() -> HTTPException:
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verify a plain password against its hashed version."""
+
+    if len(plain_password.encode("utf-8")) > 72:
+        raise ValueError("Password cannot be longer than 72 bytes for bcrypt.")
+
     return pwd_context.verify(plain_password, hashed_password)
 
 
 def get_password_hash(password: str) -> str:
     """Securely hash a password using bcrypt."""
+
+    if len(password.encode("utf-8")) > 72:
+        raise ValueError("Password cannot be longer than 72 bytes for bcrypt.")
+
     return pwd_context.hash(password)
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     """Create a JWT access token with an expiration payload."""
     to_encode = data.copy()
-    
+
     # Use timezone-aware UTC datetime to prevent standard library deprecation warnings
     now = datetime.now(timezone.utc)
+
     if expires_delta:
         expire = now + expires_delta
     else:
         expire = now + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-        
+
     to_encode.update({"exp": expire})
+
     encoded_jwt = jwt.encode(
-        to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM
+        to_encode,
+        settings.SECRET_KEY,
+        algorithm=settings.ALGORITHM
     )
+
     return encoded_jwt
 
 
@@ -58,35 +71,41 @@ def decode_token(token: str) -> Dict[str, Any]:
     """Decode and verify a JWT token, returning the payload safely."""
     try:
         payload = jwt.decode(
-            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+            token,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM]
         )
         return payload
+
     except JWTError:
         raise _get_credentials_exception()
 
 
 async def get_current_user(
-    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+    token: str = Depends(oauth2_scheme),
+    db: Session = Depends(get_db)
 ) -> "User":
     """Dependency to get the current authenticated user from a JWT."""
+
     from app.models.user import User  # Local import to avoid circular dependencies
 
     payload = decode_token(token)
+
     user_id_str: Optional[str] = payload.get("sub")
 
     if not user_id_str:
         raise _get_credentials_exception()
 
-    # Defensively handle malformed or non-integer 'sub' claims
+    # Handle malformed or non-integer sub claims
     try:
         user_id = int(user_id_str)
+
     except (ValueError, TypeError):
         raise _get_credentials_exception()
 
     user = db.query(User).filter(User.id == user_id).first()
+
     if not user:
-        # Standardized to 401 generic failure instead of a distinct "User not found" 401
-        # to prevent user enumeration attacks via valid-but-orphaned tokens.
         raise _get_credentials_exception()
 
     return user


### PR DESCRIPTION
## Description

Added password length validation before bcrypt hashing and verification to prevent runtime exceptions when passwords exceed bcrypt's 72-byte limit.

## Changes Made

* Added validation in `get_password_hash()`
* Added validation in `verify_password()`
* Prevents bcrypt runtime crashes for long passwords

## Type of Change

* [x] Bug fix

## Issue

Fixes #419
