### PR TITLE
Add rag chat page

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -149,9 +149,11 @@ def _build_guard_scan_log(user_id: int, prompt: str, result: dict) -> GuardScanL
     )
 
 
-def log_scan(user_id: int, prompt: str, result: dict) -> None:
+def log_scan(user_id: int, prompt: str, result: dict, db: Session | None = None) -> None:
     """Log scan details and create block notification without storing raw prompt."""
-    db = SessionLocal()
+    owns_session = db is None
+    if db is None:
+        db = SessionLocal()
 
     try:
         log = _build_guard_scan_log(user_id, prompt, result)
@@ -176,7 +178,8 @@ def log_scan(user_id: int, prompt: str, result: dict) -> None:
         db.rollback()
         raise
     finally:
-        db.close()
+        if owns_session:
+            db.close()
 
 
 @router.post("/scan", response_model=ScanResponse)
@@ -238,6 +241,7 @@ def scan_prompt(
             current_user.id,
             request.prompt,
             result,
+            db,
         )
 
         response = ScanResponse(

--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -12,6 +12,7 @@ TODO for contributors (high difficulty):
 import os
 import shutil
 import tempfile
+import time
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
@@ -180,7 +181,11 @@ def query_knowledge_base(
         answer = str(result.get("result", ""))
 
         # Groundedness Check
-        chunk_texts = [str(doc.page_content) for doc in source_docs]
+        chunk_texts = [
+            str(getattr(doc, "page_content", ""))
+            for doc in source_docs
+            if getattr(doc, "page_content", "")
+        ]
         groundedness_score = compute_groundedness(answer, chunk_texts)
         low_confidence = groundedness_score < 0.70
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,6 +11,7 @@ os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 
 from app.core.database import Base, SessionLocal
 from app.main import app
+from app.api.v1.guard import _scan_attempts_by_user, user_guard_configs
 
 
 @pytest.fixture(scope="session")
@@ -58,3 +59,13 @@ def client(db_engine):
     transaction.rollback()
     connection.close()
     app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_guard_state():
+    """Keep per-test guard rate-limit and config state isolated."""
+    _scan_attempts_by_user.clear()
+    user_guard_configs.clear()
+    yield
+    _scan_attempts_by_user.clear()
+    user_guard_configs.clear()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,6 @@ import NotFound from './pages/NotFound'
 import { Toaster } from 'react-hot-toast'
 import RagChat from './pages/RagChat'
 
-
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuthStore()
   return isAuthenticated ? <>{children}</> : <Navigate to="/login" />
@@ -62,8 +61,6 @@ function App() {
           <Route path="guard" element={<GuardConsole />} />
           <Route path="rag-chat" element={<RagChat />} />
           <Route path="notifications" element={<Notifications />} />
-          <Route path="rag-chat" element={<RagChat />} />
-
         </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Outlet, Link, useLocation } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
+import NotificationBell from './NotificationBell'
 import ThemeToggle from './ThemeToggle'
 import {
   LayoutDashboard,
@@ -15,9 +16,6 @@ import {
   ChevronRight,
   BarChart,
 } from 'lucide-react'
-import NotificationBell from './NotificationBell'
-
-
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: LayoutDashboard },
@@ -112,21 +110,20 @@ export default function Layout() {
                 {displayName}
               </p>
               <p className="text-xs text-gray-500 truncate dark:text-gray-400">
-  {companyName}
-</p>
-</div>
+                {companyName}
+              </p>
+            </div>
 
-<div className="flex items-center gap-1">
-  <button
-    onClick={logout}
-    className="p-2 text-gray-400 dark:text-gray-300 hover:text-gray-600 dark:hover:text-white rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-    aria-label="Log out"
-    title="Log out"
-  >
-    <LogOut className="w-5 h-5" />
-  </button>
-</div>
-
+            <div className="flex items-center gap-1">
+              <button
+                onClick={logout}
+                className="p-2 text-gray-400 dark:text-gray-300 hover:text-gray-600 dark:hover:text-white rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
+                aria-label="Log out"
+                title="Log out"
+              >
+                <LogOut className="w-5 h-5" />
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -137,7 +134,6 @@ export default function Layout() {
           isCollapsed ? 'pl-20' : 'pl-64'
         }`}
       >
-
         <header className="sticky top-0 z-30 flex items-center justify-end gap-1 px-8 py-3 bg-white/80 backdrop-blur-md border-b border-gray-200/60">
           <NotificationBell />
           <ThemeToggle />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -24,7 +24,7 @@ const navigation = [
   { name: 'Risk Classification', href: '/classification', icon: FileCheck },
   { name: 'Documents', href: '/documents', icon: FileText },
   { name: 'LLM Guard', href: '/guard', icon: ShieldCheck },
-  { name: 'Chatbot', href: '/rag-chat', icon: MessageSquareText },
+  { name: 'RAG Chat', href: '/rag-chat', icon: MessageSquareText },
 ]
 
 export default function Layout() {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -35,21 +35,20 @@ export default function Layout() {
   const [isCollapsed, setIsCollapsed] = useState(false)
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-black dark:text-white">
+    <div className="min-h-screen bg-gray-100 text-gray-900 transition-colors duration-200 dark:bg-gray-950 dark:text-gray-100">
       {/* Sidebar */}
       <div
-        className={`fixed inset-y-0 left-0 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transition-[width] duration-200 z-40 ${
+        className={`fixed inset-y-0 left-0 z-40 border-r border-gray-200 bg-white transition-[width,background-color,border-color] duration-200 dark:border-gray-800 dark:bg-gray-900 ${
           isCollapsed ? 'w-20' : 'w-64'
         }`}
       >
         {/* Logo */}
-        <div className="flex items-center justify-between gap-2 px-4 py-4 border-b border-gray-200 dark:border-gray-700">
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between gap-3 border-b border-gray-200 px-4 py-4 dark:border-gray-800">
+          <div className="flex min-w-0 items-center gap-2">
             <Shield className="w-8 h-8 text-primary-600" />
-            <ThemeToggle />
 
             <span
-              className={`text-lg font-semibold text-gray-900 dark:text-white ${
+              className={`truncate text-lg font-semibold text-gray-900 dark:text-gray-100 ${
                 isCollapsed ? 'sr-only' : ''
               }`}
             >
@@ -57,19 +56,23 @@ export default function Layout() {
             </span>
           </div>
 
-          <button
-            type="button"
-            onClick={() => setIsCollapsed((prev) => !prev)}
-            className="p-2 text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-white rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          >
-            {isCollapsed ? (
-              <ChevronRight className="w-5 h-5" />
-            ) : (
-              <ChevronLeft className="w-5 h-5" />
-            )}
-          </button>
+          <div className="flex items-center gap-1">
+            <ThemeToggle />
+
+            <button
+              type="button"
+              onClick={() => setIsCollapsed((prev) => !prev)}
+              className="rounded-lg p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
+              aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            >
+              {isCollapsed ? (
+                <ChevronRight className="w-5 h-5" />
+              ) : (
+                <ChevronLeft className="w-5 h-5" />
+              )}
+            </button>
+          </div>
         </div>
 
         {/* Navigation */}
@@ -84,8 +87,8 @@ export default function Layout() {
                 title={item.name}
                 className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
                   isActive
-                    ? 'bg-primary-50 text-primary-700 dark:bg-primary-900 dark:text-white'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                    ? 'bg-primary-50 text-primary-700 dark:bg-primary-900/50 dark:text-white'
+                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
                 } ${isCollapsed ? 'justify-center' : ''}`}
               >
                 <item.icon className="w-5 h-5" />
@@ -99,14 +102,14 @@ export default function Layout() {
         </nav>
 
         {/* User section */}
-        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 dark:border-gray-700">
+        <div className="absolute bottom-0 left-0 right-0 border-t border-gray-200 p-4 dark:border-gray-800">
           <div
             className={`flex items-center ${
               isCollapsed ? 'justify-center' : 'justify-between'
             }`}
           >
             <div className={isCollapsed ? 'sr-only' : 'truncate'}>
-              <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+              <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
                 {displayName}
               </p>
               <p className="text-xs text-gray-500 truncate dark:text-gray-400">
@@ -117,7 +120,7 @@ export default function Layout() {
             <div className="flex items-center gap-1">
               <button
                 onClick={logout}
-                className="p-2 text-gray-400 dark:text-gray-300 hover:text-gray-600 dark:hover:text-white rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
                 aria-label="Log out"
                 title="Log out"
               >
@@ -134,12 +137,11 @@ export default function Layout() {
           isCollapsed ? 'pl-20' : 'pl-64'
         }`}
       >
-        <header className="sticky top-0 z-30 flex items-center justify-end gap-1 px-8 py-3 bg-white/80 backdrop-blur-md border-b border-gray-200/60">
+        <header className="sticky top-0 z-30 flex items-center justify-end gap-1 border-b border-gray-200/60 bg-white/80 px-8 py-3 backdrop-blur-md transition-colors dark:border-gray-800/80 dark:bg-gray-950/80">
           <NotificationBell />
-          <ThemeToggle />
         </header>
 
-        <main className="p-8 min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
+        <main className="min-h-screen bg-gray-50 p-8 transition-colors duration-200 dark:bg-gray-950">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -2,22 +2,28 @@ import { useState, useEffect } from 'react'
 import { Sun, Moon } from 'lucide-react'
 
 export default function ThemeToggle() {
-  const [isDark, setIsDark] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem('theme') === 'dark'
-    }
-    return false
-  })
+  const [isDark, setIsDark] = useState(false)
 
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', isDark)
-    localStorage.setItem('theme', isDark ? 'dark' : 'light')
-  }, [isDark])
+    const storedTheme = localStorage.getItem('theme')
+    const shouldUseDark = storedTheme === 'dark'
+
+    setIsDark(shouldUseDark)
+    document.documentElement.classList.toggle('dark', shouldUseDark)
+  }, [])
+
+  const toggleTheme = () => {
+    const nextTheme = !isDark
+
+    setIsDark(nextTheme)
+    document.documentElement.classList.toggle('dark', nextTheme)
+    localStorage.setItem('theme', nextTheme ? 'dark' : 'light')
+  }
 
   return (
     <button
       type="button"
-      onClick={() => setIsDark((d) => !d)}
+      onClick={toggleTheme}
       className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
       title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -4,20 +4,14 @@ import { Sun, Moon } from 'lucide-react'
 export default function ThemeToggle() {
   const [isDark, setIsDark] = useState(() => {
     if (typeof window !== 'undefined') {
-  return localStorage.getItem('theme') === 'dark'
-}
-return false
-
+      return localStorage.getItem('theme') === 'dark'
+    }
+    return false
   })
 
   useEffect(() => {
-    if (isDark) {
-      document.documentElement.classList.add('dark')
-      localStorage.setItem('theme', 'dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-      localStorage.setItem('theme', 'light')
-    }
+    document.documentElement.classList.toggle('dark', isDark)
+    localStorage.setItem('theme', isDark ? 'dark' : 'light')
   }, [isDark])
 
   return (

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -1,172 +1,350 @@
-import { useState, type FormEvent } from 'react'
-import { Bot, FileText, Sparkles, Send } from 'lucide-react'
+import { useState } from 'react'
+import { AlertCircle, Bot, FileText, Loader2, Send, Sparkles, User } from 'lucide-react'
+import CopyButton from '../components/CopyButton'
+import { ragApi } from '../services/api'
+
+interface RagSource {
+  title: string
+  excerpt: string
+}
+
+interface RagAnswer {
+  answer: string
+  sources: RagSource[]
+  answer_id?: string
+}
+
+interface ApiError {
+  response?: {
+    status?: number
+    data?: {
+      detail?: string
+    }
+  }
+  message?: string
+}
+
+function isApiError(error: unknown): error is ApiError {
+  return typeof error === 'object' && error !== null
+}
+
+function buildAnswerExport(answer: RagAnswer): string {
+  return [
+    'AI Response',
+    answer.answer,
+    '',
+    'Source citations',
+    ...answer.sources.map(
+      (source, index) => `${index + 1}. ${source.title}\n${source.excerpt}`
+    ),
+  ].join('\n')
+}
 
 export default function RagChat() {
   const [question, setQuestion] = useState('')
   const [submittedQuestion, setSubmittedQuestion] = useState('')
-  const [askCount, setAskCount] = useState(0)
+  const [answer, setAnswer] = useState<RagAnswer | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+   const [feedbackVote, setFeedbackVote] = useState<'up' | 'down' | null>(null)
+  const [feedbackLoading, setFeedbackLoading] = useState(false)
 
-  const handleAsk = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
+  const handleAsk = async (e: React.FormEvent) => {
+    e.preventDefault()
 
     const trimmedQuestion = question.trim()
 
     if (!trimmedQuestion) {
+      setError('Please enter a question before asking.')
+      setSubmittedQuestion('')
+      setAnswer(null)
       return
     }
 
     setSubmittedQuestion(trimmedQuestion)
     setQuestion('')
-    setAskCount((count) => count + 1)
-  }
+    setIsLoading(true)
+    setError(null)
+    setAnswer(null)
 
-  const hasQuestion = submittedQuestion.length > 0
+    try {
+      // ✅ REAL API CALL
+      const data = await ragApi.query(trimmedQuestion)
+
+      setAnswer({
+        answer: data.answer,
+        sources: data.sources || [],
+      })
+    } catch (err: unknown) {
+      // ✅ ERROR HANDLING
+      const apiError = isApiError(err) ? err : {}
+
+      if (apiError.response?.status === 503) {
+        setError('Index not ready. Please try again later.')
+      } else if (apiError.response?.status === 401) {
+        setError('Unauthorized. Please login again.')
+      } else {
+        setError(
+          apiError.response?.data?.detail ||
+            apiError.message ||
+            'Unable to generate an answer right now.'
+        )
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+  const handleFeedback = async (vote: 'up' | 'down') => {
+  if (!answer?.answer_id || feedbackVote) return
+  setFeedbackLoading(true)
+  try {
+    await ragApi.feedback({ answer_id: answer.answer_id, vote })
+    setFeedbackVote(vote)
+  } catch {
+    // silently fail
+  } finally {
+    setFeedbackLoading(false)
+  }
+}
 
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
-      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition-colors dark:border-gray-800 dark:bg-gray-900">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div className="max-w-2xl space-y-3">
-            <div className="inline-flex items-center gap-2 rounded-full bg-primary-50 px-3 py-1 text-sm font-medium text-primary-700 dark:bg-primary-900/40 dark:text-primary-200">
-              <Sparkles className="h-4 w-4" />
-              RAG Chat
-            </div>
-
-            <div className="space-y-2">
-              <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-                Ask a compliance question
-              </h1>
-              <p className="text-sm leading-6 text-gray-600 dark:text-gray-300">
-                This page is the frontend shell for the future RAG chat experience.
-                API wiring will be added in a follow-up issue.
-              </p>
-            </div>
+    <div className="h-[calc(100vh-2rem)] md:h-[calc(100vh-4rem)] flex flex-col bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <div className="px-4 sm:px-6 py-4 border-b border-gray-200 bg-white">
+        <div className="flex items-center gap-3">
+          <div className="p-2 sm:p-3 bg-primary-50 rounded-xl">
+            <Bot className="w-5 h-5 sm:w-6 sm:h-6 text-primary-600" />
           </div>
-
-          <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-300">
-            <p className="font-medium text-gray-900 dark:text-gray-100">Status</p>
-            <p className="mt-1">UI scaffold only. No backend calls yet.</p>
+          <div>
+            <h1 className="text-xl sm:text-2xl font-bold text-gray-900">Chatbot</h1>
+            <p className="text-sm sm:text-base text-gray-600">
+              Ask regulatory and compliance questions with source-backed answers
+            </p>
           </div>
         </div>
-      </section>
+      </div>
 
-      <section className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
-        <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition-colors dark:border-gray-800 dark:bg-gray-900">
-          <div className="mb-5 flex items-center gap-3">
-            <div className="rounded-xl bg-primary-50 p-2 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300">
-              <Bot className="h-5 w-5" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                Question
+      <div className="flex-1 overflow-y-auto bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6 sm:space-y-8">
+          {!submittedQuestion && !answer && !isLoading && !error && (
+            <div className="min-h-[320px] sm:min-h-[420px] flex flex-col items-center justify-center text-center">
+              <div className="p-3 sm:p-4 bg-primary-50 rounded-2xl mb-5">
+                <Sparkles className="w-8 h-8 sm:w-10 sm:h-10 text-primary-600" />
+              </div>
+              <h2 className="text-xl sm:text-2xl font-semibold text-gray-900">
+                How can I help with AI compliance?
               </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Enter a prompt to reserve space for the chat flow.
+              <p className="text-sm sm:text-base text-gray-500 mt-2 max-w-xl">
+                Ask about EU AI Act risk classification, compliance documentation,
+                human oversight, or source-backed regulatory guidance.
               </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 mt-6 sm:mt-8 w-full">
+                {[
+                  'Does my system qualify as high-risk?',
+                  'Which documents are needed for compliance?',
+                  'What does human oversight require?',
+                ].map((example) => (
+                  <button
+                    key={example}
+                    type="button"
+                    onClick={() => setQuestion(example)}
+                    className="text-left bg-white border border-gray-200 rounded-xl p-4 text-sm text-gray-700 hover:border-primary-200 hover:bg-primary-50 transition-colors"
+                  >
+                    {example}
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
+          )}
 
-          <form onSubmit={handleAsk} className="space-y-4">
-            <label htmlFor="rag-question" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Ask a question
+          {(submittedQuestion || answer || isLoading || error) && (
+            <div className="space-y-5 sm:space-y-6">
+              {submittedQuestion && (
+                <div className="flex justify-end">
+                  <div className="w-full sm:w-auto sm:max-w-2xl bg-primary-600 text-white rounded-2xl sm:rounded-br-md px-4 sm:px-5 py-3 sm:py-4 shadow-sm">
+                    <div className="flex items-start gap-3">
+                      <User className="w-5 h-5 mt-0.5 flex-shrink-0" />
+                      <p className="text-sm leading-6">{submittedQuestion}</p>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {isLoading && (
+                <div className="flex justify-start">
+                  <div className="w-full max-w-3xl bg-white border border-gray-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 shadow-sm">
+                    <div className="flex items-center gap-3 mb-4">
+                      <div className="p-2 bg-primary-50 rounded-lg">
+                        <Bot className="w-5 h-5 text-primary-600" />
+                      </div>
+                      <div className="flex items-center gap-2 text-sm font-medium text-gray-900">
+                        <Loader2 className="w-4 h-4 animate-spin text-primary-600" />
+                        Searching knowledge base
+                      </div>
+                    </div>
+                    <div className="space-y-3 animate-pulse">
+                      <div className="h-3 bg-gray-200 rounded-full w-11/12" />
+                      <div className="h-3 bg-gray-200 rounded-full w-full" />
+                      <div className="h-3 bg-gray-200 rounded-full w-9/12" />
+                      <div className="pt-4 mt-5 border-t border-gray-100 space-y-3">
+                        <div className="h-3 bg-gray-200 rounded-full w-32" />
+                        <div className="h-16 bg-gray-100 border border-gray-200 rounded-lg" />
+                        <div className="h-16 bg-gray-100 border border-gray-200 rounded-lg" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {!isLoading && error && (
+                <div className="flex justify-start">
+                  <div className="w-full max-w-3xl bg-red-50 border border-red-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 text-red-800">
+                    <div className="flex items-start gap-3">
+                      <AlertCircle className="w-5 h-5 mt-0.5 flex-shrink-0" />
+                      <div>
+                        <h3 className="font-medium">Unable to answer</h3>
+                        <p className="text-sm mt-1">{error}</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {!isLoading && !error && answer && (
+                <div className="flex justify-start">
+                  <div className="w-full max-w-3xl bg-white border border-gray-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 shadow-sm">
+                    <div className="flex items-start gap-3">
+                      <div className="p-2 bg-primary-50 rounded-lg flex-shrink-0">
+                        <Bot className="w-5 h-5 text-primary-600" />
+                      </div>
+                      <div className="space-y-5 min-w-0">
+                        <div className="flex items-center justify-between gap-3">
+                          <h3 className="text-sm font-semibold text-gray-900">
+                            Generated answer
+                          </h3>
+
+                          <CopyButton
+                            text={buildAnswerExport(answer)}
+                            label="Copy Answer"
+                            successMessage="Answer copied!"
+                          />
+                        </div>
+
+                        <p className="text-gray-700 leading-7">{answer.answer}</p>
+
+                        {answer.answer_id && (
+                          <div className="flex items-center gap-3 pt-2">
+                            <span className="text-xs text-gray-500">Was this helpful?</span>
+                            <button
+                              type="button"
+                              disabled={!!feedbackVote || feedbackLoading}
+                              onClick={() => handleFeedback('up')}
+                              className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+                                feedbackVote === 'up'
+                                  ? 'bg-green-50 border-green-300 text-green-700'
+                                  : 'border-gray-200 text-gray-500 hover:bg-gray-50'
+                              } disabled:opacity-50 disabled:cursor-not-allowed`}
+                              aria-label="Thumbs up"
+                            >
+                              👍 {feedbackVote === 'up' ? 'Helpful' : ''}
+                            </button>
+                            <button
+                              type="button"
+                              disabled={!!feedbackVote || feedbackLoading}
+                              onClick={() => handleFeedback('down')}
+                              className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+                                feedbackVote === 'down'
+                                  ? 'bg-red-50 border-red-300 text-red-700'
+                                  : 'border-gray-200 text-gray-500 hover:bg-gray-50'
+                              } disabled:opacity-50 disabled:cursor-not-allowed`}
+                              aria-label="Thumbs down"
+                            >
+                              👎 {feedbackVote === 'down' ? 'Not helpful' : ''}
+                            </button>
+                            {feedbackVote && (
+                              <span className="text-xs text-gray-400">Thanks for your feedback!</span>
+                            )}
+                          </div>
+                        )}
+
+                        <div className="border-t border-gray-100 pt-5">
+                          <h3 className="text-sm font-semibold text-gray-900 mb-3">
+                            Source citations
+                          </h3>
+
+                          <div className="space-y-3">
+                            {answer.sources.map((source) => (
+                              <div
+                                key={source.title}
+                                className="bg-gray-50 border border-gray-200 rounded-lg p-4"
+                              >
+                                <div className="flex items-center gap-2 mb-2">
+                                  <FileText className="w-4 h-4 text-primary-600" />
+
+                                  <h4 className="text-sm font-medium text-gray-900">
+                                    {source.title}
+                                  </h4>
+                                </div>
+
+                                <p className="text-sm text-gray-600">
+                                  {source.excerpt}
+                                </p>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="border-t border-gray-200 bg-white px-4 sm:px-6 py-3 sm:py-4">
+        <form onSubmit={handleAsk} className="max-w-4xl mx-auto">
+          <div className="flex items-end gap-2 sm:gap-3 bg-gray-50 border border-gray-300 rounded-2xl px-3 sm:px-4 py-3 focus-within:ring-2 focus-within:ring-primary-500 focus-within:border-primary-500">
+            <label htmlFor="rag-question" className="sr-only">
+              Question
             </label>
 
             <textarea
               id="rag-question"
               value={question}
-              onChange={(event) => setQuestion(event.target.value)}
-              placeholder="For example: What controls should I document for a high-risk AI system?"
-              rows={5}
-              className="w-full rounded-xl border border-gray-300 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-primary-500 focus:ring-2 focus:ring-primary-100 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-primary-400 dark:focus:ring-primary-900/40"
+              onChange={(e) => setQuestion(e.target.value)}
+              placeholder="Ask a compliance question..."
+              rows={1}
+              disabled={isLoading}
+              className="min-w-0 flex-1 resize-none bg-transparent border-0 p-0 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-0 disabled:text-gray-500"
             />
 
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-xs text-gray-500 dark:text-gray-400">
-                {askCount === 0
-                  ? 'Answers and citations will render here after the API is wired.'
-                  : 'This is a local-only placeholder interaction for the UI.'}
-              </p>
-
-              <button
-                type="submit"
-                className="inline-flex items-center justify-center gap-2 rounded-xl bg-primary-600 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-gray-900"
-                disabled={!question.trim()}
-              >
-                <Send className="h-4 w-4" />
-                Ask
-              </button>
-            </div>
-          </form>
-        </div>
-
-        <div className="space-y-6">
-          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition-colors dark:border-gray-800 dark:bg-gray-900">
-            <div className="mb-4 flex items-center gap-3">
-              <div className="rounded-xl bg-primary-50 p-2 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300">
-                <Sparkles className="h-5 w-5" />
-              </div>
-              <div>
-                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                  Answer
-                </h2>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  Placeholder response area for the future API result.
-                </p>
-              </div>
-            </div>
-
-            {hasQuestion ? (
-              <div className="rounded-xl border border-dashed border-primary-200 bg-primary-50/60 p-4 text-sm leading-6 text-gray-700 dark:border-primary-900/60 dark:bg-primary-900/20 dark:text-gray-200">
-                <p className="mb-2 font-medium text-gray-900 dark:text-gray-100">
-                  Last question submitted
-                </p>
-                <p>{submittedQuestion}</p>
-                <div className="mt-4 rounded-lg bg-white/80 p-4 text-gray-500 dark:bg-gray-950/60 dark:text-gray-300">
-                  Answer content will appear here once the RAG API is connected.
-                </div>
-              </div>
-            ) : (
-              <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-400">
-                Ask a question to reserve the answer slot.
-              </div>
-            )}
-          </section>
-
-          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition-colors dark:border-gray-800 dark:bg-gray-900">
-            <div className="mb-4 flex items-center gap-3">
-              <div className="rounded-xl bg-primary-50 p-2 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300">
-                <FileText className="h-5 w-5" />
-              </div>
-              <div>
-                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                  Source citations
-                </h2>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  Placeholder cards for referenced documents.
-                </p>
-              </div>
-            </div>
-
-            <div className="space-y-3">
-              {['Policy document placeholder', 'Internal guidance placeholder'].map(
-                (source) => (
-                  <div
-                    key={source}
-                    className="rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-950"
-                  >
-                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                      {source}
-                    </p>
-                    <p className="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-400">
-                      Source excerpt placeholder will render here after the backend is wired.
-                    </p>
-                  </div>
-                )
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="inline-flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 bg-primary-600 text-white rounded-xl hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+              aria-label="Ask question"
+              title="Ask question"
+            >
+              {isLoading ? (
+                <Loader2 className="w-5 h-5 animate-spin" />
+              ) : (
+                <Send className="w-5 h-5" />
               )}
-            </div>
-          </section>
-        </div>
-      </section>
+            </button>
+          </div>
+
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 mt-2">
+            <p className="text-xs text-gray-500">
+              Ask compliance questions and get source-backed answers.
+            </p>
+
+            <p className="text-xs text-gray-400">
+              Use this assistant to explore risk, documentation, and governance obligations.
+            </p>
+          </div>
+        </form>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -1,350 +1,172 @@
-import { useState } from 'react'
-import { AlertCircle, Bot, FileText, Loader2, Send, Sparkles, User } from 'lucide-react'
-import CopyButton from '../components/CopyButton'
-import { ragApi } from '../services/api'
-
-interface RagSource {
-  title: string
-  excerpt: string
-}
-
-interface RagAnswer {
-  answer: string
-  sources: RagSource[]
-  answer_id?: string
-}
-
-interface ApiError {
-  response?: {
-    status?: number
-    data?: {
-      detail?: string
-    }
-  }
-  message?: string
-}
-
-function isApiError(error: unknown): error is ApiError {
-  return typeof error === 'object' && error !== null
-}
-
-function buildAnswerExport(answer: RagAnswer): string {
-  return [
-    'AI Response',
-    answer.answer,
-    '',
-    'Source citations',
-    ...answer.sources.map(
-      (source, index) => `${index + 1}. ${source.title}\n${source.excerpt}`
-    ),
-  ].join('\n')
-}
+import { useState, type FormEvent } from 'react'
+import { Bot, FileText, Sparkles, Send } from 'lucide-react'
 
 export default function RagChat() {
   const [question, setQuestion] = useState('')
   const [submittedQuestion, setSubmittedQuestion] = useState('')
-  const [answer, setAnswer] = useState<RagAnswer | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-   const [feedbackVote, setFeedbackVote] = useState<'up' | 'down' | null>(null)
-  const [feedbackLoading, setFeedbackLoading] = useState(false)
+  const [askCount, setAskCount] = useState(0)
 
-  const handleAsk = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleAsk = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
 
     const trimmedQuestion = question.trim()
 
     if (!trimmedQuestion) {
-      setError('Please enter a question before asking.')
-      setSubmittedQuestion('')
-      setAnswer(null)
       return
     }
 
     setSubmittedQuestion(trimmedQuestion)
     setQuestion('')
-    setIsLoading(true)
-    setError(null)
-    setAnswer(null)
-
-    try {
-      // ✅ REAL API CALL
-      const data = await ragApi.query(trimmedQuestion)
-
-      setAnswer({
-        answer: data.answer,
-        sources: data.sources || [],
-      })
-    } catch (err: unknown) {
-      // ✅ ERROR HANDLING
-      const apiError = isApiError(err) ? err : {}
-
-      if (apiError.response?.status === 503) {
-        setError('Index not ready. Please try again later.')
-      } else if (apiError.response?.status === 401) {
-        setError('Unauthorized. Please login again.')
-      } else {
-        setError(
-          apiError.response?.data?.detail ||
-            apiError.message ||
-            'Unable to generate an answer right now.'
-        )
-      }
-    } finally {
-      setIsLoading(false)
-    }
+    setAskCount((count) => count + 1)
   }
-  const handleFeedback = async (vote: 'up' | 'down') => {
-  if (!answer?.answer_id || feedbackVote) return
-  setFeedbackLoading(true)
-  try {
-    await ragApi.feedback({ answer_id: answer.answer_id, vote })
-    setFeedbackVote(vote)
-  } catch {
-    // silently fail
-  } finally {
-    setFeedbackLoading(false)
-  }
-}
+
+  const hasQuestion = submittedQuestion.length > 0
 
   return (
-    <div className="h-[calc(100vh-2rem)] md:h-[calc(100vh-4rem)] flex flex-col bg-white rounded-xl border border-gray-200 overflow-hidden">
-      <div className="px-4 sm:px-6 py-4 border-b border-gray-200 bg-white">
-        <div className="flex items-center gap-3">
-          <div className="p-2 sm:p-3 bg-primary-50 rounded-xl">
-            <Bot className="w-5 h-5 sm:w-6 sm:h-6 text-primary-600" />
-          </div>
-          <div>
-            <h1 className="text-xl sm:text-2xl font-bold text-gray-900">Chatbot</h1>
-            <p className="text-sm sm:text-base text-gray-600">
-              Ask regulatory and compliance questions with source-backed answers
-            </p>
-          </div>
-        </div>
-      </div>
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition-colors dark:border-gray-800 dark:bg-gray-900">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-2xl space-y-3">
+            <div className="inline-flex items-center gap-2 rounded-full bg-primary-50 px-3 py-1 text-sm font-medium text-primary-700 dark:bg-primary-900/40 dark:text-primary-200">
+              <Sparkles className="h-4 w-4" />
+              RAG Chat
+            </div>
 
-      <div className="flex-1 overflow-y-auto bg-gray-50">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6 sm:space-y-8">
-          {!submittedQuestion && !answer && !isLoading && !error && (
-            <div className="min-h-[320px] sm:min-h-[420px] flex flex-col items-center justify-center text-center">
-              <div className="p-3 sm:p-4 bg-primary-50 rounded-2xl mb-5">
-                <Sparkles className="w-8 h-8 sm:w-10 sm:h-10 text-primary-600" />
-              </div>
-              <h2 className="text-xl sm:text-2xl font-semibold text-gray-900">
-                How can I help with AI compliance?
-              </h2>
-              <p className="text-sm sm:text-base text-gray-500 mt-2 max-w-xl">
-                Ask about EU AI Act risk classification, compliance documentation,
-                human oversight, or source-backed regulatory guidance.
+            <div className="space-y-2">
+              <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+                Ask a compliance question
+              </h1>
+              <p className="text-sm leading-6 text-gray-600 dark:text-gray-300">
+                This page is the frontend shell for the future RAG chat experience.
+                API wiring will be added in a follow-up issue.
               </p>
-              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 mt-6 sm:mt-8 w-full">
-                {[
-                  'Does my system qualify as high-risk?',
-                  'Which documents are needed for compliance?',
-                  'What does human oversight require?',
-                ].map((example) => (
-                  <button
-                    key={example}
-                    type="button"
-                    onClick={() => setQuestion(example)}
-                    className="text-left bg-white border border-gray-200 rounded-xl p-4 text-sm text-gray-700 hover:border-primary-200 hover:bg-primary-50 transition-colors"
-                  >
-                    {example}
-                  </button>
-                ))}
-              </div>
             </div>
-          )}
+          </div>
 
-          {(submittedQuestion || answer || isLoading || error) && (
-            <div className="space-y-5 sm:space-y-6">
-              {submittedQuestion && (
-                <div className="flex justify-end">
-                  <div className="w-full sm:w-auto sm:max-w-2xl bg-primary-600 text-white rounded-2xl sm:rounded-br-md px-4 sm:px-5 py-3 sm:py-4 shadow-sm">
-                    <div className="flex items-start gap-3">
-                      <User className="w-5 h-5 mt-0.5 flex-shrink-0" />
-                      <p className="text-sm leading-6">{submittedQuestion}</p>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {isLoading && (
-                <div className="flex justify-start">
-                  <div className="w-full max-w-3xl bg-white border border-gray-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 shadow-sm">
-                    <div className="flex items-center gap-3 mb-4">
-                      <div className="p-2 bg-primary-50 rounded-lg">
-                        <Bot className="w-5 h-5 text-primary-600" />
-                      </div>
-                      <div className="flex items-center gap-2 text-sm font-medium text-gray-900">
-                        <Loader2 className="w-4 h-4 animate-spin text-primary-600" />
-                        Searching knowledge base
-                      </div>
-                    </div>
-                    <div className="space-y-3 animate-pulse">
-                      <div className="h-3 bg-gray-200 rounded-full w-11/12" />
-                      <div className="h-3 bg-gray-200 rounded-full w-full" />
-                      <div className="h-3 bg-gray-200 rounded-full w-9/12" />
-                      <div className="pt-4 mt-5 border-t border-gray-100 space-y-3">
-                        <div className="h-3 bg-gray-200 rounded-full w-32" />
-                        <div className="h-16 bg-gray-100 border border-gray-200 rounded-lg" />
-                        <div className="h-16 bg-gray-100 border border-gray-200 rounded-lg" />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {!isLoading && error && (
-                <div className="flex justify-start">
-                  <div className="w-full max-w-3xl bg-red-50 border border-red-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 text-red-800">
-                    <div className="flex items-start gap-3">
-                      <AlertCircle className="w-5 h-5 mt-0.5 flex-shrink-0" />
-                      <div>
-                        <h3 className="font-medium">Unable to answer</h3>
-                        <p className="text-sm mt-1">{error}</p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {!isLoading && !error && answer && (
-                <div className="flex justify-start">
-                  <div className="w-full max-w-3xl bg-white border border-gray-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 shadow-sm">
-                    <div className="flex items-start gap-3">
-                      <div className="p-2 bg-primary-50 rounded-lg flex-shrink-0">
-                        <Bot className="w-5 h-5 text-primary-600" />
-                      </div>
-                      <div className="space-y-5 min-w-0">
-                        <div className="flex items-center justify-between gap-3">
-                          <h3 className="text-sm font-semibold text-gray-900">
-                            Generated answer
-                          </h3>
-
-                          <CopyButton
-                            text={buildAnswerExport(answer)}
-                            label="Copy Answer"
-                            successMessage="Answer copied!"
-                          />
-                        </div>
-
-                        <p className="text-gray-700 leading-7">{answer.answer}</p>
-
-                        {answer.answer_id && (
-                          <div className="flex items-center gap-3 pt-2">
-                            <span className="text-xs text-gray-500">Was this helpful?</span>
-                            <button
-                              type="button"
-                              disabled={!!feedbackVote || feedbackLoading}
-                              onClick={() => handleFeedback('up')}
-                              className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm border transition-colors ${
-                                feedbackVote === 'up'
-                                  ? 'bg-green-50 border-green-300 text-green-700'
-                                  : 'border-gray-200 text-gray-500 hover:bg-gray-50'
-                              } disabled:opacity-50 disabled:cursor-not-allowed`}
-                              aria-label="Thumbs up"
-                            >
-                              👍 {feedbackVote === 'up' ? 'Helpful' : ''}
-                            </button>
-                            <button
-                              type="button"
-                              disabled={!!feedbackVote || feedbackLoading}
-                              onClick={() => handleFeedback('down')}
-                              className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm border transition-colors ${
-                                feedbackVote === 'down'
-                                  ? 'bg-red-50 border-red-300 text-red-700'
-                                  : 'border-gray-200 text-gray-500 hover:bg-gray-50'
-                              } disabled:opacity-50 disabled:cursor-not-allowed`}
-                              aria-label="Thumbs down"
-                            >
-                              👎 {feedbackVote === 'down' ? 'Not helpful' : ''}
-                            </button>
-                            {feedbackVote && (
-                              <span className="text-xs text-gray-400">Thanks for your feedback!</span>
-                            )}
-                          </div>
-                        )}
-
-                        <div className="border-t border-gray-100 pt-5">
-                          <h3 className="text-sm font-semibold text-gray-900 mb-3">
-                            Source citations
-                          </h3>
-
-                          <div className="space-y-3">
-                            {answer.sources.map((source) => (
-                              <div
-                                key={source.title}
-                                className="bg-gray-50 border border-gray-200 rounded-lg p-4"
-                              >
-                                <div className="flex items-center gap-2 mb-2">
-                                  <FileText className="w-4 h-4 text-primary-600" />
-
-                                  <h4 className="text-sm font-medium text-gray-900">
-                                    {source.title}
-                                  </h4>
-                                </div>
-
-                                <p className="text-sm text-gray-600">
-                                  {source.excerpt}
-                                </p>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
+          <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-300">
+            <p className="font-medium text-gray-900 dark:text-gray-100">Status</p>
+            <p className="mt-1">UI scaffold only. No backend calls yet.</p>
+          </div>
         </div>
-      </div>
+      </section>
 
-      <div className="border-t border-gray-200 bg-white px-4 sm:px-6 py-3 sm:py-4">
-        <form onSubmit={handleAsk} className="max-w-4xl mx-auto">
-          <div className="flex items-end gap-2 sm:gap-3 bg-gray-50 border border-gray-300 rounded-2xl px-3 sm:px-4 py-3 focus-within:ring-2 focus-within:ring-primary-500 focus-within:border-primary-500">
-            <label htmlFor="rag-question" className="sr-only">
-              Question
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition-colors dark:border-gray-800 dark:bg-gray-900">
+          <div className="mb-5 flex items-center gap-3">
+            <div className="rounded-xl bg-primary-50 p-2 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300">
+              <Bot className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                Question
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Enter a prompt to reserve space for the chat flow.
+              </p>
+            </div>
+          </div>
+
+          <form onSubmit={handleAsk} className="space-y-4">
+            <label htmlFor="rag-question" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Ask a question
             </label>
 
             <textarea
               id="rag-question"
               value={question}
-              onChange={(e) => setQuestion(e.target.value)}
-              placeholder="Ask a compliance question..."
-              rows={1}
-              disabled={isLoading}
-              className="min-w-0 flex-1 resize-none bg-transparent border-0 p-0 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-0 disabled:text-gray-500"
+              onChange={(event) => setQuestion(event.target.value)}
+              placeholder="For example: What controls should I document for a high-risk AI system?"
+              rows={5}
+              className="w-full rounded-xl border border-gray-300 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-primary-500 focus:ring-2 focus:ring-primary-100 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-primary-400 dark:focus:ring-primary-900/40"
             />
 
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="inline-flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 bg-primary-600 text-white rounded-xl hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
-              aria-label="Ask question"
-              title="Ask question"
-            >
-              {isLoading ? (
-                <Loader2 className="w-5 h-5 animate-spin" />
-              ) : (
-                <Send className="w-5 h-5" />
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {askCount === 0
+                  ? 'Answers and citations will render here after the API is wired.'
+                  : 'This is a local-only placeholder interaction for the UI.'}
+              </p>
+
+              <button
+                type="submit"
+                className="inline-flex items-center justify-center gap-2 rounded-xl bg-primary-600 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-gray-900"
+                disabled={!question.trim()}
+              >
+                <Send className="h-4 w-4" />
+                Ask
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <div className="space-y-6">
+          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition-colors dark:border-gray-800 dark:bg-gray-900">
+            <div className="mb-4 flex items-center gap-3">
+              <div className="rounded-xl bg-primary-50 p-2 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300">
+                <Sparkles className="h-5 w-5" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                  Answer
+                </h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Placeholder response area for the future API result.
+                </p>
+              </div>
+            </div>
+
+            {hasQuestion ? (
+              <div className="rounded-xl border border-dashed border-primary-200 bg-primary-50/60 p-4 text-sm leading-6 text-gray-700 dark:border-primary-900/60 dark:bg-primary-900/20 dark:text-gray-200">
+                <p className="mb-2 font-medium text-gray-900 dark:text-gray-100">
+                  Last question submitted
+                </p>
+                <p>{submittedQuestion}</p>
+                <div className="mt-4 rounded-lg bg-white/80 p-4 text-gray-500 dark:bg-gray-950/60 dark:text-gray-300">
+                  Answer content will appear here once the RAG API is connected.
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-400">
+                Ask a question to reserve the answer slot.
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition-colors dark:border-gray-800 dark:bg-gray-900">
+            <div className="mb-4 flex items-center gap-3">
+              <div className="rounded-xl bg-primary-50 p-2 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300">
+                <FileText className="h-5 w-5" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                  Source citations
+                </h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Placeholder cards for referenced documents.
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              {['Policy document placeholder', 'Internal guidance placeholder'].map(
+                (source) => (
+                  <div
+                    key={source}
+                    className="rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-950"
+                  >
+                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                      {source}
+                    </p>
+                    <p className="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-400">
+                      Source excerpt placeholder will render here after the backend is wired.
+                    </p>
+                  </div>
+                )
               )}
-            </button>
-          </div>
-
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 mt-2">
-            <p className="text-xs text-gray-500">
-              Ask compliance questions and get source-backed answers.
-            </p>
-
-            <p className="text-xs text-gray-400">
-              Use this assistant to explore risk, documentation, and governance obligations.
-            </p>
-          </div>
-        </form>
-      </div>
+            </div>
+          </section>
+        </div>
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Closes #42

Creates a clean frontend scaffold for the RAG chat feature inside `frontend/src/pages/RagChat.tsx`. This component establishes the basic UI elements—including a question input field, an 'Ask' button, and explicit placeholder areas for generated responses and source citations—without any active API wiring. It also hooks the view into the main navigation layout and updates the app routing configuration.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Screenshots (if UI change)