### PR TITLE
Add integration tests for PATCH status endpoint

### DIFF
--- a/backend/tests/test_patch_status.py
+++ b/backend/tests/test_patch_status.py
@@ -73,6 +73,26 @@ class TestPatchStatus:
         )
         assert resp.status_code == 200
         assert resp.json()["compliance_status"] == "compliant"
+        
+    def test_patch_status_reflected_in_get(self, client):
+        c, system = client
+
+        # Update status
+        patch_resp = c.patch(
+            f"/api/v1/ai-systems/{system.id}/status",
+            json={"compliance_status": "compliant"},
+        )
+
+        assert patch_resp.status_code == 200
+
+        # Fetch updated system
+        get_resp = c.get(f"/api/v1/ai-systems/{system.id}")
+
+        assert get_resp.status_code == 200
+
+        data = get_resp.json()
+
+        assert data["compliance_status"] == "compliant"
 
     def test_patch_status_other_fields_unchanged(self, client):
         c, system = client

--- a/backend/tests/test_patch_status.py
+++ b/backend/tests/test_patch_status.py
@@ -73,7 +73,7 @@ class TestPatchStatus:
         )
         assert resp.status_code == 200
         assert resp.json()["compliance_status"] == "compliant"
-        
+
     def test_patch_status_reflected_in_get(self, client):
         c, system = client
 
@@ -120,3 +120,53 @@ class TestPatchStatus:
             json={"compliance_status": "banana"},
         )
         assert resp.status_code == 422
+
+    def test_patch_other_users_system_returns_404(self, db):
+        # Create owner user
+        owner = User(
+            email="owner@test.com",
+            hashed_password="x",
+            full_name="Owner",
+        )
+
+        db.add(owner)
+        db.flush()
+
+        # Create another user
+        other_user = User(
+            email="other@test.com",
+            hashed_password="x",
+            full_name="Other User",
+        )
+
+        db.add(other_user)
+        db.flush()
+
+        # Create system owned by owner
+        system = AISystem(
+            owner_id=owner.id,
+            name="Owner System",
+            compliance_status=ComplianceStatus.NOT_STARTED,
+        )
+
+        db.add(system)
+        db.flush()
+
+        def override_db():
+            yield db
+
+        def override_user():
+            return other_user
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_current_user] = override_user
+
+        with TestClient(app) as c:
+            resp = c.patch(
+                f"/api/v1/ai-systems/{system.id}/status",
+                json={"compliance_status": "compliant"},
+            )
+
+            assert resp.status_code == 404
+
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

Closes #109 

Added integration tests for the PATCH /ai-systems/{id}/status endpoint.
The tests verify that status updates are reflected in GET requests and ensure that users cannot update another user's AI system. All tests were passed successfully locally.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x ] Tests
- [ ] Infra / CI

## Checklist

- [x ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x ] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x ] I have added/updated tests where relevant
- [x ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change) : N/A

Test Result : 6 passed locally
