### PR TITLE
fix: add input length validation to POST /rag/query endpoint

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -32,7 +32,7 @@ router = APIRouter()
 
 
 class RAGQueryRequest(BaseModel):
-    question: str
+    question: str = Field(..., min_length=1, max_length=2000)
 
 
 class RAGQueryResponse(BaseModel):


### PR DESCRIPTION
## Summary

Closes #<729>

Added input length validation to POST /rag/query endpoint. The RAGQueryRequest model now enforces min_length=1 and max_length=2000 on the question field, preventing potential DoS attacks from oversized inputs.

## Type of Change

- [✅] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [✅] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [✅] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [✅] `pytest backend/tests/` passes locally
- [ ] I have not committed `.env` or any secrets
- [✅] I have updated documentation if needed

## Screenshots (if UI change)

<!-- Add before/after screenshots here -->
