### PR TITLE
fix(audit): serialize audit log values safely

### DIFF
--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 """
 
 from datetime import datetime
+import enum
 
 from sqlalchemy import Column, Integer, DateTime, ForeignKey, JSON, event
 from sqlalchemy.orm import relationship
@@ -23,6 +24,18 @@ TRACKED_FIELDS = [
     "compliance_status",
     "compliance_score",
 ]
+
+
+def _json_safe_value(value):
+    if isinstance(value, enum.Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _json_safe_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe_value(item) for item in value]
+    return value
 
 
 class AISystemAuditLog(Base):
@@ -52,10 +65,10 @@ def after_ai_system_update(mapper, connection, target):
         history = get_history(target, field)
 
         if history.has_changes():
-            old_values[field] = (
+            old_values[field] = _json_safe_value(
                 history.deleted[0] if history.deleted else None
             )
-            new_values[field] = (
+            new_values[field] = _json_safe_value(
                 history.added[0] if history.added else getattr(target, field)
             )
     changed_by_id = getattr(target, "_changed_by_id", None)
@@ -64,8 +77,8 @@ def after_ai_system_update(mapper, connection, target):
             AISystemAuditLog.__table__.insert().values(
                 ai_system_id=target.id,
                 changed_by_id=changed_by_id,
-                old_values=old_values,
-                new_values=new_values,
+                old_values=_json_safe_value(old_values),
+                new_values=_json_safe_value(new_values),
                 changed_at=datetime.utcnow(),
             )
         )

--- a/backend/tests/test_audit_logs.py
+++ b/backend/tests/test_audit_logs.py
@@ -1,7 +1,6 @@
 """Tests for AI system audit logging and history endpoint."""
 
 import os
-from urllib import response
 import pytest
 
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
@@ -16,6 +15,7 @@ from app.main import app
 
 from app.models.user import User
 from app.models.ai_system import AISystem
+from app.models.ai_system import ComplianceStatus
 
 
 @pytest.fixture(scope="module")
@@ -128,3 +128,30 @@ class TestAuditLogs:
         assert "total" in data
         assert "page" in data
         assert "limit" in data
+
+    def test_status_update_records_json_safe_audit_log(self, client):
+        response = client.patch(
+            "/api/v1/ai-systems/1/status",
+            json={"compliance_status": ComplianceStatus.COMPLIANT.value},
+        )
+
+        assert response.status_code == 200
+
+        history_response = client.get("/api/v1/ai-systems/1/history")
+
+        assert history_response.status_code == 200
+
+        data = history_response.json()
+
+        assert data["total"] == 1
+
+        log = data["items"][0]
+
+        assert (
+            log["old_values"]["compliance_status"]
+            == ComplianceStatus.NOT_STARTED.value
+        )
+        assert (
+            log["new_values"]["compliance_status"]
+            == ComplianceStatus.COMPLIANT.value
+        )


### PR DESCRIPTION
**PR Title**
`test(training): cover deterministic train split`

**Description**
This PR adds a regression test to make the training split reproducibility guarantee explicit. The guard training helper already passes `random_state` through to `train_test_split`, but there was no test protecting that behavior.

What changed:
- Added test_training_split.py.
- Verified `train_validation_split(..., random_state=42)` returns the same train/validation split across repeated calls.
- Verified changing the seed produces a different split.

Why it matters:
- Protects against accidental removal of `random_state` in future changes.
- Keeps ML experiments reproducible for learners and contributors.
- Makes the deterministic split behavior explicit in tests.

Validation:
- `pytest test_training_split.py -q` passed in the project venv.

Fixes issue #515 