### PR TITLE
docs: add environment variables reference table to README (#531)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,72 @@ Then `docker compose up -d`. See [Getting Started](docs/getting-started.md) for 
 
 ---
 
+## ⚙️ Environment Variables
+
+Copy `backend/.env.example` to `backend/.env` before starting. Below is a full reference for every variable:
+
+### 🔧 App
+| Variable | Description | Required | Default |
+|---|---|---|---|
+| `APP_NAME` | Application name | No | `AegisAI` |
+| `DEBUG` | Enable debug mode | No | `true` |
+| `API_V1_PREFIX` | API route prefix | No | `/api/v1` |
+
+### 🗄️ Database
+| Variable | Description | Required | Example |
+|---|---|---|---|
+| `DATABASE_URL` | PostgreSQL connection string | **Yes** | `postgresql://postgres:postgres@localhost:5432/aegisai_db` |
+
+### 🔐 Authentication
+| Variable | Description | Required | Example |
+|---|---|---|---|
+| `SECRET_KEY` | JWT signing secret — generate with `openssl rand -hex 32` | **Yes** | `a3f9...` |
+| `ALGORITHM` | JWT signing algorithm | No | `HS256` |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | Token expiry duration in minutes | No | `30` |
+
+### 🤖 LLM Provider
+| Variable | Description | Required | Example |
+|---|---|---|---|
+| `LLM_API_KEY` | API key for your LLM provider | **Yes** | `sk-...` |
+| `LLM_BASE_URL` | Custom LLM endpoint — leave empty for OpenAI | No | `http://localhost:11434/v1` |
+| `LLM_MODEL` | Model name to use | No | `gpt-4o-mini` |
+
+> **Supported providers:**
+> - **OpenAI** (default): set `LLM_API_KEY=sk-...`, leave `LLM_BASE_URL` empty
+> - **Ollama** (free/local): set `LLM_API_KEY=ollama`, `LLM_BASE_URL=http://localhost:11434/v1`, `LLM_MODEL=llama3.2`
+> - **Groq** (free tier): set `LLM_API_KEY=gsk_...`, `LLM_BASE_URL=https://api.groq.com/openai/v1`, `LLM_MODEL=llama-3.3-70b-versatile`
+
+### 🛡️ LLM Guard Module
+| Variable | Description | Required | Default |
+|---|---|---|---|
+| `GUARD_SANITIZATION_LEVEL` | Sanitization strictness: `low`, `medium`, or `high` | No | `medium` |
+| `GUARD_MAX_PROMPT_LENGTH` | Maximum allowed prompt length in characters | No | `2000` |
+
+### 📚 RAG Intelligence Module
+| Variable | Description | Required | Default |
+|---|---|---|---|
+| `S3_BUCKET_NAME` | S3 bucket name for document storage | No | — |
+| `FAISS_INDEX_PATH` | Local path to store the FAISS vector index | No | `faiss_index` |
+| `RAG_CHUNK_SIZE` | Document chunk size for indexing | No | `1000` |
+| `RAG_CHUNK_OVERLAP` | Overlap between consecutive chunks | No | `200` |
+
+### 📊 MLflow Tracking
+| Variable | Description | Required | Default |
+|---|---|---|---|
+| `MLFLOW_TRACKING_URI` | MLflow server URI. Leave empty to store runs locally in `./mlruns` | No | — |
+
+### 💳 Stripe (Optional — leave blank to run without billing)
+| Variable | Description | Required |
+|---|---|---|
+| `STRIPE_SECRET_KEY` | Stripe secret key | No |
+| `STRIPE_PUBLISHABLE_KEY` | Stripe publishable key | No |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret | No |
+| `STRIPE_PRICE_STARTER` | Price ID for Starter plan | No |
+| `STRIPE_PRICE_GROWTH` | Price ID for Growth plan | No |
+| `STRIPE_PRICE_SCALE` | Price ID for Scale plan | No |
+
+---
+
 ## 📓 Colab Notebooks
 
 If you want to train the machine learning models yourself, you can run our official Google Colab notebooks on a free T4 GPU:


### PR DESCRIPTION
## Summary

Closes #531

Adds a comprehensive Environment Variables reference section to README.md so contributors can understand every variable without digging through the codebase.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Changes Made
- Documented all variables from `.env.example` with descriptions, required status, and default/example values
- Grouped by module: App, Database, Auth, LLM Provider, Guard, RAG, MLflow, Stripe
- Added LLM provider quick-reference (OpenAI / Ollama / Groq)
- Placed section after Quick Start for natural reading flow