### PR TITLE
feat: add Jira and Linear integration for high-risk AI systems (#89)

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
-from app.api.v1 import auth, ai_systems, documents, classification, guard, rag, badge, analytics, notifications, webhooks
+from app.api.v1 import auth, ai_systems, documents, classification, guard, rag, badge, analytics, notifications, webhooks, integrations
+
 
 api_router = APIRouter()
 
@@ -15,3 +16,4 @@ api_router.include_router(rag.router, prefix="/rag", tags=["RAG Intelligence"])
 api_router.include_router(analytics.router, prefix="/analytics", tags=["Analytics"])
 api_router.include_router(notifications.router, prefix="/notifications", tags=["Notifications"])
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["Webhooks"])
+api_router.include_router(integrations.router, prefix="/integrations", tags=["Integrations"])

--- a/backend/app/api/v1/classification.py
+++ b/backend/app/api/v1/classification.py
@@ -7,6 +7,9 @@ from pydantic import BaseModel
 from app.core.database import get_db
 from app.core.security import get_current_user
 from app.models.user import User
+from app.models.integration import UserIntegration, IntegrationType
+from app.modules.integrations.jira_client import JiraClient
+from app.modules.integrations.linear_client import LinearClient
 from app.models.ai_system import AISystem, RiskLevel, RiskAssessment, ComplianceStatus
 from app.schemas.ai_system import (
     RiskClassificationRequest,
@@ -273,7 +276,7 @@ def classify_ai_system(
 
 
 @router.post("/classify/{system_id}", response_model=RiskClassificationResponse)
-def classify_and_save(
+async def classify_and_save(
     system_id: int,
     data: RiskClassificationRequest,
     db: Session = Depends(get_db),
@@ -314,6 +317,37 @@ def classify_and_save(
         overall_score=70 if result.risk_level == RiskLevel.MINIMAL else 30,
     )
     db.add(assessment)
+    # Auto-create tickets if HIGH or UNACCEPTABLE
+    if result.risk_level in (RiskLevel.HIGH, RiskLevel.UNACCEPTABLE):
+        gaps = result.requirements
+        integrations = db.query(UserIntegration).filter_by(user_id=current_user.id).all()
+
+        for integration in integrations:
+            for gap in gaps:
+                title = f"[AegisAI] {system.name}: {gap[:80]}"
+                description = (
+                    f"System: {system.name}\n"
+                    f"Risk Level: {result.risk_level.value.upper()}\n"
+                    f"Compliance Gap: {gap}\n"
+                    f"EU AI Act Reference: See AegisAI dashboard for full details."
+                )
+                try:
+                    if integration.integration_type == IntegrationType.jira:
+                        client = JiraClient(
+                            base_url=integration.base_url,
+                            email=integration.email,
+                            api_token=integration.api_token,
+                            project_key=integration.project_key,
+                        )
+                        await client.create_issue(title, description)
+                    elif integration.integration_type == IntegrationType.linear:
+                        client = LinearClient(
+                            api_key=integration.api_token,
+                            team_id=integration.project_key,
+                        )
+                        await client.create_issue(title, description)
+                except Exception:
+                    pass  # Don't fail classification if ticket creation fails
 
     db.commit()
     db.refresh(system)

--- a/backend/app/api/v1/integrations.py
+++ b/backend/app/api/v1/integrations.py
@@ -1,0 +1,79 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.models.user import User
+from app.models.integration import UserIntegration, IntegrationType
+from app.schemas.integration import JiraIntegrationCreate, LinearIntegrationCreate, IntegrationResponse
+from app.modules.integrations.jira_client import JiraClient
+from app.modules.integrations.linear_client import LinearClient
+
+router = APIRouter()
+
+
+@router.post("/jira", response_model=IntegrationResponse)
+async def save_jira_integration(
+    data: JiraIntegrationCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    existing = db.query(UserIntegration).filter_by(
+        user_id=current_user.id, integration_type=IntegrationType.jira
+    ).first()
+
+    if existing:
+        existing.base_url = data.base_url
+        existing.email = data.email
+        existing.api_token = data.api_token
+        existing.project_key = data.project_key
+    else:
+        existing = UserIntegration(
+            user_id=current_user.id,
+            integration_type=IntegrationType.jira,
+            base_url=data.base_url,
+            email=data.email,
+            api_token=data.api_token,
+            project_key=data.project_key,
+        )
+        db.add(existing)
+
+    db.commit()
+    db.refresh(existing)
+    return existing
+
+
+@router.post("/linear", response_model=IntegrationResponse)
+async def save_linear_integration(
+    data: LinearIntegrationCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    existing = db.query(UserIntegration).filter_by(
+        user_id=current_user.id, integration_type=IntegrationType.linear
+    ).first()
+
+    if existing:
+        existing.api_token = data.api_key
+        existing.project_key = data.team_id
+    else:
+        existing = UserIntegration(
+            user_id=current_user.id,
+            integration_type=IntegrationType.linear,
+            api_token=data.api_key,
+            project_key=data.team_id,
+        )
+        db.add(existing)
+
+    db.commit()
+    db.refresh(existing)
+    return existing
+
+
+@router.get("/", response_model=List[IntegrationResponse])
+def get_integrations(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return db.query(UserIntegration).filter_by(user_id=current_user.id).all()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,4 +7,5 @@ from app.models.guard_scan_log import GuardScanLog
 from app.models.webhook import WebhookConfig
 from app.models.notification import Notification                      
 from app.models.compliance_snapshot import ComplianceSnapshot
+from app.models.integration import UserIntegration
 __all__ = ["User", "AISystem", "RiskAssessment", "Document", "RAGFeedback", "AISystemAuditLog", "GuardScanLog", "WebhookConfig", "Notification", "ComplianceSnapshot"]

--- a/backend/app/models/integration.py
+++ b/backend/app/models/integration.py
@@ -1,0 +1,26 @@
+from sqlalchemy import Column, Integer, String, Enum, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from datetime import datetime
+import enum
+from app.core.database import Base
+
+
+class IntegrationType(str, enum.Enum):
+    jira = "jira"
+    linear = "linear"
+
+
+class UserIntegration(Base):
+    __tablename__ = "user_integrations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    integration_type = Column(Enum(IntegrationType), nullable=False)
+    base_url = Column(String(512), nullable=True)   # Jira only
+    email = Column(String(255), nullable=True)       # Jira only
+    api_token = Column(String(512), nullable=False)  # Jira: API token, Linear: API key
+    project_key = Column(String(255), nullable=True) # Jira: project key, Linear: team ID
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user = relationship("User", back_populates="integrations")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -39,3 +39,4 @@ class User(Base):
     documents = relationship("Document", back_populates="owner")
     webhook_configs = relationship("WebhookConfig", back_populates="user")
     notifications    = relationship("Notification",    back_populates="user")
+    integrations = relationship("UserIntegration", back_populates="user")

--- a/backend/app/modules/integrations/jira_client.py
+++ b/backend/app/modules/integrations/jira_client.py
@@ -1,0 +1,40 @@
+import base64
+import httpx
+
+
+class JiraClient:
+    def __init__(self, base_url: str, email: str, api_token: str, project_key: str):
+        self.base_url = base_url.rstrip("/")
+        self.project_key = project_key
+        token = base64.b64encode(f"{email}:{api_token}".encode()).decode()
+        self.headers = {
+            "Authorization": f"Basic {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def create_issue(self, summary: str, description: str) -> dict:
+        payload = {
+            "fields": {
+                "project": {"key": self.project_key},
+                "summary": summary,
+                "description": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [{"type": "paragraph", "content": [{"type": "text", "text": description}]}],
+                },
+                "issuetype": {"name": "Task"},
+            }
+        }
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(
+                f"{self.base_url}/rest/api/3/issue",
+                json=payload,
+                headers=self.headers,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return {
+                "ticket_id": data.get("key"),
+                "ticket_url": f"{self.base_url}/browse/{data.get('key')}",
+            }

--- a/backend/app/modules/integrations/linear_client.py
+++ b/backend/app/modules/integrations/linear_client.py
@@ -1,0 +1,39 @@
+import httpx
+
+LINEAR_API_URL = "https://api.linear.app/graphql"
+
+
+class LinearClient:
+    def __init__(self, api_key: str, team_id: str):
+        self.team_id = team_id
+        self.headers = {
+            "Authorization": api_key,
+            "Content-Type": "application/json",
+        }
+
+    async def create_issue(self, title: str, description: str) -> dict:
+        query = """
+        mutation CreateIssue($title: String!, $description: String, $teamId: String!) {
+          issueCreate(input: {title: $title, description: $description, teamId: $teamId}) {
+            success
+            issue { id title url }
+          }
+        }
+        """
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(
+                LINEAR_API_URL,
+                json={"query": query, "variables": {
+                    "title": title,
+                    "description": description,
+                    "teamId": self.team_id,
+                }},
+                headers=self.headers,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            issue = data.get("data", {}).get("issueCreate", {}).get("issue", {})
+            return {
+                "ticket_id": issue.get("id"),
+                "ticket_url": issue.get("url"),
+            }

--- a/backend/app/schemas/integration.py
+++ b/backend/app/schemas/integration.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+from app.models.integration import IntegrationType
+
+
+class JiraIntegrationCreate(BaseModel):
+    base_url: str
+    email: str
+    api_token: str
+    project_key: str
+
+
+class LinearIntegrationCreate(BaseModel):
+    api_key: str
+    team_id: str
+
+
+class IntegrationResponse(BaseModel):
+    id: int
+    integration_type: IntegrationType
+    base_url: Optional[str] = None
+    email: Optional[str] = None
+    project_key: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
Closes #89

## What's changed

- Added `UserIntegration` model to store per-user Jira/Linear credentials
- Added `POST /api/v1/integrations/jira` save Jira integration settings
- Added `POST /api/v1/integrations/linear` save Linear integration settings  
- Added `GET /api/v1/integrations/` list user's integrations
- Auto-creates tickets in Jira/Linear when a system is classified HIGH or UNACCEPTABLE
- Each compliance gap maps to a separate ticket

## Files added
- `backend/app/models/integration.py`
- `backend/app/schemas/integration.py`
- `backend/app/modules/integrations/jira_client.py`
- `backend/app/modules/integrations/linear_client.py`
- `backend/app/api/v1/integrations.py`

## Files modified
- `backend/app/models/__init__.py` registered `UserIntegration`
- `backend/app/models/user.py` added `integrations` relationship
- `backend/app/api/v1/__init__.py` registered integrations router
- `backend/app/api/v1/classification.py` trigger ticket creation on HIGH/UNACCEPTABLE classification

## Testing
- Tested via Swagger UI
- `POST /api/v1/integrations/jira` ✅
- `POST /api/v1/integrations/linear` ✅
- `GET /api/v1/integrations/` ✅


> Note: Lint error in `RagChat.tsx` is a pre-existing issue unrelated to this PR (frontend file not modified in this PR).