### PR TITLE
test(guard): implement validation edge-case tests for batch scan endpoint

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -65,6 +65,9 @@ class BulkScanRequest(BaseModel):
     prompts: list[str]
 
     def validate_prompts(self) -> None:
+        if not self.prompts:
+            raise ValueError("At least one prompt is required per batch request.")
+
         if len(self.prompts) > 50:
             raise ValueError("Maximum 50 prompts allowed per batch request.")
 

--- a/backend/tests/test_guard_batch_scan.py
+++ b/backend/tests/test_guard_batch_scan.py
@@ -1,0 +1,141 @@
+"""Tests for the Guard batch scan endpoint validation behavior."""
+
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from app.api.v1 import guard as guard_api
+
+
+def _guard_result():
+    return {
+        "decision": "allow",
+        "metadata": {
+            "regex_analysis": {
+                "flag": False,
+                "risk_score": 0.0,
+                "matched_patterns": [],
+            },
+            "intent_analysis": {
+                "intent": "benign",
+                "confidence": 0.99,
+            },
+            "decision_reasoning": {
+                "confidence": 0.99,
+                "reasoning": "Safe prompt",
+            },
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def clear_guard_rate_limits():
+    guard_api._scan_attempts_by_user.clear()
+    yield
+    guard_api._scan_attempts_by_user.clear()
+
+
+@pytest.fixture
+def auth_headers(client):
+    email = f"batch-scan-{uuid4()}@example.com"
+    password = "testpassword123"
+
+    client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": password,
+            "full_name": "Batch Scan Test User",
+        },
+    )
+
+    response = client.post(
+        "/api/v1/auth/login",
+        data={"username": email, "password": password},
+    )
+    token = response.json()["access_token"]
+
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_batch_scan_accepts_standard_valid_batch_request(client, auth_headers):
+    payload = {
+        "prompts": [
+            "Summarize the EU AI Act risk categories.",
+            "What is a safe model monitoring checklist?",
+        ]
+    }
+
+    with patch("app.modules.guard.llm_guard.LLMGuard") as mock_guard_class:
+        mock_guard = mock_guard_class.return_value
+        mock_guard.guard.return_value = _guard_result()
+
+        response = client.post(
+            "/api/v1/guard/scan/batch",
+            json=payload,
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total"] == 2
+    assert data["processed"] == 2
+    assert len(data["results"]) == 2
+    assert {result["decision"] for result in data["results"]} == {"allow"}
+    assert mock_guard.guard.call_count == 2
+
+
+def test_batch_scan_rejects_empty_batch_payload(client, auth_headers):
+    response = client.post(
+        "/api/v1/guard/scan/batch",
+        json={"prompts": []},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "At least one prompt is required per batch request."
+    }
+
+
+def test_batch_scan_rejects_payload_exceeding_validate_prompts_limit(
+    client,
+    auth_headers,
+):
+    payload = {"prompts": [f"Prompt {index}" for index in range(51)]}
+
+    response = client.post(
+        "/api/v1/guard/scan/batch",
+        json=payload,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Maximum 50 prompts allowed per batch request."
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"prompts": "this should be a list"},
+        {"prompts": [{"text": "objects are not valid prompt strings"}]},
+    ],
+)
+def test_batch_scan_rejects_malformed_payload_without_server_error(
+    client,
+    auth_headers,
+    payload,
+):
+    response = client.post(
+        "/api/v1/guard/scan/batch",
+        json=payload,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+    assert "detail" in response.json()


### PR DESCRIPTION
Closes #483

This PR adds focused validation coverage for the `/guard/scan/batch` endpoint and hardens the batch validation pipeline against empty prompt arrays. The new tests cover valid batch execution, empty payload rejection, over-limit batch rejection, and malformed request bodies returning FastAPI validation errors instead of unhandled server failures.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Tests
- [ ] Infra / CI

## Files Changed

| File | Change |
|---|---|
| `backend/app/api/v1/guard.py` | Added an explicit empty-batch guard inside `BulkScanRequest.validate_prompts()` so `prompts: []` is rejected before rate limiting, guard execution, DB writes, or notifications. |
| `backend/tests/test_guard_batch_scan.py` | Added endpoint-level pytest coverage for valid batch scans, empty batches, over-limit batches, and malformed payload structures. |

## Technical Details

- Keeps Pydantic responsible for malformed structural payloads, which continue to return `422 Unprocessable Entity`.
- Uses endpoint-level business validation for structurally valid but invalid batch inputs, returning explicit `400 Bad Request` responses.
- Mocks `LLMGuard` in the valid batch test to avoid model inference and keep the test deterministic.
- Clears in-memory guard rate-limit state before and after each test to avoid cross-test contamination.
- Uses the existing `TestClient` and auth flow style already present in the backend test suite.

## Validation Coverage

| Case | Payload | Expected Result |
|---|---|---|
| Standard valid batch | `{"prompts": ["...", "..."]}` | `200 OK`, `total == 2`, `processed == 2` |
| Empty batch | `{"prompts": []}` | `400 Bad Request` with explicit empty-batch message |
| Exceeded batch limit | `51` prompt strings | `400 Bad Request` with max-50 validation message |
| Malformed structure | missing `prompts`, non-list `prompts`, invalid item shape | `422 Unprocessable Entity` |

## Testing

Static verification completed locally:

- [x] `python -m py_compile backend\app\api\v1\guard.py backend\tests\test_guard_batch_scan.py`

Full pytest execution could not be run in the local environment because Python dependencies such as `pytest` and `fastapi` are not installed. The test file is written against the existing repository fixtures and should run in CI with the backend requirements installed.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style
- [x] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed