### PR TITLE
Sanitized prompt

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -208,7 +208,7 @@ def scan_prompt(
             decision=result["decision"],
             confidence=result["metadata"]["decision_reasoning"]["confidence"],
             reasoning=result["metadata"]["decision_reasoning"]["reasoning"],
-            sanitized_prompt=None,
+            sanitized_prompt=result.get("sanitized_prompt"),
             matched_patterns=result["metadata"]["regex_analysis"].get(
                 "matched_patterns",
                 [],
@@ -595,7 +595,7 @@ def bulk_scan_prompts(
                     decision=result["decision"],
                     confidence=result["metadata"]["decision_reasoning"]["confidence"],
                     reasoning=result["metadata"]["decision_reasoning"]["reasoning"],
-                    sanitized_prompt=None,
+                    sanitized_prompt=result.get("sanitized_prompt"),
                     matched_patterns=result["metadata"]["regex_analysis"].get(
                         "matched_patterns",
                         [],
@@ -618,4 +618,3 @@ def bulk_scan_prompts(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while processing the batch Guard scan."
         )
-    

--- a/backend/app/modules/guard/llm_guard.py
+++ b/backend/app/modules/guard/llm_guard.py
@@ -151,6 +151,7 @@ class LLMGuard:
             sanitized_prompt, sanitization_summary = self.sanitizer.sanitize(
                 normalized_prompt
             )
+            result["sanitized_prompt"] = sanitized_prompt  # FIX: expose sanitized text to API layer
             result["metadata"]["sanitization"] = {
                 "original_length": len(user_prompt),
                 "sanitized_length": len(sanitized_prompt),


### PR DESCRIPTION
## Summary

Closes #739 

`sanitized_prompt` was always returned as `null` from `/guard/scan` and 
`/guard/scan/batch` even when the guard actively sanitized the prompt.

Fixed by storing the sanitized text in `result["sanitized_prompt"]` inside 
`llm_guard.py`, and reading it via `result.get("sanitized_prompt")` in both 
endpoints in `guard.py` instead of hardcoding `None`.



## Type of Change

- [x ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [ x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ x] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [ x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed


