### PR TITLE
fix(auth): handle expired JWT tokens separately

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional, TYPE_CHECKING
 
-from jose import JWTError, jwt
+from jose import ExpiredSignatureError, JWTError, jwt
 from passlib.context import CryptContext
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
@@ -68,6 +68,13 @@ def decode_token(token: str) -> Dict[str, Any]:
             token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
         )
         return payload
+    except ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired. Please log in again.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
     except JWTError:
         raise _get_credentials_exception()
 


### PR DESCRIPTION
## Summary

Updated JWT token decoding in `backend/app/core/security.py` to handle expired access tokens separately while preserving generic authentication failures for all other invalid token cases.

### Changes

* Added explicit handling for `ExpiredSignatureError`
* Returns:
  `"Token has expired. Please log in again."`
  only for expired tokens
* Preserved generic:
  `"Could not validate credentials"`
  response for tampered, malformed, invalid-signature, and other JWT failures

### Why

This follows the maintainer review feedback from the previous PR and avoids leaking unnecessary validation details for non-expiry authentication failures.

## Testing

* `python -m compileall backend/app/core/security.py` passed successfully
* Existing pytest failures appear unrelated to this change and are caused by missing project dependencies during test collection