### PR TITLE
Docs/readme troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Set in `backend/.env`:
 LLM_API_KEY=ollama
 LLM_BASE_URL=http://localhost:11434/v1
 LLM_MODEL=llama3.2
+## 🛠 Troubleshooting
+
+This section collects common setup and runtime problems contributors encounter, with quick checks and recommended fixes.
 ```
 
 Then `docker compose up -d`. See [Getting Started](https://github.com/SdSarthak/AegisAI/blob/main/docs/getting-started.md) for all provider options.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,48 @@ Then `docker compose up -d`. See [Getting Started](https://github.com/SdSarthak/
 
 ---
 
+## Environment Variables
+
+Copy `backend/.env.example` to `backend/.env`, then adjust values for your setup.
+
+```bash
+cp backend/.env.example backend/.env
+```
+
+| Variable | Description | Required | Example |
+|---|---|---|---|
+| `APP_NAME` | Display name used by the backend. | Optional | `AegisAI` |
+| `DEBUG` | Enables debug behavior and verbose logging. | Optional | `true` |
+| `API_V1_PREFIX` | Base path prefix for API routes. | Optional | `/api/v1` |
+| `DATABASE_URL` | SQLAlchemy database connection string (PostgreSQL in production). | Yes | `postgresql://postgres:postgres@localhost:5432/aegisai_db` |
+| `SECRET_KEY` | JWT signing secret. Use a long random value. | Yes | `f2d5...` |
+| `ALGORITHM` | JWT algorithm used for token signing. | Optional | `HS256` |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | JWT access token lifetime in minutes. | Optional | `30` |
+| `LLM_API_KEY` | API key for your OpenAI-compatible provider. Use `ollama` for local Ollama mode. | Yes (unless fully local mock setup) | `sk-...` or `ollama` |
+| `LLM_BASE_URL` | Custom OpenAI-compatible base URL. Leave empty for OpenAI default. | Optional | `http://localhost:11434/v1` |
+| `LLM_MODEL` | Chat/completion model name used by Guard and RAG modules. | Yes | `gpt-4o-mini` |
+| `GUARD_SANITIZATION_LEVEL` | Prompt sanitization strictness (`low`, `medium`, `high`). | Optional | `medium` |
+| `GUARD_MAX_PROMPT_LENGTH` | Maximum prompt length accepted by Guard processing. | Optional | `2000` |
+| `RAG_CHUNK_SIZE` | Document chunk size for RAG indexing. | Optional | `1000` |
+| `RAG_CHUNK_OVERLAP` | Overlap between adjacent RAG chunks. | Optional | `200` |
+| `FAISS_INDEX_PATH` | Filesystem path for persisted FAISS index. | Optional | `faiss_index` |
+| `S3_BUCKET_NAME` | Bucket used for optional document/object storage integration. | Optional | `aegisai-docs` |
+| `MLFLOW_TRACKING_URI` | Remote MLflow server URI. Leave empty for local `./mlruns`. | Optional | `http://localhost:5000` |
+| `STRIPE_SECRET_KEY` | Stripe secret key for billing features. | Optional | `sk_test_...` |
+| `STRIPE_PUBLISHABLE_KEY` | Stripe publishable key for frontend billing flows. | Optional | `pk_test_...` |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret for event validation. | Optional | `whsec_...` |
+| `STRIPE_PRICE_STARTER` | Stripe Price ID for starter plan. | Optional | `price_123` |
+| `STRIPE_PRICE_GROWTH` | Stripe Price ID for growth plan. | Optional | `price_456` |
+| `STRIPE_PRICE_SCALE` | Stripe Price ID for scale plan. | Optional | `price_789` |
+
+### Common Setup Profiles
+
+- Ollama local (no paid API): set `LLM_API_KEY=ollama`, `LLM_BASE_URL=http://localhost:11434/v1`, and `LLM_MODEL` to a local model such as `llama3.2`.
+- OpenAI: set `LLM_API_KEY=sk-...`, leave `LLM_BASE_URL` empty, and keep `LLM_MODEL=gpt-4o-mini` (or another OpenAI model).
+- PostgreSQL local: keep `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/aegisai_db` and make sure the database exists before startup.
+
+---
+
 ## 📓 Colab Notebooks
 
 If you want to train the machine learning models yourself, you can run our official Google Colab notebooks on a free T4 GPU:


### PR DESCRIPTION

### Motivation
AegisAI supports multiple setup modes (Docker, manual, Ollama). New contributors frequently encounter the same onboarding issues (failed Docker builds, DB connection errors, missing env vars, port conflicts). The README lacks a centralized troubleshooting reference, which slows onboarding and increases duplicate issues.

### What this PR does
Adds a concise ** Troubleshooting** section to README.md that documents common setup and runtime problems with quick checks and recommended fixes:
- Docker Compose startup failures
- Backend `.env` configuration issues
- PostgreSQL connection errors and migrations
- Port conflicts (5173, 8000, 5432)
- Ollama connectivity checks
- Dependency installation troubleshooting (Python/Node native builds)
- Python / Node.js version recommendations and remediation steps

### Files changed
- README.md — new Troubleshooting section

### Impact
- Documentation-only change; no code, tests, or DB migrations required.
- Improves onboarding and reduces repetitive setup questions.

### Notes for reviewers
- Suggest any additional OS- or distro-specific commands to add (Windows vs Linux).
- We may later extract this to `docs/troubleshooting.md` if maintainers prefer a longer guide.

Fixes issue #529 