### PR TITLE
feat(k8s): add startupProbe to backend deployment

### DIFF
--- a/infra/deployment.yaml
+++ b/infra/deployment.yaml
@@ -31,6 +31,13 @@ spec:
           limits:
             cpu: "1000m"
             memory: "2Gi"
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 5  
+          failureThreshold: 30
+          periodSeconds: 10   
         readinessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
 Description
Closes #755

Added a Kubernetes startupProbe to the backend deployment configuration in `infra/deployment.yaml`.

Changes Made
- Added `startupProbe` using existing `/health` endpoint
- Configured probe timings for slower AI/ML backend initialization
- Improved pod startup stability and reduced premature restarts

 Benefits
- Prevents crash loops during startup
- Improves Kubernetes deployment resilience
- Aligns with Kubernetes probe best practices

Testing
- Validated deployment YAML locally
- Reviewed manifest structure and probe configuration