### PR TITLE
feat: add Export CSV button to AISystems toolbar (#212)

### DIFF
--- a/frontend/src/pages/AISystems.tsx
+++ b/frontend/src/pages/AISystems.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { aiSystemsApi } from '../services/api'
-import { Bot, Plus, Trash2, Edit, Search, Filter, ArrowUpDown, X } from 'lucide-react'
+import { useAuthStore } from '../stores/authStore'
+import { Bot, Plus, Trash2, Edit, Search, Filter, ArrowUpDown, X, Download } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 
 interface AISystem {
@@ -32,10 +33,38 @@ export default function AISystems() {
   const [order, setOrder] = useState('desc')
   const [systemToDelete, setSystemToDelete] = useState<AISystem | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
+  const [exporting, setExporting] = useState(false)
+
+  const handleExport = async () => {
+    setExporting(true)
+    try {
+      // Guarantee the loading state is visible for at least 1 second
+      const minDelay = new Promise((r) => setTimeout(r, 1000))
+      const fetchExport = async () => {
+        const token = useAuthStore.getState().token
+        const response = await fetch('/api/v1/ai-systems/export', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        return response.blob()
+      }
+      const [blob] = await Promise.all([fetchExport(), minDelay])
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'ai_systems.csv'
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (error) {
+      console.error('Export failed:', error)
+    } finally {
+      setExporting(false)
+    }
+  }
+
 
   const limit = 10
 
-// Fix: Track filters in the cache key array, but keep the API function strictly to known parameters
+  // Fix: Track filters in the cache key array, but keep the API function strictly to known parameters
   const { data: systemsData, isLoading } = useQuery({
     queryKey: ['ai-systems', sortBy, order, currentPage, riskFilter, complianceFilter],
     queryFn: () =>
@@ -139,13 +168,23 @@ export default function AISystems() {
           <h1 className="text-2xl font-bold text-gray-900">AI Systems</h1>
           <p className="text-gray-600">Manage your AI systems for compliance tracking</p>
         </div>
-        <button
-          onClick={() => setShowModal(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700"
-        >
-          <Plus className="w-5 h-5" />
-          Add AI System
-        </button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleExport}
+            disabled={exporting}
+            className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Download className="w-5 h-5" />
+            {exporting ? 'Exporting...' : 'Export CSV'}
+          </button>
+          <button
+            onClick={() => setShowModal(true)}
+            className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700"
+          >
+            <Plus className="w-5 h-5" />
+            Add AI System
+          </button>
+        </div>
       </div>
 
       {/* Search and Filters */}
@@ -266,22 +305,33 @@ export default function AISystems() {
         <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
           <Bot className="w-16 h-16 mx-auto mb-4 text-gray-300" />
           <h3 className="text-lg font-medium text-gray-900">
-            {searchTerm || riskFilter || complianceFilter 
-              ? 'No matching AI systems' 
+            {searchTerm || riskFilter || complianceFilter
+              ? 'No matching AI systems'
               : 'No AI systems yet'}
           </h3>
           <p className="text-gray-500 mt-1">
-            {searchTerm || riskFilter || complianceFilter 
+            {searchTerm || riskFilter || complianceFilter
               ? 'Try adjusting your filters or search term'
               : 'Add your first AI system to start tracking compliance'}
           </p>
           {!searchTerm && !riskFilter && !complianceFilter && (
-            <button
-              onClick={() => setShowModal(true)}
-              className="mt-4 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700"
-            >
-              Add AI System
-            </button>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleExport}
+                disabled={exporting}
+                className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Download className="w-5 h-5" />
+                {exporting ? 'Exporting...' : 'Export CSV'}
+              </button>
+              <button
+                onClick={() => setShowModal(true)}
+                className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700"
+              >
+                <Plus className="w-5 h-5" />
+                Add AI System
+              </button>
+            </div>
           )}
         </div>
       ) : (
@@ -308,7 +358,7 @@ export default function AISystems() {
                           addSuffix: true,
                         })}
                       </p>
-                    )}    
+                    )}
                     <div className="flex items-center gap-3 mt-2">
                       {system.sector && (
                         <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded">
@@ -342,7 +392,7 @@ export default function AISystems() {
                   </button>
                 </div>
               </div>
-              
+
               {/* Compliance Progress */}
               <div className="mt-4 pt-4 border-t border-gray-100">
                 <div className="flex items-center justify-between text-sm">
@@ -351,13 +401,12 @@ export default function AISystems() {
                 </div>
                 <div className="mt-2 h-2 bg-gray-100 rounded-full overflow-hidden">
                   <div
-                    className={`h-full rounded-full ${
-                      system.compliance_score >= 80
+                    className={`h-full rounded-full ${system.compliance_score >= 80
                         ? 'bg-green-500'
                         : system.compliance_score >= 50
-                        ? 'bg-yellow-500'
-                        : 'bg-red-500'
-                    }`}
+                          ? 'bg-yellow-500'
+                          : 'bg-red-500'
+                      }`}
                     style={{ width: `${system.compliance_score}%` }}
                   />
                 </div>


### PR DESCRIPTION
Closes #212

## What I did
- Added Export CSV button to the AISystems page toolbar
- Placed to the left of the existing "Add AI System" button
- Uses Download icon from lucide-react for clear visual indication
- Calls GET /api/v1/ai-systems/export with Bearer token auth header
- Shows "Exporting..." and disabled state while download is in progress
- Revokes object URL after download to prevent memory leaks
- Button uses outlined style to distinguish from primary actions

## Screenshots
<img width="1919" height="904" alt="image" src="https://github.com/user-attachments/assets/1b63832c-beb6-4e08-9ada-940579b09ff2" />


## Testing
- [x] Export CSV button renders in toolbar
- [x] Clicking downloads ai_systems.csv
- [x] Button shows loading/disabled state while exporting
- [x] URL revoked after download completes