### PR TITLE
chore: add pre-commit hooks for code quality enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-yaml
+        args: ['--allow-multiple-documents']
+      - id: check-json
+
+  - repo: local
+    hooks:
+      - id: frontend-eslint
+        name: Frontend ESLint
+        entry: npm --prefix frontend run lint
+        language: system
+        files: ^frontend/.*\.(ts|tsx)$
+        pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **Pre-commit hooks** — Added `.pre-commit-config.yaml` with repository hygiene hooks (trailing-whitespace, end-of-file-fixer, check-merge-conflict, check-yaml, check-json) and a local ESLint hook wrapping the existing frontend lint command.
 - **LLM Guard Prompt Normalization** — Preprocessor layer (`normalizer.py`) to prevent Unicode, zero-width, and homoglyph bypasses:
   - Strips invisible format characters in Unicode `Cf` category (e.g. zero-width space, non-joiner, joiner)
   - Normalizes stylized font variations using NFKC compatibility normalization

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,21 @@ cd backend
 pytest tests/ -v --cov=app
 ```
 
+### Pre-commit Hooks
+
+We use [pre-commit](https://pre-commit.com/) to catch common issues before they reach CI.
+
+```bash
+pip install pre-commit   # one-time install
+pre-commit install       # activate hooks for this repo
+```
+
+Hooks run automatically on `git commit`. To run them manually against all files:
+
+```bash
+pre-commit run --all-files
+```
+
 ---
 
 ## Pull Request Process


### PR DESCRIPTION
## Summary

Closes #699

This PR introduces repository-wide pre-commit hooks to enforce code quality and formatting checks before commits reach CI. It adds standard hygiene hooks (whitespace trimming, EOF normalization, merge conflict detection, JSON/YAML validation) along with ESLint integration for frontend consistency.
Additionally, `check-yaml` is configured with `--allow-multiple-documents` to support Kubernetes manifests in the `infra/` directory.

---

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [x] Infra / CI

---

## Checklist

* [x] I have read [[CONTRIBUTING.md]](../CONTRIBUTING.md)
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [ ] I have added/updated tests where relevant
* [x] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [x] I have updated documentation if needed

---

## Screenshots (if UI change)

N/A

---
