### PR TITLE
Add API route docstrings

### DIFF
--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -30,7 +30,16 @@ def create_ai_system(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Create a new AI system for compliance tracking."""
+    """Create a new AI system for compliance tracking.
+
+    Args:
+        system_data: AI system creation payload.
+        db: Database session used to persist the new system.
+        current_user: Authenticated user who will own the new system.
+
+    Returns:
+        The created AI system serialized as AISystemResponse.
+    """
     ai_system = AISystem(
         owner_id=current_user.id,
         name=system_data.name,
@@ -62,7 +71,22 @@ def list_ai_systems(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """List all AI systems for the current user, with optional sorting and pagination."""
+    """List the current user's AI systems with sorting and pagination.
+
+    Args:
+        sort_by: Column used to sort the results.
+        order: Sort direction, ascending or descending.
+        page: Page number to return, starting at 1.
+        limit: Maximum number of systems to return per page.
+        db: Database session used to query AI systems.
+        current_user: Authenticated user whose systems are being listed.
+
+    Returns:
+        PaginatedResponse containing the user's AI systems.
+
+    Raises:
+        HTTPException: If the requested sort field or order is invalid.
+    """
     if sort_by not in _SORTABLE_FIELDS:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -97,7 +121,19 @@ def bulk_import_systems(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    """Import AI systems from a CSV file."""
+    """Import AI systems from a CSV file.
+
+    Args:
+        file: CSV upload containing AI system rows.
+        db: Database session used to create imported systems.
+        current_user: Authenticated user who will own the imported systems.
+
+    Returns:
+        BulkImportResponse summarizing created rows and row-level errors.
+
+    Raises:
+        HTTPException: If the upload is not a valid UTF-8 CSV file.
+    """
     errors = []
     created_count = 0
 
@@ -180,7 +216,19 @@ def export_ai_systems(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Export the authenticated user's AI systems registry as a CSV file."""
+    """Export the authenticated user's AI systems registry as CSV.
+
+    Args:
+        risk_level: Optional risk level filter applied before export.
+        db: Database session used to query the systems.
+        current_user: Authenticated user whose systems are exported.
+
+    Returns:
+        StreamingResponse containing the generated CSV file.
+
+    Raises:
+        HTTPException: If the requested risk level is invalid.
+    """
     query = db.query(AISystem).filter(AISystem.owner_id == current_user.id)
 
     if risk_level is not None:
@@ -234,7 +282,22 @@ def get_ai_system_history(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Get paginated and sorted audit history for a specific AI system."""
+    """Return paginated audit history for a specific AI system.
+
+    Args:
+        system_id: ID of the AI system whose history is requested.
+        order: Sort direction for the audit log entries.
+        page: Page number to return, starting at 1.
+        limit: Maximum number of audit entries to return per page.
+        db: Database session used to query the audit log.
+        current_user: Authenticated user who must own the AI system.
+
+    Returns:
+        PaginatedResponse containing the system's audit history.
+
+    Raises:
+        HTTPException: If the system does not exist or the order is invalid.
+    """
     
     # 1. Validate sorting parameter
     if order not in ("asc", "desc"):
@@ -294,7 +357,19 @@ def get_ai_system(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Get a specific AI system."""
+    """Return a single AI system owned by the current user.
+
+    Args:
+        system_id: ID of the AI system to retrieve.
+        db: Database session used to query the system.
+        current_user: Authenticated user who must own the system.
+
+    Returns:
+        The requested AI system serialized as AISystemResponse.
+
+    Raises:
+        HTTPException: If the AI system does not exist or belongs to another user.
+    """
     system = (
         db.query(AISystem)
         .filter(AISystem.id == system_id, AISystem.owner_id == current_user.id)
@@ -315,7 +390,20 @@ def update_ai_system(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Update an AI system."""
+    """Update an existing AI system.
+
+    Args:
+        system_id: ID of the AI system to update.
+        system_data: Partial update payload for the AI system.
+        db: Database session used to load and persist the system.
+        current_user: Authenticated user who must own the system.
+
+    Returns:
+        The updated AI system serialized as AISystemResponse.
+
+    Raises:
+        HTTPException: If the AI system does not exist or belongs to another user.
+    """
     system = (
         db.query(AISystem)
         .filter(AISystem.id == system_id, AISystem.owner_id == current_user.id)
@@ -343,7 +431,19 @@ def delete_ai_system(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Delete an AI system."""
+    """Delete an AI system owned by the current user.
+
+    Args:
+        system_id: ID of the AI system to delete.
+        db: Database session used to locate and delete the system.
+        current_user: Authenticated user who must own the system.
+
+    Returns:
+        None. The endpoint responds with HTTP 204 No Content.
+
+    Raises:
+        HTTPException: If the AI system does not exist or belongs to another user.
+    """
     system = (
         db.query(AISystem)
         .filter(AISystem.id == system_id, AISystem.owner_id == current_user.id)
@@ -366,7 +466,20 @@ def update_ai_system_status(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Update only the compliance_status of an AI system."""
+    """Update only the compliance status of an AI system.
+
+    Args:
+        system_id: ID of the AI system to update.
+        payload: Compliance status update payload.
+        db: Database session used to load and persist the system.
+        current_user: Authenticated user who must own the system.
+
+    Returns:
+        The updated AI system serialized as AISystemResponse.
+
+    Raises:
+        HTTPException: If the AI system does not exist or belongs to another user.
+    """
     system = db.query(AISystem).filter(
         AISystem.id == system_id,
         AISystem.owner_id == current_user.id,

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -31,11 +31,16 @@ def get_compliance_timeline(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """
-    Return daily compliance snapshots for a given AI system.
+    """Return daily compliance snapshots for a single AI system.
 
-    TODO (help wanted): query ComplianceSnapshot filtered by ai_system_id and
-    snapshotted_at >= now - days. Verify the system belongs to current_user.
+    Args:
+        system_id: ID of the AI system to inspect.
+        days: Number of days of history to return.
+        current_user: Authenticated user requesting the timeline.
+        db: Database session used to query compliance snapshots.
+
+    Returns:
+        ComplianceTimelineResponse containing the system's daily compliance data.
     """
     # TODO: implement — replace with real DB query
     raise HTTPException(
@@ -48,10 +53,14 @@ def get_analytics_summary(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """
-    Return aggregate compliance stats for the current user's systems.
+    """Return aggregate compliance statistics for the current user.
 
-    TODO (help wanted): aggregate counts and averages from ai_systems table.
+    Args:
+        current_user: Authenticated user whose systems are being summarized.
+        db: Database session used to aggregate compliance metrics.
+
+    Returns:
+        Aggregate compliance statistics for the user's AI systems.
     """
     # TODO: implement
     raise HTTPException(

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -61,7 +61,18 @@ users_router = APIRouter()
     "/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED
 )
 def register(user_data: UserCreate, db: Session = Depends(get_db)):
-    """Register a new user."""
+    """Register a new user account.
+
+    Args:
+        user_data: Registration payload containing email, password, and profile fields.
+        db: Database session used to check for duplicates and create the user.
+
+    Returns:
+        The created user serialized as UserResponse.
+
+    Raises:
+        HTTPException: If the email is already registered.
+    """
     existing_user = db.query(User).filter(User.email == user_data.email).first()
     if existing_user:
         raise HTTPException(
@@ -85,7 +96,18 @@ def register(user_data: UserCreate, db: Session = Depends(get_db)):
 def login(
     form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
 ):
-    """Login and get access token."""
+    """Authenticate a user and return an access token.
+
+    Args:
+        form_data: OAuth2 password form containing the user's email and password.
+        db: Database session used to look up and validate the user.
+
+    Returns:
+        A bearer token payload with the access token and token type.
+
+    Raises:
+        HTTPException: If the credentials are invalid or the user is inactive.
+    """
     user = db.query(User).filter(User.email == form_data.username).first()
 
     if not user or not verify_password(form_data.password, user.hashed_password):
@@ -110,7 +132,14 @@ def login(
 
 @router.get("/me", response_model=UserResponse)
 def get_current_user_info(current_user: User = Depends(get_current_user)):
-    """Get current user information."""
+    """Return the authenticated user's profile.
+
+    Args:
+        current_user: Authenticated user resolved from the access token.
+
+    Returns:
+        The current user's profile serialized as UserResponse.
+    """
     return current_user
 
 
@@ -120,7 +149,19 @@ def change_password(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Change the authenticated user's password."""
+    """Change the authenticated user's password.
+
+    Args:
+        payload: Current and new password values.
+        current_user: Authenticated user whose password is being changed.
+        db: Database session used to persist the updated password hash.
+
+    Returns:
+        A confirmation message indicating the password was updated.
+
+    Raises:
+        HTTPException: If the current password does not match.
+    """
     if not verify_password(payload.current_password, current_user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -139,7 +180,16 @@ def update_current_user_info(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Update the authenticated user's profile details."""
+    """Update the authenticated user's profile details.
+
+    Args:
+        user_data: Partial profile update payload.
+        current_user: Authenticated user whose profile is being updated.
+        db: Database session used to persist the changes.
+
+    Returns:
+        The updated user serialized as UserResponse.
+    """
     if user_data.full_name is not None:
         current_user.full_name = user_data.full_name
     if user_data.company_name is not None:
@@ -156,7 +206,15 @@ def get_current_user_stats(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Get stats summary for the authenticated user."""
+    """Return summary statistics for the authenticated user.
+
+    Args:
+        current_user: Authenticated user whose activity is being summarized.
+        db: Database session used to count systems and documents.
+
+    Returns:
+        UserStatsResponse containing system, document, risk, and compliance counts.
+    """
     systems = db.query(AISystem).filter(AISystem.owner_id == current_user.id).all()
 
     risk_breakdown: dict = {}

--- a/backend/app/api/v1/classification.py
+++ b/backend/app/api/v1/classification.py
@@ -327,9 +327,14 @@ def classify_risk(data: RiskClassificationRequest) -> RiskClassificationResponse
 def classify_ai_system(
     data: RiskClassificationRequest, current_user: User = Depends(get_current_user)
 ):
-    """
-    Classify an AI system's risk level based on EU AI Act criteria.
-    This is a preliminary classification - full assessment requires more details.
+    """Classify an AI system's risk level from the questionnaire payload.
+
+    Args:
+        data: Risk classification questionnaire answers for the AI system.
+        current_user: Authenticated user requesting the classification.
+
+    Returns:
+        RiskClassificationResponse containing the inferred risk level and guidance.
     """
     return classify_risk(data)
 
@@ -341,8 +346,19 @@ def classify_and_save(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Classify an AI system and save the result to the database.
+    """Classify an AI system and persist the result.
+
+    Args:
+        system_id: ID of the AI system to classify.
+        data: Risk classification questionnaire answers.
+        db: Database session used to load the system and save the assessment.
+        current_user: Authenticated user who must own the system.
+
+    Returns:
+        RiskClassificationResponse for the submitted questionnaire.
+
+    Raises:
+        HTTPException: If the system does not exist or does not belong to the user.
     """
     # Get the AI system
     system = (
@@ -388,12 +404,13 @@ def classify_and_save(
 def get_questionnaire_risk_factors(
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Return the static questionnaire metadata used by the risk classification flow.
+    """Return the static questionnaire metadata used by the classifier.
 
-    This does not query the database because these factors describe the
-    classification rules themselves, not a user's saved questionnaire answers.
-    Keep this list aligned with RiskClassificationRequest and classify_risk().
+    Args:
+        current_user: Authenticated user requesting the questionnaire metadata.
+
+    Returns:
+        The list of questionnaire risk factors used by the classification flow.
     """
     return QUESTIONNAIRE_RISK_FACTORS
 
@@ -403,9 +420,15 @@ def bulk_classify_systems(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    """
-    Classify multiple AI systems in one request.
-    Returns per-system classification results and partial failure details.
+    """Classify multiple AI systems in a single request.
+
+    Args:
+        request: Payload containing the AI system IDs to classify.
+        db: Database session used to load systems and store assessments.
+        current_user: Authenticated user who must own every system.
+
+    Returns:
+        BulkClassificationResponse containing per-system results and errors.
     """
     results: List[BulkClassificationItem] = []
 

--- a/backend/app/api/v1/documents.py
+++ b/backend/app/api/v1/documents.py
@@ -165,7 +165,16 @@ def create_document(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Create a new document."""
+    """Create a new document for the authenticated user.
+
+    Args:
+        doc_data: Document creation payload.
+        db: Database session used to persist the new document.
+        current_user: Authenticated user who will own the document.
+
+    Returns:
+        The created document serialized as DocumentResponse.
+    """
     document = Document(
         owner_id=current_user.id,
         title=doc_data.title,
@@ -186,7 +195,17 @@ def list_documents(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    """List all documents for the current user with pagination."""
+    """List the current user's documents with pagination.
+
+    Args:
+        page: Page number to return, starting at 1.
+        limit: Maximum number of documents to return per page.
+        db: Database session used to query documents.
+        current_user: Authenticated user whose documents are being listed.
+
+    Returns:
+        PaginatedResponse containing the user's documents.
+    """
     base_query = db.query(Document).filter(Document.owner_id == current_user.id)
     total = base_query.count()
     offset = (page - 1) * limit
@@ -201,7 +220,19 @@ def get_document(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Get a specific document."""
+    """Return a single document owned by the current user.
+
+    Args:
+        document_id: ID of the document to retrieve.
+        db: Database session used to query the document.
+        current_user: Authenticated user who must own the document.
+
+    Returns:
+        The requested document serialized as DocumentResponse.
+
+    Raises:
+        HTTPException: If the document does not exist or belongs to another user.
+    """
     document = (
         db.query(Document)
         .filter(Document.id == document_id, Document.owner_id == current_user.id)
@@ -221,7 +252,20 @@ def update_document(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    """Update document content."""
+    """Update the content of an existing document.
+
+    Args:
+        document_id: ID of the document to update.
+        body: Payload containing the replacement document content.
+        db: Database session used to load and persist the document.
+        current_user: Authenticated user who must own the document.
+
+    Returns:
+        The updated document serialized as DocumentResponse.
+
+    Raises:
+        HTTPException: If the document does not exist or belongs to another user.
+    """
     # Fetch document
     document = db.query(Document).filter(
         Document.id == document_id,
@@ -247,7 +291,19 @@ def generate_document(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Generate a compliance document for an AI system."""
+    """Generate a compliance document for a user's AI system.
+
+    Args:
+        request: Payload specifying the AI system and document type.
+        db: Database session used to look up the AI system and save the result.
+        current_user: Authenticated user who must own the AI system.
+
+    Returns:
+        The generated document serialized as DocumentResponse.
+
+    Raises:
+        HTTPException: If the AI system or template is missing.
+    """
     # Get the AI system
     ai_system = (
         db.query(AISystem)
@@ -327,7 +383,19 @@ def delete_document(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Delete a document."""
+    """Delete a document owned by the current user.
+
+    Args:
+        document_id: ID of the document to delete.
+        db: Database session used to locate and delete the document.
+        current_user: Authenticated user who must own the document.
+
+    Returns:
+        None. The endpoint responds with HTTP 204 No Content.
+
+    Raises:
+        HTTPException: If the document does not exist or belongs to another user.
+    """
     document = (
         db.query(Document)
         .filter(Document.id == document_id, Document.owner_id == current_user.id)
@@ -349,13 +417,18 @@ def export_document_pdf(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    """Export a document as a PDF file.
-    
+    """Export a document as a PDF attachment.
+
+    Args:
+        document_id: ID of the document to export.
+        db: Database session used to load the document.
+        current_user: Authenticated user who must own the document.
+
     Returns:
-        - Response status 200 with PDF bytes
-        - Content-Type: application/pdf
-        - File starts with %PDF- magic bytes
-        - File size > 1KB
+        StreamingResponse containing the generated PDF bytes.
+
+    Raises:
+        HTTPException: If the document is missing, has no content, or PDF generation fails.
     """
     # Retrieve the document
     document = db.query(Document).filter(

--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -182,9 +182,18 @@ def scan_prompt(
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Scan a prompt for injection risks.
-    Returns a decision: allow, sanitize, or block.
+    """Scan a prompt for injection risks.
+
+    Args:
+        request: Prompt text and scan options submitted by the client.
+        background_tasks: FastAPI background task runner used for scan logging.
+        current_user: Authenticated user submitting the prompt.
+
+    Returns:
+        ScanResponse describing the guard decision and any sanitization details.
+
+    Raises:
+        HTTPException: If scan processing fails or the request is rate limited.
     """
     limited, retry_after = _check_rate_limit(current_user.id)
 
@@ -243,7 +252,11 @@ def scan_prompt(
 
 @router.get("/health", tags=["LLM Guard"])
 def guard_health():
-    """Check if the Guard module is available."""
+    """Check whether the Guard module is available.
+
+    Returns:
+        A status payload describing the Guard module availability.
+    """
     return {"module": "llm_guard", "status": "available"}
 
 
@@ -254,7 +267,11 @@ class GuardConfigRequest(BaseModel):
 
 @router.get("/info", tags=["LLM Guard"])
 def guard_info():
-    """Return diagnostic information about the Guard module."""
+    """Return diagnostic information about the Guard module.
+
+    Returns:
+        A status payload containing device and model details.
+    """
 
     try:
         import torch
@@ -281,7 +298,17 @@ def get_guard_history(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Return the current user's Guard scan history, newest first."""
+    """Return the current user's Guard scan history, newest first.
+
+    Args:
+        page: Page number to return, starting at 1.
+        limit: Maximum number of scan logs to include per page.
+        db: Database session used to query scan history.
+        current_user: Authenticated user whose history is requested.
+
+    Returns:
+        PaginatedResponse containing the user's scan history.
+    """
     base_query = db.query(GuardScanLog).filter(
         GuardScanLog.user_id == current_user.id,
     )
@@ -304,9 +331,19 @@ def get_guard_stats(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Get Guard scan statistics for the specified window and user.
-    Admins can query stats for any user; regular users only for themselves.
+    """Return Guard scan statistics for a time window and user.
+
+    Args:
+        window: Time window to aggregate over (24h, 7d, 30d, or all).
+        user_id: Optional user ID to query; defaults to the current user.
+        db: Database session used to aggregate scan statistics.
+        current_user: Authenticated user requesting the statistics.
+
+    Returns:
+        GuardStatsResponse containing decision, detection, and trend statistics.
+
+    Raises:
+        HTTPException: If the caller is not allowed to query another user's stats.
     """
     target_user_id = user_id if user_id is not None else current_user.id
     is_admin = getattr(current_user, "role", None) == "admin"
@@ -432,7 +469,14 @@ def get_guard_stats(
 
 @router.get("/config", tags=["LLM Guard"])
 def get_guard_config(current_user: User = Depends(get_current_user)):
-    """Get per-user guard configuration."""
+    """Return the current user's Guard configuration.
+
+    Args:
+        current_user: Authenticated user whose Guard config is requested.
+
+    Returns:
+        The user's saved Guard configuration, or the default config.
+    """
     default_config = {
         "sanitization_level": "medium",
         "malicious_threshold": 0.8,
@@ -447,7 +491,18 @@ def update_guard_config(
     config: GuardConfigRequest,
     current_user: User = Depends(get_current_user),
 ):
-    """Update per-user guard configuration."""
+    """Update the current user's Guard configuration.
+
+    Args:
+        config: Sanitization level and threshold values to persist.
+        current_user: Authenticated user whose Guard config is being updated.
+
+    Returns:
+        A confirmation payload containing the saved configuration.
+
+    Raises:
+        HTTPException: If any configuration value is out of range.
+    """
     if config.sanitization_level not in VALID_SANITIZATION_LEVELS:
         raise HTTPException(
             status_code=400,
@@ -484,9 +539,18 @@ def bulk_scan_prompts(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """
-    Scan a batch of prompts, max 50, for injection risks.
-    Each prompt counts as one rate-limit unit and produces one GuardScanLog row.
+    """Scan a batch of prompts for injection risks.
+
+    Args:
+        request: Prompt list payload to scan in one batch.
+        current_user: Authenticated user submitting the batch.
+        db: Database session used to persist batch scan results.
+
+    Returns:
+        BulkScanResponse containing scan results, totals, and processed count.
+
+    Raises:
+        HTTPException: If the batch exceeds limits or validation fails.
     """
     try:
         request.validate_prompts()

--- a/backend/app/api/v1/notifications.py
+++ b/backend/app/api/v1/notifications.py
@@ -48,7 +48,18 @@ def list_notifications(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Return notifications for the current user."""
+    """List the current user's notifications with optional unread filtering.
+
+    Args:
+        unread_only: If true, return only unread notifications.
+        page: Page number to return, starting at 1.
+        limit: Maximum number of notifications to return per page.
+        current_user: Authenticated user whose notifications are requested.
+        db: Database session used to query notifications.
+
+    Returns:
+        PaginatedResponse containing the user's notifications.
+    """
     query = db.query(Notification).filter(Notification.user_id == current_user.id)
 
     if unread_only:
@@ -77,7 +88,16 @@ def mark_notifications_read(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Mark a list of notification IDs as read."""
+    """Mark the specified notifications as read.
+
+    Args:
+        body: Payload containing the notification IDs to mark read.
+        current_user: Authenticated user who owns the notifications.
+        db: Database session used to update the matching rows.
+
+    Returns:
+        None. The endpoint responds with HTTP 204 No Content.
+    """
     db.query(Notification).filter(
         Notification.user_id == current_user.id,
         Notification.id.in_(body.ids),
@@ -96,7 +116,19 @@ def delete_notification(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Delete a single notification owned by the current user."""
+    """Delete a notification owned by the current user.
+
+    Args:
+        notification_id: ID of the notification to delete.
+        current_user: Authenticated user who must own the notification.
+        db: Database session used to locate and delete the notification.
+
+    Returns:
+        None. The endpoint responds with HTTP 204 No Content.
+
+    Raises:
+        HTTPException: If the notification does not exist or belongs to another user.
+    """
     notification = (
         db.query(Notification)
         .filter(

--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -65,19 +65,17 @@ def ingest_documents(
     files: List[UploadFile] = File(..., description="One or more PDF files to ingest"),
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Accept one or more PDF uploads, process them through the document loader,
-    build (or rebuild) the FAISS vector index, and persist it to
-    ``settings.FAISS_INDEX_PATH``.
+    """Ingest one or more regulatory PDFs and rebuild the FAISS index.
 
-    **Returns**
-    - ``files_processed`` - number of PDFs successfully saved and chunked
-    - ``chunks_created``  - total text chunks fed into the vector store
-    - ``index_size_bytes`` - on-disk size of the persisted FAISS index
+    Args:
+        files: One or more PDF uploads to save, chunk, and index.
+        current_user: Authenticated user requesting the ingestion.
 
-    **Errors**
-    - ``400`` if no valid PDF files are supplied
-    - ``503`` if the embedding model or FAISS build step fails
+    Returns:
+        RAGIngestResponse with file, chunk, and index size counts.
+
+    Raises:
+        HTTPException: If no valid PDFs are supplied or indexing fails.
     """
 
     # ── 1. Validate: at least one PDF ─────────────────────────────────────
@@ -146,12 +144,18 @@ def query_knowledge_base(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """
-    Ask a regulatory question and get an answer grounded in source documents.
+    """Answer a regulatory question using the RAG knowledge base.
 
-    Example questions:
-    - "Does my CV-screening tool qualify as high-risk under the EU AI Act?"
-    - "What are the transparency requirements for chatbots?"
+    Args:
+        request: Query payload containing the user's question.
+        current_user: Authenticated user asking the question.
+        db: Database session used to persist the query and feedback record.
+
+    Returns:
+        RAGQueryResponse containing the generated answer and source references.
+
+    Raises:
+        HTTPException: If the RAG subsystem cannot produce an answer.
     """
     try:
         from app.modules.rag.retrieval_chain import get_qa_chain
@@ -217,7 +221,11 @@ def query_knowledge_base(
 
 @router.get("/health", tags=["RAG Intelligence"])
 def rag_health():
-    """Check if the RAG module is available."""
+    """Check whether the RAG module has an available index.
+
+    Returns:
+        A status payload describing whether the RAG index is available.
+    """
     from app.modules.rag.vector_store import check_index_exists
     
     index_loaded = check_index_exists()
@@ -248,7 +256,19 @@ def rag_feedback(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Record a thumbs-up or thumbs-down for a previously returned answer."""
+    """Record feedback for a previously returned RAG answer.
+
+    Args:
+        payload: Answer ID and vote direction submitted by the user.
+        current_user: Authenticated user submitting the feedback.
+        db: Database session used to update the feedback row.
+
+    Returns:
+        A confirmation payload containing the feedback status and answer ID.
+
+    Raises:
+        HTTPException: If the referenced answer does not exist.
+    """
     fb = db.query(RAGFeedback).filter(RAGFeedback.id == payload.answer_id).first()
     if not fb:
         raise HTTPException(status_code=404, detail="Answer not found")
@@ -268,9 +288,18 @@ def get_low_quality_chunks(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Admin endpoint: aggregate feedback by source chunk and return low-quality candidates.
+    """Return source chunks whose feedback ratio exceeds the threshold.
 
-    A chunk is considered low-quality when thumbs_down / total_feedback > threshold.
+    Args:
+        threshold: Minimum thumbs-down ratio required to flag a chunk.
+        current_user: Authenticated user; must have admin access.
+        db: Database session used to aggregate feedback.
+
+    Returns:
+        A payload containing the threshold and low-quality chunk candidates.
+
+    Raises:
+        HTTPException: If the caller is not allowed to access the admin report.
     """
     # Admin-only access: restrict to system owners / scale tier
     try:
@@ -309,7 +338,17 @@ def get_rag_history(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Return paginated list of the current user's past RAG queries."""
+    """Return the current user's paginated RAG query history.
+
+    Args:
+        page: Page number to return, starting at 1.
+        page_size: Maximum number of queries to include per page.
+        current_user: Authenticated user whose query history is requested.
+        db: Database session used to query the history table.
+
+    Returns:
+        A paginated history payload containing the user's past RAG queries.
+    """
     offset = (page - 1) * page_size
     queries = (
         db.query(RagQuery)

--- a/backend/app/api/v1/webhooks.py
+++ b/backend/app/api/v1/webhooks.py
@@ -33,8 +33,15 @@ def create_webhook(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """
-    Register a new webhook endpoint for the current user.
+    """Register a new webhook endpoint for the current user.
+
+    Args:
+        body: Webhook configuration payload supplied by the client.
+        current_user: Authenticated user that will own the webhook.
+        db: Database session used to persist the webhook configuration.
+
+    Returns:
+        The created webhook configuration serialized as WebhookResponse.
     """
     # Force the user_id to be the authenticated user to prevent spoofing
     webhook_data = body.model_dump()
@@ -55,8 +62,14 @@ def list_webhooks(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """
-    List all webhook configs for the current user.
+    """List all webhook configurations for the current user.
+
+    Args:
+        current_user: Authenticated user whose webhooks are being listed.
+        db: Database session used to query webhook configurations.
+
+    Returns:
+        A list of webhook configurations owned by the current user.
     """
     # Fetch webhooks strictly scoped to the authenticated user
     webhooks = db.query(WebhookConfig).filter(WebhookConfig.user_id == current_user.id).all()
@@ -70,8 +83,18 @@ def delete_webhook(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """
-    Delete a webhook config (must belong to current user).
+    """Delete a webhook configuration owned by the current user.
+
+    Args:
+        webhook_id: ID of the webhook configuration to delete.
+        current_user: Authenticated user who must own the webhook.
+        db: Database session used to locate and delete the webhook.
+
+    Returns:
+        None. The endpoint responds with HTTP 204 No Content.
+
+    Raises:
+        HTTPException: If the webhook does not exist or belongs to another user.
     """
     # Query checking BOTH the webhook ID and the user ID
     db_webhook = db.query(WebhookConfig).filter(


### PR DESCRIPTION
## Summary

Closes #568 
Adds Google-style docstrings to the route handlers in the backend API v1 modules so contributors can understand each endpoint's purpose, inputs, and return values more easily. This is a documentation-only change and does not alter any runtime logic.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Screenshots (if UI change)

Not applicable.