### PR TITLE
fix: handle empty API responses to prevent UI freeze (#664)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     RAG_CHUNK_SIZE: int = 1000
     RAG_CHUNK_OVERLAP: int = 200
     FAISS_INDEX_PATH: str = "faiss_index"
+    MLFLOW_TRACKING_URI: str = ""
 
     class Config:
         env_file = ".env"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -80,7 +80,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -445,7 +444,6 @@
     "node_modules/@codemirror/view": {
       "version": "6.42.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1584,7 +1582,6 @@
       "version": "18.3.28",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1648,7 +1645,6 @@
       "version": "6.21.0",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1870,7 +1866,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2070,7 +2065,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2274,8 +2268,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -2581,7 +2574,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3245,7 +3237,6 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3669,7 +3660,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3859,7 +3849,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3870,7 +3859,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3882,7 +3870,6 @@
     "node_modules/react-hook-form": {
       "version": "7.72.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4369,7 +4356,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4430,7 +4416,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4512,7 +4497,6 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -49,11 +49,14 @@ export default function NotificationBell() {
 
   // Live data via useQuery
   const queryClient = useQueryClient()
-  const { data: notifications = [] } = useQuery({
-    queryKey: ['notifications', 'unread'],
-    queryFn: () => notificationsApi.list(true),
-    refetchInterval: 60_000,
-  })
+  const { data: rawNotifications } = useQuery({
+  queryKey: ['notifications', 'unread'],
+  queryFn: () => notificationsApi.list(true),
+  refetchInterval: 60_000,
+})
+const notifications: NotificationPreview[] = Array.isArray(rawNotifications)
+  ? rawNotifications
+  : (rawNotifications as { items?: NotificationPreview[] })?.items ?? []
 
   const unreadCount = notifications.filter((n: NotificationPreview) => !n.is_read).length
 

--- a/frontend/src/pages/AISystems.tsx
+++ b/frontend/src/pages/AISystems.tsx
@@ -36,7 +36,7 @@ export default function AISystems() {
   const limit = 10
 
 // Fix: Track filters in the cache key array, but keep the API function strictly to known parameters
-  const { data: systemsData, isLoading } = useQuery({
+  const { data: systemsData, isLoading, error } = useQuery({
     queryKey: ['ai-systems', sortBy, order, currentPage, riskFilter, complianceFilter],
     queryFn: () =>
       aiSystemsApi.list({
@@ -55,6 +55,9 @@ export default function AISystems() {
       setShowModal(false)
       setFormData({ name: '', description: '', use_case: '', sector: '' })
     },
+    onError: (err: Error) => {
+      alert(err.message || 'Failed to create AI system.')
+    },
   })
 
   const deleteMutation = useMutation({
@@ -62,6 +65,9 @@ export default function AISystems() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['ai-systems'] })
       setSystemToDelete(null)
+    },
+    onError: (err: Error) => {
+      alert(err.message || 'Failed to delete AI system.')
     },
   })
 
@@ -134,6 +140,19 @@ export default function AISystems() {
 
   return (
     <div className="space-y-8">
+      {error && (
+  <div className="bg-red-50 border border-red-200 rounded-xl p-4 flex items-center justify-between">
+    <p className="text-red-700 text-sm">
+      {error instanceof Error ? error.message : 'Failed to load AI systems.'}
+    </p>
+    <button
+      onClick={() => window.location.reload()}
+      className="text-sm text-red-600 hover:text-red-500 font-medium underline"
+    >
+      Retry
+    </button>
+  </div>
+)}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">AI Systems</h1>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,18 +5,19 @@ import { Bot, FileText, AlertTriangle, CheckCircle, Clock } from 'lucide-react'
 import BackendStatus from '../components/BackendStatus'
 
 export default function Dashboard() {
-  const { data: systemsData, isLoading: systemsLoading } = useQuery({
-    queryKey: ['ai-systems'],
-    queryFn: () => aiSystemsApi.list(),
-  })
+  const { data: systemsData, isLoading: systemsLoading, error: systemsError } = useQuery({
+  queryKey: ['ai-systems'],
+  queryFn: () => aiSystemsApi.list(),
+})
   const systems = Array.isArray(systemsData) ? systemsData : (systemsData?.items ?? [])
 
-  const { data: documentsData, isLoading: documentsLoading } = useQuery({
+  const { data: documentsData, isLoading: documentsLoading, error: documentsError } = useQuery({
     queryKey: ['documents'],
     queryFn: documentsApi.list,
   })
   const documents = Array.isArray(documentsData) ? documentsData : (documentsData?.items ?? [])
   const isLoading = systemsLoading || documentsLoading
+  const error = systemsError || documentsError
 
   const stats = [
     {
@@ -47,6 +48,19 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-8">
+    {error && (
+  <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-4 flex items-center justify-between">
+    <p className="text-red-700 dark:text-red-400 text-sm">
+      {error instanceof Error ? error.message : 'Failed to load data.'}
+    </p>
+    <button
+      onClick={() => window.location.reload()}
+      className="text-sm text-red-600 hover:text-red-500 font-medium underline"
+    >
+      Retry
+    </button>
+  </div>
+)}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Dashboard</h1>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -19,13 +19,24 @@ api.interceptors.request.use((config) => {
 
 // Handle 401 errors
 api.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    // Guard against empty/null payload
+    if (response.data === null || response.data === undefined) {
+      return Promise.reject(new Error('Empty response received from server.'))
+    }
+    return response
+  },
   (error) => {
     if (error.response?.status === 401) {
       useAuthStore.getState().logout()
       window.location.href = '/login'
     }
-    return Promise.reject(error)
+    // Always reject with a meaningful message
+    const message =
+      error.response?.data?.detail ||
+      error.message ||
+      'Something went wrong. Please try again.'
+    return Promise.reject(new Error(message))
   }
 )
 
@@ -151,8 +162,17 @@ export interface HealthResponse {
 }
 
 export const checkHealth = async (): Promise<HealthResponse> => {
-  const response = await axios.get<HealthResponse>("/health")
-  return response.data
+  try {
+    const response = await axios.get<HealthResponse>("/health")
+    if (!response.data) {
+      throw new Error('Empty health response from server.')
+    }
+    return response.data
+  } catch (error) {
+    throw new Error(
+      error instanceof Error ? error.message : 'Health check failed.'
+    )
+  }
 }
 
 /* ============================


### PR DESCRIPTION
Closes #664

## Problem
When the backend returns an empty/null response, the frontend UI was freezing instead of showing a fallback error state.

## Changes
- `backend/app/core/config.py` — Added missing `MLFLOW_TRACKING_URI` field to Settings
- `frontend/src/services/api.ts` — Hardened axios interceptor with null/empty payload guard + try/catch in checkHealth
- `frontend/src/pages/Dashboard.tsx` — Added error state with retry UI
- `frontend/src/pages/AISystems.tsx` — Added error state + onError handlers for mutations
- `frontend/src/components/NotificationBell.tsx` — Fixed crash when API returns non-array response

## Testing
1. Started backend and logged in — Dashboard loads normally ✅
2. Stopped backend — Red error banner shows with Retry button instead of freeze ✅
3. Restarted backend and clicked Retry — Page recovered normally ✅

Screenshot 1 — Error state 

<img width="1470" height="956" alt="Screenshot 2026-05-27 at 1 29 15 PM" src="https://github.com/user-attachments/assets/dd10301f-5cb7-49e8-86d6-fb1ee76b0a10" />

Screenshot 2 — Normal state
<img width="1470" height="956" alt="Screenshot 2026-05-27 at 1 34 43 PM" src="https://github.com/user-attachments/assets/5d95afb2-12ae-4975-bd59-627cb224f4b0" />
