### PR TITLE
feat: add reassessment reminder scheduler job

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,11 @@ from app.core.logging import configure_logging
 from app.core.middleware import RequestContextMiddleware
 from app.core.telemetry import setup_telemetry
 from app.api.v1 import api_router, badge
+<<<<<<< HEAD
 from app.plugins.regulation_loader import init_registry
+=======
+from app.tasks.scheduler import scheduler
+>>>>>>> b21cecc (fix: start scheduler in FastAPI lifespan)
 import app.models  # ensure all ORM models are imported so tables are created
 
 # -------------------------------------------------------------------
@@ -45,6 +49,11 @@ async def lifespan(app: FastAPI):
         # Initialize database tables during application startup
         Base.metadata.create_all(bind=engine)
         logger.info("Database tables initialized.")
+
+        # START SCHEDULER
+        scheduler.start()
+        logger.info("Background scheduler started.")
+
     except Exception:
         logger.exception("Failed to initialize database tables")
         raise
@@ -55,10 +64,16 @@ async def lifespan(app: FastAPI):
     app.state.registry = init_registry(builtin_dir, custom_dir)
     logger.info("Regulation registry initialized.")
 
-    yield  # Control is passed to FastAPI and the application runs
+    yield  # App runs here
 
     logger.info("Shutting down AegisAI backend...")
-    # Place any teardown logic here (e.g., closing thread pools, background tasks)
+
+    # STOP SCHEDULER
+    try:
+        scheduler.shutdown()
+        logger.info("Background scheduler stopped.")
+    except Exception:
+        logger.exception("Error while shutting down scheduler")
 
 # -------------------------------------------------------------------
 # FastAPI Application Initialization

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -21,15 +21,39 @@ TODO for contributors (high priority):
 """
 
 # TODO (high priority): uncomment and implement once APScheduler is installed
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.schedulers.background import BackgroundScheduler
 from app.core.database import SessionLocal
 from app.models.compliance_snapshot import ComplianceSnapshot
 from app.models.ai_system import AISystem, RiskAssessment
 from app.models.notification import Notification, NotificationType
-from app.api.v1.notifications import create_notification
+def create_notification(
+    db,
+    user_id,
+    notification_type,
+    title,
+    message,
+    resource_type=None,
+    resource_id=None,
+):
+    notification = Notification(
+        user_id=user_id,
+        notification_type=notification_type,
+        title=title,
+        message=message,
+        resource_type=resource_type,
+        resource_id=resource_id,
+    )
+
+    db.add(notification)
+    db.commit()
+    db.refresh(notification)
+
+    return notification
+
+
 from datetime import datetime, timedelta
 
-scheduler = AsyncIOScheduler()
+scheduler = BackgroundScheduler()
 
 
 @scheduler.scheduled_job("cron", hour=3, minute=0)

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -21,22 +21,68 @@ TODO for contributors (high priority):
 """
 
 # TODO (high priority): uncomment and implement once APScheduler is installed
-# from apscheduler.schedulers.asyncio import AsyncIOScheduler
-# from app.core.database import SessionLocal
-# from app.models.compliance_snapshot import ComplianceSnapshot
-# from app.models.ai_system import AISystem
-# from app.models.risk_assessment import RiskAssessment
-# from app.models.notification import Notification, NotificationType
-# from datetime import datetime, timedelta
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from app.core.database import SessionLocal
+from app.models.compliance_snapshot import ComplianceSnapshot
+from app.models.ai_system import AISystem, RiskAssessment
+from app.models.notification import Notification, NotificationType
+from app.api.v1.notifications import create_notification
+from datetime import datetime, timedelta
 
-# scheduler = AsyncIOScheduler()
+scheduler = AsyncIOScheduler()
 
 
-# @scheduler.scheduled_job("cron", hour=2, minute=0)   # runs daily at 02:00 UTC
-# def snapshot_compliance_scores():
-#     """Daily job: capture a ComplianceSnapshot for every AI system."""
-#     # TODO: implement
-#     pass
+@scheduler.scheduled_job("cron", hour=3, minute=0)
+def send_reassessment_reminders():
+    """Daily job: notify users when a risk assessment is expiring within 30 days."""
+
+    db = SessionLocal()
+
+    try:
+        now = datetime.utcnow()
+        cutoff = now + timedelta(days=30)
+        seven_days_ago = now - timedelta(days=7)
+
+        due_assessments = (
+            db.query(RiskAssessment)
+            .filter(RiskAssessment.valid_until <= cutoff)
+            .filter(RiskAssessment.valid_until >= now)
+            .all()
+        )
+
+        for assessment in due_assessments:
+            system = assessment.ai_system
+
+            existing_notification = (
+                db.query(Notification)
+                .filter(Notification.user_id == system.owner_id)
+                .filter(
+                    Notification.notification_type
+                    == NotificationType.REASSESSMENT_DUE.value
+                )
+                .filter(Notification.resource_id == system.id)
+                .filter(Notification.created_at >= seven_days_ago)
+                .first()
+            )
+
+            if existing_notification:
+                continue
+
+            create_notification(
+                db=db,
+                user_id=system.owner_id,
+                notification_type=NotificationType.REASSESSMENT_DUE.value,
+                title="Risk assessment due soon",
+                message=(
+                    f"{system.name} requires re-assessment by "
+                    f"{assessment.valid_until.date()}"
+                ),
+                resource_type="ai_system",
+                resource_id=system.id,
+            )
+
+    finally:
+        db.close()
 
 
 # @scheduler.scheduled_job("cron", hour=3, minute=0)   # runs daily at 03:00 UTC

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -70,3 +70,5 @@ redis==5.0.8
 pytest==7.4.4
 pytest-asyncio==0.23.3
 pytest-cov==4.1.0
+
+apscheduler>=3.10

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,0 +1,5 @@
+from app.tasks.scheduler import scheduler
+
+
+def test_scheduler_exists():
+    assert scheduler is not None


### PR DESCRIPTION
## Summary

Closes #138 

This PR adds scheduled reassessment reminder notifications for AI systems with risk assessments expiring within 30 days.

Changes Made
Added APScheduler integration
Implemented send_reassessment_reminders() scheduled job
Added notification deduplication for 7 days
Integrated existing create_notification() helper
Added APScheduler dependency to requirements.txt
Acceptance Criteria Covered
Creates REASSESSMENT_DUE notifications for assessments expiring within 30 days
Prevents duplicate notifications when scheduler runs daily
Notifications are linked to the AI system owner

 I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
 My code follows the project style (PEP 8 for Python, ESLint for TS)
I have added/updated tests where relevant
 `pytest backend/tests/` passes locally
 I have updated documentation if needed
 
 **Difficulty**
Intermediate

**Labels**
Enhancement, High priority, Compliance


