### PR TITLE
Feat: implement Article 5 UNACCEPTABLE risk classification

### DIFF
--- a/backend/app/api/v1/classification.py
+++ b/backend/app/api/v1/classification.py
@@ -17,6 +17,31 @@ from app.schemas.ai_system import (
 router = APIRouter()
 
 QUESTIONNAIRE_RISK_FACTORS: List[QuestionnaireRiskFactor] = [
+    # Article 5 — Prohibited practices (checked first)
+    QuestionnaireRiskFactor(
+        id="social_scoring",
+        question="Is the system used by a public authority to evaluate or classify individuals based on their social behaviour or personal characteristics?",
+        article="Article 5(1)(c)",
+        triggers_level=RiskLevel.UNACCEPTABLE,
+    ),
+    QuestionnaireRiskFactor(
+        id="realtime_biometric_public",
+        question="Does the system perform real-time remote biometric identification of individuals in publicly accessible spaces?",
+        article="Article 5(1)(h)",
+        triggers_level=RiskLevel.UNACCEPTABLE,
+    ),
+    QuestionnaireRiskFactor(
+        id="subliminal_manipulation",
+        question="Does the system use subliminal techniques or manipulative methods that impair a person's ability to make free decisions, causing them harm?",
+        article="Article 5(1)(a)",
+        triggers_level=RiskLevel.UNACCEPTABLE,
+    ),
+    QuestionnaireRiskFactor(
+        id="exploits_vulnerable_groups",
+        question="Does the system exploit vulnerabilities of specific groups such as children, elderly, or persons with disabilities to distort their behaviour in a harmful way?",
+        article="Article 5(1)(b)",
+        triggers_level=RiskLevel.UNACCEPTABLE,
+    ),
     QuestionnaireRiskFactor(
         id="is_safety_component",
         question="Is the AI system used as a safety component of a product or system?",
@@ -124,20 +149,6 @@ class BulkClassificationResponse(BaseModel):
     results: List[BulkClassificationItem]
 
 
-class BulkClassificationItem(BaseModel):
-    system_id: int
-    classification: Optional[RiskClassificationResponse] = None
-    error: Optional[str] = None
-
-
-class BulkClassificationRequest(BaseModel):
-    system_ids: List[int]
-
-
-class BulkClassificationResponse(BaseModel):
-    results: List[BulkClassificationItem]
-
-
 def classify_risk(data: RiskClassificationRequest) -> RiskClassificationResponse:
     """
     Classify the risk level of an AI system based on EU AI Act criteria.
@@ -147,10 +158,41 @@ def classify_risk(data: RiskClassificationRequest) -> RiskClassificationResponse
     risk_level = RiskLevel.MINIMAL
     confidence = 0.9
 
-    # Check for UNACCEPTABLE risk (Article 5 - Prohibited practices)
-    # Social scoring, real-time biometric identification in public spaces, etc.
-    # These are typically banned outright
+    # ----------------------------------------------------------------
+    # Article 5 — Prohibited practices (UNACCEPTABLE risk)
+    # These must be checked first — they override all other categories
+    # ----------------------------------------------------------------
+    prohibited_flags = {
+        "social_scoring": "Social scoring by public authorities (Article 5(1)(c))",
+        "realtime_biometric_public": "Real-time remote biometric identification in public spaces (Article 5(1)(h))",
+        "subliminal_manipulation": "Subliminal manipulation of behaviour (Article 5(1)(a))",
+        "exploits_vulnerable_groups": "Exploitation of vulnerabilities of specific groups (Article 5(1)(b))",
+    }
 
+    triggered_prohibitions = [
+        label for field, label in prohibited_flags.items()
+        if getattr(data, field, False)
+    ]
+
+    if triggered_prohibitions:
+        risk_level = RiskLevel.UNACCEPTABLE
+        reasons.extend(triggered_prohibitions)
+        requirements.append(
+            "This AI system is prohibited under Article 5 of the EU AI Act "
+            "and must not be placed on the market, put into service, or used."
+        )
+        return RiskClassificationResponse(
+            risk_level=risk_level,
+            confidence=0.99,
+            reasons=reasons,
+            requirements=requirements,
+            next_steps=[
+                "Immediately cease development or deployment of this system.",
+                "Consult legal counsel regarding Article 5 compliance obligations.",
+                "Review whether any Article 5 exceptions apply to your use case.",
+            ],
+        )
+    
     # Check for HIGH risk (Article 6 + Annex III)
     high_risk_indicators = []
 
@@ -198,6 +240,20 @@ def classify_risk(data: RiskClassificationRequest) -> RiskClassificationResponse
             "Use in law enforcement, border control, or justice is HIGH risk"
         )
 
+    # Biometric data usage (Annex III)           
+    if data.uses_biometric_data:
+        high_risk_indicators.append("Uses biometric data")
+        reasons.append(
+            "System uses biometric data for identification, verification, or categorization (Annex III)"
+        )
+
+    # Automated decisions without human review (Article 6 / Annex III)
+    if data.makes_automated_decisions:
+        high_risk_indicators.append("Automated decisions without human review")
+        reasons.append(
+            "System makes automated decisions without meaningful human oversight (Article 6)"
+        )    
+
     # Determine if HIGH risk
     if high_risk_indicators:
         risk_level = RiskLevel.HIGH
@@ -207,6 +263,7 @@ def classify_risk(data: RiskClassificationRequest) -> RiskClassificationResponse
         data.interacts_with_humans
         or data.emotion_recognition
         or data.generates_synthetic_content
+        or data.biometric_categorization
     ):
         risk_level = RiskLevel.LIMITED
         if data.interacts_with_humans:
@@ -220,6 +277,11 @@ def classify_risk(data: RiskClassificationRequest) -> RiskClassificationResponse
         if data.generates_synthetic_content:
             reasons.append("System generates synthetic/manipulated content")
             requirements.append("Label AI-generated content appropriately")
+        if data.biometric_categorization:   
+            reasons.append("System performs biometric categorization")
+            requirements.append(
+                "Inform subjects about biometric categorization (Article 52)"
+            )
 
     # MINIMAL risk - no specific requirements
     else:
@@ -385,7 +447,7 @@ def bulk_classify_systems(
         result = classify_risk(classification_data)
         system.risk_level = result.risk_level
         system.compliance_status = ComplianceStatus.IN_PROGRESS
-        system.questionnaire_responses = system.questionnaire_responses
+        system.questionnaire_responses = classification_data.model_dump()
 
         assessment = RiskAssessment(
             ai_system_id=system.id,
@@ -407,16 +469,4 @@ def bulk_classify_systems(
     db.commit()
     return BulkClassificationResponse(results=results)
 
-    
-@router.get("/risk-factors", response_model=List[QuestionnaireRiskFactor])
-def get_questionnaire_risk_factors(
-    current_user: User = Depends(get_current_user),
-):
-    """
-    Return the static questionnaire metadata used by the risk classification flow.
 
-    This does not query the database because these factors describe the
-    classification rules themselves, not a user's saved questionnaire answers.
-    Keep this list aligned with RiskClassificationRequest and classify_risk().
-    """
-    return QUESTIONNAIRE_RISK_FACTORS

--- a/backend/app/schemas/ai_system.py
+++ b/backend/app/schemas/ai_system.py
@@ -42,6 +42,16 @@ class AISystemResponse(BaseModel):
 class RiskClassificationRequest(BaseModel):
     """Questionnaire for EU AI Act risk classification."""
 
+    # Prohibited practices (Article 5) — checked first
+    social_scoring: bool = False
+    # AI used by public authorities to evaluate/classify people based on social behaviour
+    realtime_biometric_public: bool = False
+    # Real-time remote biometric identification in publicly accessible spaces
+    subliminal_manipulation: bool = False
+    # Techniques that manipulate behaviour subliminally causing harm
+    exploits_vulnerable_groups: bool = False
+    # Targets or exploits vulnerabilities of specific groups (age, disability, etc.)
+
     # Basic use case
     use_case_category: str  # "hr_recruitment", "credit_scoring", "healthcare", etc.
 


### PR DESCRIPTION
## Summary
Closes #446 

`classify_risk()` never returned `RiskLevel.UNACCEPTABLE` despite the enum value and a placeholder comment existing. Any AI system prohibited under Article 5 (social scoring, real-time biometric surveillance, subliminal manipulation, exploitation of vulnerable groups) was silently misclassified as HIGH risk. This PR implements the full Article 5 check as the first
classification step with an early return before other risk tiers are evaluated.

Also fixes three additional bugs found in the same file:
- `uses_biometric_data`, `makes_automated_decisions`, and `biometric_categorization` were present in the questionnaire but silently ignored in `classify_risk()`
- `bulk_classify_systems` had a no-op self-assignment that prevented questionnaire responses from being saved during bulk classification
- Duplicate class definitions and a duplicate route registration are removed

## Type of Change
- [x] Bug fix
- [x] New feature

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

**Suggested labels:** `ggsoc'26` `enhancement` `module: compliance` 
