### PR TITLE
fix: remove dead rag query response path

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -204,7 +204,6 @@ def query_knowledge_base(
             pass
 
         return RAGQueryResponse(answer=answer, sources=sources, answer_id=feedback.id)
-        return RAGQueryResponse(answer=result["result"], sources=sources, answer_id=answer_id)
     except FileNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,


### PR DESCRIPTION
## Summary
- remove the stale second `RAGQueryResponse` return in `POST /api/v1/rag/query`
- eliminate the dead path that still referenced undefined `answer_id`
- keep the persisted `feedback.id` response path as the single return path

## Validation
- `python3 -m py_compile backend/app/api/v1/rag.py`
- targeted pytest run was attempted, but this local clone is missing backend test dependencies like `sqlalchemy`, so the test suite could not be executed in this environment
- `git diff --check`

Closes #562