### PR TITLE
fix(frontend): handle paginated notifications response

### DIFF
--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -48,14 +48,19 @@ export default function NotificationBell() {
   const wrapperRef = useRef<HTMLDivElement>(null)
 
   // Live data via useQuery
-  const queryClient = useQueryClient()
-  const { data: notifications = [] } = useQuery({
-    queryKey: ['notifications', 'unread'],
-    queryFn: () => notificationsApi.list(true),
-    refetchInterval: 60_000,
-  })
+const queryClient = useQueryClient()
 
-  const unreadCount = notifications.filter((n: NotificationPreview) => !n.is_read).length
+const { data } = useQuery({
+  queryKey: ['notifications', 'unread'],
+  queryFn: () => notificationsApi.list(true),
+  refetchInterval: 60_000,
+})
+
+const notifications = data?.items ?? []
+
+const unreadCount = notifications.filter(
+  n => !n.is_read
+).length
 
   const handleNotificationClick = async (id: number) => {
     await notificationsApi.markRead([id])


### PR DESCRIPTION
## Summary

Fixes frontend notification handling for paginated API responses.

The notifications endpoint returns:
{
  "items": [],
  "total": 0,
  "page": 1,
  "limit": 50
}

but NotificationBell expected a plain array, which could break unread notification rendering.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Changes Made

- Updated NotificationBell to read notifications from `data?.items ?? []`
- Preserved unread filtering logic
- Verified backend notifications API response structure in Swagger

## Testing

- [x] Frontend loads correctly
- [x] Notifications endpoint tested via Swagger auth
- [x] No notification rendering crash