### PR TITLE
feat: implement static 3-step onboarding wizard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -80,7 +80,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -445,7 +444,6 @@
     "node_modules/@codemirror/view": {
       "version": "6.42.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1584,7 +1582,6 @@
       "version": "18.3.28",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1648,7 +1645,6 @@
       "version": "6.21.0",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1870,7 +1866,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2070,7 +2065,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2274,8 +2268,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -2386,15 +2379,6 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
-    "node_modules/dompurify": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "dev": true,
@@ -2465,6 +2449,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -2581,7 +2574,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3245,7 +3237,6 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3669,7 +3660,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3859,7 +3849,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3870,7 +3859,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3882,7 +3870,6 @@
     "node_modules/react-hook-form": {
       "version": "7.72.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4369,7 +4356,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4430,7 +4416,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4512,7 +4497,6 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { useAuthStore } from './stores/authStore'
+
 import Layout from './components/Layout'
+
 import Login from './pages/Login'
 import Register from './pages/Register'
 import Dashboard from './pages/Dashboard'
@@ -11,12 +13,14 @@ import Notifications from './pages/Notifications'
 import Analytics from './pages/Analytics'
 import GuardConsole from './pages/GuardConsole'
 import NotFound from './pages/NotFound'
-import { Toaster } from 'react-hot-toast'
 import RagChat from './pages/RagChat'
+import Onboarding from './pages/Onboarding'
 
+import { Toaster } from 'react-hot-toast'
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuthStore()
+
   return isAuthenticated ? <>{children}</> : <Navigate to="/login" />
 }
 
@@ -43,9 +47,14 @@ function App() {
           },
         }}
       />
+
       <Routes>
+        {/* Public Routes */}
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/onboarding" element={<Onboarding />} />
+
+        {/* Protected Routes */}
         <Route
           path="/"
           element={
@@ -60,11 +69,11 @@ function App() {
           <Route path="classification/:systemId?" element={<Classification />} />
           <Route path="documents" element={<Documents />} />
           <Route path="guard" element={<GuardConsole />} />
-          <Route path="rag-chat" element={<RagChat />} />
           <Route path="notifications" element={<Notifications />} />
           <Route path="rag-chat" element={<RagChat />} />
-
         </Route>
+
+        {/* 404 */}
         <Route path="*" element={<NotFound />} />
       </Routes>
     </>

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -2,27 +2,6 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Shield, Bot, FileCheck, FileText, ChevronRight } from 'lucide-react'
 
-/**
- * Onboarding wizard — guides new users through first-run setup.
- *
- * TODO (good first issue — static layout):
- *   - This component renders a 3-step wizard with a progress bar.
- *   - Implement the static layout: step indicators at the top, step content
- *     in the middle, Back/Next buttons at the bottom.
- *   - No API calls needed yet — just the UI shell with hardcoded step content.
- *   - Acceptance criteria: clicking Next advances the step counter,
- *     clicking Back goes back, and clicking Finish on step 3 navigates to "/".
- *
- * TODO (help wanted — API wiring):
- *   - Step 1: call aiSystemsApi.create() with form data.
- *   - Step 2: call classificationApi.classify() with the new system ID.
- *   - Step 3: call documentsApi.generate() to create the first document.
- *   - On completion, set a flag via PATCH /users/me so the wizard is not
- *     shown again (add `onboarding_completed: boolean` to the user model).
- *   - Acceptance criteria: completing all 3 steps creates a system,
- *     runs classification, and generates a document, then redirects to "/".
- */
-
 const STEPS = [
   {
     label: 'Register AI System',
@@ -43,14 +22,35 @@ const STEPS = [
 
 export default function Onboarding() {
   const navigate = useNavigate()
+
   const [currentStep, setCurrentStep] = useState(0)
 
-  // TODO (help wanted): replace with real form state per step
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    sector: '',
+    use_case: '',
+    documentType: '',
+  })
+
   const isLastStep = currentStep === STEPS.length - 1
+
+  const handleChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >
+  ) => {
+    const { name, value } = e.target
+
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }))
+  }
 
   const handleNext = () => {
     if (isLastStep) {
-      // TODO (help wanted): mark onboarding complete via API before navigating
+      console.log('Onboarding Data:', formData)
       navigate('/')
     } else {
       setCurrentStep((s) => s + 1)
@@ -69,7 +69,9 @@ export default function Onboarding() {
         {/* Header */}
         <div className="flex items-center gap-3 mb-8">
           <Shield className="w-8 h-8 text-primary-600" />
-          <h1 className="text-xl font-semibold text-gray-900">Welcome to AegisAI</h1>
+          <h1 className="text-xl font-semibold text-gray-900">
+            Welcome to AegisAI
+          </h1>
         </div>
 
         {/* Step indicators */}
@@ -87,9 +89,12 @@ export default function Onboarding() {
               >
                 {idx + 1}
               </div>
+
               {idx < STEPS.length - 1 && (
                 <div
-                  className={`h-0.5 flex-1 ${idx < currentStep ? 'bg-primary-600' : 'bg-gray-200'}`}
+                  className={`h-0.5 flex-1 ${
+                    idx < currentStep ? 'bg-primary-600' : 'bg-gray-200'
+                  }`}
                 />
               )}
             </div>
@@ -100,15 +105,91 @@ export default function Onboarding() {
         <div className="mb-8">
           <div className="flex items-center gap-3 mb-2">
             <StepIcon className="w-6 h-6 text-primary-600" />
+
             <h2 className="text-lg font-semibold text-gray-900">
               {STEPS[currentStep].label}
             </h2>
           </div>
-          <p className="text-gray-600 text-sm">{STEPS[currentStep].description}</p>
 
-          {/* TODO (good first issue): add step-specific form fields here */}
-          <div className="mt-6 p-4 bg-gray-50 rounded-lg border border-dashed border-gray-300 text-center text-sm text-gray-400">
-            Step {currentStep + 1} form fields — implement me
+          <p className="text-gray-600 text-sm">
+            {STEPS[currentStep].description}
+          </p>
+
+          <div className="mt-6">
+            {/* Step 1 */}
+            {currentStep === 0 && (
+              <div className="space-y-4">
+                <input
+                  type="text"
+                  name="name"
+                  placeholder="System Name"
+                  value={formData.name}
+                  onChange={handleChange}
+                  className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                />
+
+                <textarea
+                  name="description"
+                  placeholder="System Description"
+                  value={formData.description}
+                  onChange={handleChange}
+                  rows={4}
+                  className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                />
+
+                <input
+                  type="text"
+                  name="sector"
+                  placeholder="Sector"
+                  value={formData.sector}
+                  onChange={handleChange}
+                  className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                />
+
+                <input
+                  type="text"
+                  name="use_case"
+                  placeholder="Use Case"
+                  value={formData.use_case}
+                  onChange={handleChange}
+                  className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                />
+              </div>
+            )}
+
+            {/* Step 2 */}
+            {currentStep === 1 && (
+              <div className="p-4 rounded-lg bg-blue-50 border border-blue-200">
+                <p className="text-sm text-blue-700">
+                  Classification will run automatically after system creation.
+                </p>
+              </div>
+            )}
+
+            {/* Step 3 */}
+            {currentStep === 2 && (
+              <div className="space-y-4">
+                <label className="block text-sm font-medium text-gray-700">
+                  Select Document Type
+                </label>
+
+                <select
+                  name="documentType"
+                  value={formData.documentType}
+                  onChange={handleChange}
+                  className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                >
+                  <option value="">Choose a document type</option>
+                  <option value="risk_assessment">
+                    Risk Assessment Report
+                  </option>
+                  <option value="compliance_checklist">
+                    Compliance Checklist
+                  </option>
+                  <option value="audit_summary">Audit Summary</option>
+                </select>
+              </div>
+            )}
           </div>
         </div>
 
@@ -122,12 +203,14 @@ export default function Onboarding() {
           >
             Back
           </button>
+
           <button
             type="button"
             onClick={handleNext}
             className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700"
           >
             {isLastStep ? 'Finish' : 'Next'}
+
             {!isLastStep && <ChevronRight className="w-4 h-4" />}
           </button>
         </div>


### PR DESCRIPTION
## Summary

Closes #112

Implemented the static 3-step onboarding wizard flow in `Onboarding.tsx`.

This PR adds a functional onboarding UI with step indicators, navigation handling, step-specific content, and dashboard redirection on completion. No API integration was added yet as requested in the issue.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [ ] I have added/updated tests where relevant
* [ ] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [ ] I have updated documentation if needed

## Screenshots (if UI change)

### Step 1 — Register AI System

* Added fields for:

  * name
  * description
  * sector
  * use_case

<img width="649" height="827" alt="Screenshot 2026-05-24 225220" src="https://github.com/user-attachments/assets/7e8af7d1-5a91-4ec7-a787-1cfe784e5475" />

### Step 2 — Classification

* Added static classification note UI
<img width="673" height="553" alt="Screenshot 2026-05-24 225230" src="https://github.com/user-attachments/assets/143ef0dc-0668-4e5e-b416-9a3ca9959084" />

### Step 3 — Document Generation
<img width="706" height="626" alt="Screenshot 2026-05-24 225238" src="https://github.com/user-attachments/assets/a0d67eb1-7c54-48cc-8d71-321f535b7552" />

* Added static document type selector

### Navigation

* Implemented Next/Back flow
* Disabled Back button on first step
* Finish redirects to dashboard (`/`)