### PR TITLE
fix(ai-systems): enforce unique system name per user

### DIFF
--- a/backend/alembic/versions/c3d9f1b2a4e6_add_unique_constraint_ai_system_owner_name.py
+++ b/backend/alembic/versions/c3d9f1b2a4e6_add_unique_constraint_ai_system_owner_name.py
@@ -1,0 +1,28 @@
+"""add unique constraint on ai_systems(owner_id, name)
+
+Revision ID: c3d9f1b2a4e6
+Revises: a7c004156ad1
+Create Date: 2026-05-27 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3d9f1b2a4e6'
+down_revision: Union[str, None] = 'a7c004156ad1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # create composite unique constraint on owner_id, name
+    op.create_unique_constraint('uq_ai_system_owner_name', 'ai_systems', ['owner_id', 'name'])
+
+
+def downgrade() -> None:
+    # drop the composite unique constraint
+    op.drop_constraint('uq_ai_system_owner_name', 'ai_systems', type_='unique')

--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File,
 from fastapi.responses import StreamingResponse
 from sqlalchemy import asc, desc
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from typing import List, Optional
 import csv
 import io
@@ -156,7 +157,14 @@ def create_ai_system(
         sector=system_data.sector,
     )
     db.add(ai_system)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"AI system with name '{system_data.name}' already exists",
+        )
     db.refresh(ai_system)
     return ai_system
 

--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -67,6 +67,7 @@ def _process_import_rows(
 
     errors: list[dict[str, object]] = []
     created_count = 0
+    seen_names: set[str] = set()
 
     for row_num, row in enumerate(csv_reader, start=2):
         if row_num - 1 > max_rows:
@@ -86,9 +87,14 @@ def _process_import_rows(
             errors.append({"row": row_num, "error": "name is required"})
             continue
 
+        # Check for duplicates within the same uploaded CSV first
+        if name in seen_names:
+            errors.append({"row": row_num, "error": f"duplicate name '{name}' in uploaded file"})
+            continue
+
         existing = db.query(AISystem).filter(
             AISystem.owner_id == current_user.id,
-            AISystem.name == name
+            AISystem.name == name,
         ).first()
 
         if existing:
@@ -106,6 +112,7 @@ def _process_import_rows(
             )
             db.add(ai_system)
             created_count += 1
+            seen_names.add(name)
         except Exception as e:
             errors.append({"row": row_num, "error": str(e)})
 
@@ -128,6 +135,18 @@ def create_ai_system(
     Returns:
         The created AI system serialized as AISystemResponse.
     """
+    # Enforce per-user uniqueness of AI system names to match bulk import behavior
+    existing = db.query(AISystem).filter(
+        AISystem.owner_id == current_user.id,
+        AISystem.name == system_data.name,
+    ).first()
+
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"AI system with name '{system_data.name}' already exists",
+        )
+
     ai_system = AISystem(
         owner_id=current_user.id,
         name=system_data.name,

--- a/backend/app/models/ai_system.py
+++ b/backend/app/models/ai_system.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, Enum, ForeignKey, JSON, Float
+from sqlalchemy import Column, Integer, String, Text, DateTime, Enum, ForeignKey, JSON, Float, UniqueConstraint
 from sqlalchemy.orm import relationship
 from datetime import datetime
 import enum
@@ -22,6 +22,9 @@ class ComplianceStatus(str, enum.Enum):
 
 class AISystem(Base):
     __tablename__ = "ai_systems"
+    __table_args__ = (
+        UniqueConstraint("owner_id", "name", name="uq_ai_system_owner_name"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)

--- a/backend/tests/test_ai_systems_duplicates.py
+++ b/backend/tests/test_ai_systems_duplicates.py
@@ -1,0 +1,69 @@
+import os
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.database import Base, get_db
+from app.core.security import get_current_user
+from app.main import app
+from app.models.user import User
+
+
+@pytest.fixture(scope="module")
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=eng)
+    yield eng
+    Base.metadata.drop_all(bind=eng)
+
+
+@pytest.fixture
+def db(engine):
+    conn = engine.connect()
+    tx = conn.begin()
+    session = sessionmaker(autocommit=False, autoflush=False, bind=conn)()
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+@pytest.fixture
+def client(db):
+    user = User(email="dup@test.com", hashed_password="x", full_name="Dupe")
+    db.add(user)
+    db.flush()
+
+    def override_get_db():
+        yield db
+
+    def override_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def test_create_duplicate_ai_system_rejected(client):
+    c = client
+
+    payload = {
+        "name": "Unique System",
+        "description": "Test",
+    }
+
+    resp1 = c.post("/api/v1/ai-systems/", json=payload)
+    assert resp1.status_code == 201
+
+    resp2 = c.post("/api/v1/ai-systems/", json=payload)
+    assert resp2.status_code == 400
+    assert "already exists" in resp2.json()["detail"].lower()


### PR DESCRIPTION
Closes #730 

## Summary

This PR enforces per-user uniqueness of AI system names and fixes a gap where the canonical `POST /api/v1/ai-systems/` endpoint could create duplicate systems even though the bulk CSV importer attempted to detect duplicates. Changes include:

- Add DB-level composite `UNIQUE(owner_id, name)` constraint for `ai_systems`.
- Enforce duplicate-name validation in the create endpoint (returns 400).
- Prevent duplicates inside the same uploaded CSV by tracking `seen_names` (row-level errors).
- Catch `IntegrityError` on commit and return a friendly 400 for race-condition violations.
- Add an Alembic migration that creates the unique constraint.
- Add a unit test verifying duplicate creation is rejected.

Files changed (high level)
- ai_system.py — add UniqueConstraint
- ai_systems.py — create endpoint validation, bulk-import dedupe, IntegrityError handling
- c3d9f1b2a4e6_add_unique_constraint_ai_system_owner_name.py — migration
- test_ai_systems_duplicates.py — new test

## Type of Change

- [x] Bug fix
- [x] Tests
- [x] Infra / CI (DB migration)

## Checklist

- [x] I have read [CONTRIBUTING.md](.CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## How I tested

- Added test_ai_systems_duplicates.py which:
  - creates a user,
  - posts `POST /api/v1/ai-systems/` to create a system,
  - asserts the second identical create returns 400 and contains an appropriate error message.
