### PR TITLE
fix: preserve risk filter state during pagination

### DIFF
--- a/frontend/src/pages/AISystems.tsx
+++ b/frontend/src/pages/AISystems.tsx
@@ -35,16 +35,16 @@ export default function AISystems() {
 
   const limit = 10
 
-  const { data: systemsData, isLoading } = useQuery({
-    queryKey: ['ai-systems', sortBy, order, currentPage],
-    queryFn: () =>
-      aiSystemsApi.list({
-        sort_by: sortBy,
-        order,
-        page: currentPage,
-        limit,
-      }),
-  })
+ const { data: systemsData, isLoading } = useQuery({
+  queryKey: ['ai-systems', sortBy, order, currentPage, riskFilter],
+  queryFn: () =>
+    aiSystemsApi.list({
+      sort_by: sortBy,
+      order,
+      page: currentPage,
+      limit,
+    }),
+});
   const systems = Array.isArray(systemsData) ? systemsData : (systemsData?.items ?? [])
 
   const createMutation = useMutation({
@@ -164,7 +164,10 @@ export default function AISystems() {
             <Filter className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
             <select
               value={riskFilter}
-              onChange={(e) => setRiskFilter(e.target.value)}
+              onChange={(e) => {
+                setRiskFilter(e.target.value);
+                setCurrentPage(1);
+              }}
               className="pl-9 pr-4 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 outline-none transition-all appearance-none cursor-pointer"
             >
               <option value="">All Risk Levels</option>


### PR DESCRIPTION
## Summary

Closes #632 

This PR fixes the issue where the selected risk filter state was not preserved during pagination on the AI Systems page. The React Query cache key now includes the active riskFilter, ensuring filtered results remain consistent across page navigation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)

N/A
