### PR TITLE
Add darkmode toggle persistence

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Outlet, Link, useLocation } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
+import NotificationBell from './NotificationBell'
 import ThemeToggle from './ThemeToggle'
 import {
   LayoutDashboard,
@@ -15,9 +16,6 @@ import {
   ChevronRight,
   BarChart,
 } from 'lucide-react'
-import NotificationBell from './NotificationBell'
-
-
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: LayoutDashboard },
@@ -112,21 +110,20 @@ export default function Layout() {
                 {displayName}
               </p>
               <p className="text-xs text-gray-500 truncate dark:text-gray-400">
-  {companyName}
-</p>
-</div>
+                {companyName}
+              </p>
+            </div>
 
-<div className="flex items-center gap-1">
-  <button
-    onClick={logout}
-    className="p-2 text-gray-400 dark:text-gray-300 hover:text-gray-600 dark:hover:text-white rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-    aria-label="Log out"
-    title="Log out"
-  >
-    <LogOut className="w-5 h-5" />
-  </button>
-</div>
-
+            <div className="flex items-center gap-1">
+              <button
+                onClick={logout}
+                className="p-2 text-gray-400 dark:text-gray-300 hover:text-gray-600 dark:hover:text-white rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
+                aria-label="Log out"
+                title="Log out"
+              >
+                <LogOut className="w-5 h-5" />
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -137,7 +134,6 @@ export default function Layout() {
           isCollapsed ? 'pl-20' : 'pl-64'
         }`}
       >
-
         <header className="sticky top-0 z-30 flex items-center justify-end gap-1 px-8 py-3 bg-white/80 backdrop-blur-md border-b border-gray-200/60">
           <NotificationBell />
           <ThemeToggle />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -35,21 +35,20 @@ export default function Layout() {
   const [isCollapsed, setIsCollapsed] = useState(false)
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-black dark:text-white">
+    <div className="min-h-screen bg-gray-100 text-gray-900 transition-colors duration-200 dark:bg-gray-950 dark:text-gray-100">
       {/* Sidebar */}
       <div
-        className={`fixed inset-y-0 left-0 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transition-[width] duration-200 z-40 ${
+        className={`fixed inset-y-0 left-0 z-40 border-r border-gray-200 bg-white transition-[width,background-color,border-color] duration-200 dark:border-gray-800 dark:bg-gray-900 ${
           isCollapsed ? 'w-20' : 'w-64'
         }`}
       >
         {/* Logo */}
-        <div className="flex items-center justify-between gap-2 px-4 py-4 border-b border-gray-200 dark:border-gray-700">
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between gap-3 border-b border-gray-200 px-4 py-4 dark:border-gray-800">
+          <div className="flex min-w-0 items-center gap-2">
             <Shield className="w-8 h-8 text-primary-600" />
-            <ThemeToggle />
 
             <span
-              className={`text-lg font-semibold text-gray-900 dark:text-white ${
+              className={`truncate text-lg font-semibold text-gray-900 dark:text-gray-100 ${
                 isCollapsed ? 'sr-only' : ''
               }`}
             >
@@ -57,19 +56,23 @@ export default function Layout() {
             </span>
           </div>
 
-          <button
-            type="button"
-            onClick={() => setIsCollapsed((prev) => !prev)}
-            className="p-2 text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-white rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          >
-            {isCollapsed ? (
-              <ChevronRight className="w-5 h-5" />
-            ) : (
-              <ChevronLeft className="w-5 h-5" />
-            )}
-          </button>
+          <div className="flex items-center gap-1">
+            <ThemeToggle />
+
+            <button
+              type="button"
+              onClick={() => setIsCollapsed((prev) => !prev)}
+              className="rounded-lg p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
+              aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            >
+              {isCollapsed ? (
+                <ChevronRight className="w-5 h-5" />
+              ) : (
+                <ChevronLeft className="w-5 h-5" />
+              )}
+            </button>
+          </div>
         </div>
 
         {/* Navigation */}
@@ -84,8 +87,8 @@ export default function Layout() {
                 title={item.name}
                 className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
                   isActive
-                    ? 'bg-primary-50 text-primary-700 dark:bg-primary-900 dark:text-white'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                    ? 'bg-primary-50 text-primary-700 dark:bg-primary-900/50 dark:text-white'
+                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
                 } ${isCollapsed ? 'justify-center' : ''}`}
               >
                 <item.icon className="w-5 h-5" />
@@ -99,14 +102,14 @@ export default function Layout() {
         </nav>
 
         {/* User section */}
-        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 dark:border-gray-700">
+        <div className="absolute bottom-0 left-0 right-0 border-t border-gray-200 p-4 dark:border-gray-800">
           <div
             className={`flex items-center ${
               isCollapsed ? 'justify-center' : 'justify-between'
             }`}
           >
             <div className={isCollapsed ? 'sr-only' : 'truncate'}>
-              <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+              <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
                 {displayName}
               </p>
               <p className="text-xs text-gray-500 truncate dark:text-gray-400">
@@ -117,7 +120,7 @@ export default function Layout() {
             <div className="flex items-center gap-1">
               <button
                 onClick={logout}
-                className="p-2 text-gray-400 dark:text-gray-300 hover:text-gray-600 dark:hover:text-white rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
                 aria-label="Log out"
                 title="Log out"
               >
@@ -134,12 +137,11 @@ export default function Layout() {
           isCollapsed ? 'pl-20' : 'pl-64'
         }`}
       >
-        <header className="sticky top-0 z-30 flex items-center justify-end gap-1 px-8 py-3 bg-white/80 backdrop-blur-md border-b border-gray-200/60">
+        <header className="sticky top-0 z-30 flex items-center justify-end gap-1 border-b border-gray-200/60 bg-white/80 px-8 py-3 backdrop-blur-md transition-colors dark:border-gray-800/80 dark:bg-gray-950/80">
           <NotificationBell />
-          <ThemeToggle />
         </header>
 
-        <main className="p-8 min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
+        <main className="min-h-screen bg-gray-50 p-8 transition-colors duration-200 dark:bg-gray-950">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -2,22 +2,28 @@ import { useState, useEffect } from 'react'
 import { Sun, Moon } from 'lucide-react'
 
 export default function ThemeToggle() {
-  const [isDark, setIsDark] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem('theme') === 'dark'
-    }
-    return false
-  })
+  const [isDark, setIsDark] = useState(false)
 
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', isDark)
-    localStorage.setItem('theme', isDark ? 'dark' : 'light')
-  }, [isDark])
+    const storedTheme = localStorage.getItem('theme')
+    const shouldUseDark = storedTheme === 'dark'
+
+    setIsDark(shouldUseDark)
+    document.documentElement.classList.toggle('dark', shouldUseDark)
+  }, [])
+
+  const toggleTheme = () => {
+    const nextTheme = !isDark
+
+    setIsDark(nextTheme)
+    document.documentElement.classList.toggle('dark', nextTheme)
+    localStorage.setItem('theme', nextTheme ? 'dark' : 'light')
+  }
 
   return (
     <button
       type="button"
-      onClick={() => setIsDark((d) => !d)}
+      onClick={toggleTheme}
       className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
       title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -4,20 +4,14 @@ import { Sun, Moon } from 'lucide-react'
 export default function ThemeToggle() {
   const [isDark, setIsDark] = useState(() => {
     if (typeof window !== 'undefined') {
-  return localStorage.getItem('theme') === 'dark'
-}
-return false
-
+      return localStorage.getItem('theme') === 'dark'
+    }
+    return false
   })
 
   useEffect(() => {
-    if (isDark) {
-      document.documentElement.classList.add('dark')
-      localStorage.setItem('theme', 'dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-      localStorage.setItem('theme', 'light')
-    }
+    document.documentElement.classList.toggle('dark', isDark)
+    localStorage.setItem('theme', isDark ? 'dark' : 'light')
   }, [isDark])
 
   return (


### PR DESCRIPTION
## Summary

Closes #111

This PR implements a dark mode toggle for the AegisAI frontend with persistent theme states. It introduces a `ThemeToggle` component mounted within the sidebar header that toggles the `dark` class on the root HTML element and synchronizes the preference using `localStorage`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Screenshots (if UI change)
