### PR TITLE
fix: sanitize DocumentEditor markdown preview

### DIFF
--- a/backend/tests/test_document_editor_preview_sanitizer.py
+++ b/backend/tests/test_document_editor_preview_sanitizer.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EDITOR_PATH = REPO_ROOT / "frontend" / "src" / "components" / "DocumentEditor.tsx"
+SANITIZER_PATH = REPO_ROOT / "frontend" / "src" / "utils" / "sanitizePreviewHtml.ts"
+
+
+def test_document_editor_sanitizes_markdown_preview():
+    editor_source = EDITOR_PATH.read_text(encoding="utf-8")
+
+    assert "sanitizePreviewHtml" in editor_source
+    assert "dangerouslySetInnerHTML" in editor_source
+    assert "previewHtml" in editor_source
+    assert "marked.parse(content, { async: false })" in editor_source
+
+
+def test_preview_sanitizer_blocks_scriptable_content():
+    sanitizer_source = SANITIZER_PATH.read_text(encoding="utf-8")
+
+    assert "name.startsWith('on')" in sanitizer_source
+    assert "name === 'style'" in sanitizer_source
+    assert "name === 'srcdoc'" in sanitizer_source
+    assert "URL_ATTRIBUTES" in sanitizer_source
+    assert "SAFE_URL_PATTERN" in sanitizer_source
+
+    for tag_name in ("'script'", "'iframe'", "'object'", "'embed'", "'svg'"):
+        assert tag_name in sanitizer_source

--- a/frontend/src/components/DocumentEditor.tsx
+++ b/frontend/src/components/DocumentEditor.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Save, Eye, EyeOff } from 'lucide-react'
 import CodeMirror from '@uiw/react-codemirror'
 import { markdown } from '@codemirror/lang-markdown'
 import { marked } from 'marked'
 import api from '../services/api'
+import { sanitizePreviewHtml } from '../utils/sanitizePreviewHtml'
 
 interface DocumentEditorProps {
   documentId: number
@@ -22,6 +23,10 @@ export default function DocumentEditor({
   const [showPreview, setShowPreview] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [saveTimeout, setSaveTimeout] = useState<ReturnType<typeof setTimeout> | null>(null)
+  const previewHtml = useMemo(
+    () => sanitizePreviewHtml(marked.parse(content, { async: false }) as string),
+    [content]
+  )
 
   const handleSave = useCallback(async () => {
     setIsSaving(true)
@@ -91,7 +96,7 @@ export default function DocumentEditor({
       <div className="flex-1 overflow-auto">
         {showPreview ? (
           <div className="prose max-w-none p-6">
-            <div dangerouslySetInnerHTML={{ __html: marked.parse(content, { async: false }) }} />
+            <div dangerouslySetInnerHTML={{ __html: previewHtml }} />
           </div>
         ) : (
           <div className="h-full">

--- a/frontend/src/utils/sanitizePreviewHtml.ts
+++ b/frontend/src/utils/sanitizePreviewHtml.ts
@@ -1,0 +1,73 @@
+const BLOCKED_TAGS = new Set([
+  'script',
+  'style',
+  'iframe',
+  'object',
+  'embed',
+  'link',
+  'meta',
+  'base',
+  'form',
+  'input',
+  'button',
+  'select',
+  'option',
+  'textarea',
+  'svg',
+  'math',
+  'template',
+])
+
+const URL_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction', 'poster'])
+const SAFE_URL_PATTERN = /^(?:https?:|mailto:|tel:|#|\/(?!\/)|\.\.?\/)/i
+
+function isSafeUrl(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return true
+  }
+
+  if (SAFE_URL_PATTERN.test(trimmed)) {
+    return true
+  }
+
+  return false
+}
+
+function sanitizeElement(root: ParentNode): void {
+  const elements = Array.from(root.querySelectorAll('*'))
+
+  for (const element of elements) {
+    const tagName = element.tagName.toLowerCase()
+
+    if (BLOCKED_TAGS.has(tagName)) {
+      element.remove()
+      continue
+    }
+
+    for (const attribute of Array.from(element.attributes)) {
+      const name = attribute.name.toLowerCase()
+      const value = attribute.value
+
+      if (name.startsWith('on') || name === 'style' || name === 'srcdoc') {
+        element.removeAttribute(attribute.name)
+        continue
+      }
+
+      if (URL_ATTRIBUTES.has(name) && !isSafeUrl(value)) {
+        element.removeAttribute(attribute.name)
+      }
+    }
+  }
+}
+
+export function sanitizePreviewHtml(html: string): string {
+  if (typeof document === 'undefined') {
+    return html
+  }
+
+  const template = document.createElement('template')
+  template.innerHTML = html
+  sanitizeElement(template.content)
+  return template.innerHTML
+}


### PR DESCRIPTION
## Summary
- sanitize rendered markdown preview HTML before injecting it into the DocumentEditor preview
- strip blocked tags, inline handlers, srcdoc, and scriptable URL attributes without adding a new frontend dependency
- add a lightweight regression test that locks the sanitizer contract in place

## Validation
- python3 -m pytest --noconftest backend/tests/test_document_editor_preview_sanitizer.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/aegisai-issue-324/.pycache python3 -m py_compile backend/tests/test_document_editor_preview_sanitizer.py
- git diff --check