### PR TITLE
fix: add max-length validation for full_name and company_name fields

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -18,8 +18,8 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String(255), unique=True, index=True, nullable=False)
     hashed_password = Column(String(255), nullable=False)
-    full_name = Column(String(255))
-    company_name = Column(String(255))
+    full_name = Column(String(100))
+    company_name = Column(String(100))
 
     # Subscription
     subscription_tier = Column(Enum(SubscriptionTier), default=SubscriptionTier.FREE)


### PR DESCRIPTION
# Summary

Closes #<issue-number>

This PR adds max-length validation for `full_name` and `company_name` fields to improve input validation and prevent oversized values from being stored in the database.

### Changes Made

* Updated `full_name` and `company_name` field lengths from `255` to `100`
* Added validation tests in `backend/tests/test_auth.py`
* Updated `tsconfig.json` `ignoreDeprecations` value to `6.0`

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [x] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My code follows the project style
* [x] I have added/updated tests where relevant
* [ ] pytest backend/tests/ passes locally
* [x] I have not committed .env or any secrets
* [ ] I have updated documentation if needed

## Screenshots (if UI change)

N/A
