### PR TITLE
fix: normalize RAG source citations in chat UI

### DIFF
--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -13,6 +13,8 @@ interface RagSource {
   excerpt: string
 }
 
+type RagSourceResponse = string | RagSource
+
 interface RagAnswer {
   answer: string
   sources: RagSource[]
@@ -53,6 +55,23 @@ function buildAnswerExport(
   ].join('\n')
 }
 
+function normalizeSources(
+  sources: RagSourceResponse[] = []
+): RagSource[] {
+  return sources
+    .map((source) => {
+      if (typeof source === 'string') {
+        return {
+          title: source,
+          excerpt: '',
+        }
+      }
+
+      return source
+    })
+    .filter((source) => source.title.trim())
+}
+
 export default function RagChat() {
   const [question, setQuestion] = useState('')
   const [submittedQuestion, setSubmittedQuestion] =
@@ -88,7 +107,7 @@ export default function RagChat() {
 
       setAnswer({
         answer: data.answer,
-        sources: data.sources || [],
+        sources: normalizeSources(data.sources),
         answer_id: data.answer_id,
       })
     } catch (err: unknown) {
@@ -271,9 +290,11 @@ export default function RagChat() {
                                 {source.title}
                               </p>
 
-                              <p className="text-sm text-gray-600 mt-1">
-                                {source.excerpt}
-                              </p>
+                              {source.excerpt && (
+                                <p className="text-sm text-gray-600 mt-1">
+                                  {source.excerpt}
+                                </p>
+                              )}
                             </div>
                           )
                         )}


### PR DESCRIPTION
## Summary

Fixes the RAG chat source citation rendering issue where the backend returns sources as strings, but the frontend expects citation objects with title and excerpt fields.

This change normalizes incoming RAG sources before storing them in component state. String sources are now displayed as citation titles, while existing structured source objects remain supported.

## What changed

- Added source normalization in the RAG chat page
- Preserved support for structured citation objects
- Avoided rendering empty excerpt text

## Verification

- npm run build
- npm run lint

## Related issue

Closes #770 