### PR TITLE
fix(frontend): map page index into skip query offset for backend list compatibility

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -63,7 +63,19 @@ export const aiSystemsApi = {
     page?: number
     limit?: number
   }) => {
-    const { data } = await api.get('/ai-systems/', { params })
+    // Fix for Issue #631: Transform frontend 'page' into the backend-expected 'skip' query offset parameter
+    const limit = params?.limit ?? 10
+    const page = params?.page ?? 1
+    const skip = (page - 1) * limit
+
+    const queryParams = {
+      sort_by: params?.sort_by,
+      order: params?.order,
+      skip: skip,
+      limit: limit,
+    }
+
+    const { data } = await api.get('/ai-systems/', { params: queryParams })
     return data
   },
   get: async (id: number) => {
@@ -179,3 +191,4 @@ export const guardApi = {
 }
 
 export default api
+


### PR DESCRIPTION
## Summary

Closes #631

This PR resolves the issue where the AI Systems dashboard page was stuck on Page 1 and unable to paginate. The frontend pagination components utilize a `page` index, whereas the FastAPI backend service explicitly expects an offset-based `skip` parameter to paginate records at the database tier. 

To fix this synchronization breakdown, the `aiSystemsApi.list` method inside `frontend/src/services/api.ts` has been refactored to calculate the appropriate `skip` offset parameter dynamically using the active `page` and `limit` context before sending the Axios payload request over the network.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [ ] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

