### PR TITLE
feat: add document templates endpoint

### DIFF
--- a/backend/app/api/v1/documents.py
+++ b/backend/app/api/v1/documents.py
@@ -15,6 +15,7 @@ from app.schemas.document import (
     DocumentResponse,
     DocumentGenerateRequest,
     DocumentUpdateRequest,
+    DocumentTemplateResponse,
 )
 from app.schemas.pagination import PaginatedResponse
 
@@ -194,6 +195,25 @@ def list_documents(
     documents = base_query.offset(offset).limit(limit).all()
     return PaginatedResponse(items=documents, total=total, page=page, limit=limit)
 
+@router.get("/templates", response_model=List[DocumentTemplateResponse])
+def list_document_templates(
+    current_user: User = Depends(get_current_user),
+):
+    """List available document templates for generation."""
+    descriptions = {
+        DocumentType.TECHNICAL_DOCUMENTATION: "Generate technical documentation for an AI system.",
+        DocumentType.RISK_ASSESSMENT: "Generate a risk assessment report for an AI system.",
+        DocumentType.CONFORMITY_DECLARATION: "Generate an EU declaration of conformity for an AI system.",
+    }
+
+    return [
+        DocumentTemplateResponse(
+            type=document_type,
+            name=document_type.value.replace("_", " ").title(),
+            description=descriptions[document_type],
+        )
+        for document_type in DOCUMENT_TEMPLATES.keys()
+    ]
 
 @router.get("/{document_id}", response_model=DocumentResponse)
 def get_document(

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -20,6 +20,13 @@ class DocumentUpdateRequest(BaseModel):
     """Request to update document content only."""
     content: str
 
+class DocumentTemplateResponse(BaseModel):
+    """Available document template metadata for generation."""
+
+    type: DocumentType
+    name: str
+    description: str
+
 class DocumentResponse(BaseModel):
     id: int
     title: str

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -24,6 +24,32 @@ def create_ai_system(client, headers):
     )
     return response.json()["id"]
 
+def test_list_document_templates(client):
+    headers = register_and_login(client, "templates@example.com")
+
+    response = client.get(
+        "/api/v1/documents/templates",
+        headers=headers
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 3
+
+    template_types = {template["type"] for template in data}
+    assert "technical_documentation" in template_types
+    assert "risk_assessment" in template_types
+    assert "conformity_declaration" in template_types
+
+    for template in data:
+        assert "type" in template
+        assert "name" in template
+        assert "description" in template
+        assert template["name"]
+        assert template["description"]
+
 
 # ✅ Test 1: Generate Technical Documentation → 201
 def test_generate_technical_documentation(client):


### PR DESCRIPTION
## Summary

Closes #28

Added a `GET /api/v1/documents/templates` endpoint so the frontend can fetch available document templates dynamically instead of hardcoding them. The endpoint returns the currently supported generation templates with type, display name, and description.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Testing

- `pytest tests/test_documents.py::test_list_document_templates -q`

Note: the full `pytest tests/test_documents.py -q` currently has pre-existing failures in document generation tests expecting `201`, while the existing `/documents/generate` route returns `200`. The new templates endpoint test passes.

## Screenshots (if UI change)

N/A