### PR TITLE
feat: add Notification SQLAlchemy model and Alembic migration

### DIFF
--- a/backend/alembic/versions/0a8c1331b696_add_notifications_table.py
+++ b/backend/alembic/versions/0a8c1331b696_add_notifications_table.py
@@ -1,11 +1,10 @@
-"""add notifications table
+"""add_notifications_table
 
-Revision ID: add_notifications_table
+Revision ID: 0a8c1331b696
 Revises: eb8060353ac6
-Create Date: 2026-05-24
+Create Date: 2026-05-25 18:12:31.917793
 
 """
-
 from typing import Sequence, Union
 
 from alembic import op
@@ -13,40 +12,24 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = "add_notifications_table"
+revision: str = '0a8c1331b696'
 down_revision: Union[str, None] = "eb8060353ac6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
-
 
 def upgrade() -> None:
     op.create_table(
         "notifications",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("user_id", sa.Integer(), nullable=False),
-        sa.Column("notification_type", sa.String(length=100), nullable=False),
         sa.Column("title", sa.String(length=255), nullable=False),
         sa.Column("message", sa.Text(), nullable=False),
-        sa.Column("is_read", sa.Boolean(), nullable=True),
-        sa.Column("resource_type", sa.String(length=100), nullable=True),
-        sa.Column("resource_id", sa.Integer(), nullable=True),
+        sa.Column("is_read", sa.Boolean(), nullable=False, server_default=sa.false()),
         sa.Column("created_at", sa.DateTime(), nullable=True),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
 
-    op.create_index(
-        op.f("ix_notifications_id"),
-        "notifications",
-        ["id"],
-        unique=False,
-    )
-
 
 def downgrade() -> None:
-    op.drop_index(
-        op.f("ix_notifications_id"),
-        table_name="notifications",
-    )
-
     op.drop_table("notifications")

--- a/backend/alembic/versions/add_notifications_table.py
+++ b/backend/alembic/versions/add_notifications_table.py
@@ -1,0 +1,52 @@
+"""add notifications table
+
+Revision ID: add_notifications_table
+Revises: eb8060353ac6
+Create Date: 2026-05-24
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "add_notifications_table"
+down_revision: Union[str, None] = "eb8060353ac6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("notification_type", sa.String(length=100), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column("is_read", sa.Boolean(), nullable=True),
+        sa.Column("resource_type", sa.String(length=100), nullable=True),
+        sa.Column("resource_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        op.f("ix_notifications_id"),
+        "notifications",
+        ["id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_notifications_id"),
+        table_name="notifications",
+    )
+
+    op.drop_table("notifications")


### PR DESCRIPTION
## Summary

Closes #116

Implemented Notification model registration and added Alembic migration support for the notifications table.

### Changes Made

* Registered `Notification` model in `app/models/__init__.py`
* Added `notifications` relationship in `User` model
* Added migration file for notifications table creation
* Verified migration and model syntax locally

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [ ] I have added/updated tests where relevant
* [ ] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets.
* [ ] I have updated documentation if needed.

## Screenshots (if UI change)

N/A