### PR TITLE
fix: badge SVG injection (escape + allowlist)

### DIFF
--- a/backend/app/modules/badge/badge_generator.py
+++ b/backend/app/modules/badge/badge_generator.py
@@ -13,6 +13,10 @@ TODO for contributors (good first issue):
     that starts with "<svg" and can be saved as a .svg file.
 """
 
+from __future__ import annotations
+
+from xml.sax.saxutils import escape as _xml_escape
+
 STATUS_COLORS = {
     "compliant": "#4ade80",  # green
     "in_progress": "#facc15",  # yellow
@@ -28,6 +32,18 @@ RISK_LABELS = {
     "unacceptable": "Unacceptable",
 }
 
+STATUS_LABELS = {
+    "compliant": "Compliant",
+    "in_progress": "In Progress",
+    "under_review": "Under Review",
+    "non_compliant": "Non Compliant",
+    "not_started": "Not Started",
+}
+
+
+def _escape_svg_text(text: str) -> str:
+    return _xml_escape(text, {'"': "&quot;", "'": "&apos;"})
+
 
 def generate_badge_svg(
     system_name: str,
@@ -37,12 +53,20 @@ def generate_badge_svg(
     """
     Generate an SVG compliance badge.
     """
-    color = STATUS_COLORS.get(compliance_status, STATUS_COLORS["not_started"])
-    status_label = compliance_status.replace("_", " ").title()
+    if compliance_status in STATUS_COLORS:
+        status_key = compliance_status
+        status_label = STATUS_LABELS.get(status_key, "Unknown")
+    else:
+        status_key = "not_started"
+        status_label = "Unknown"
+
+    color = STATUS_COLORS[status_key]
     risk_label = RISK_LABELS.get(risk_level, "Unknown Risk") if risk_level else None
 
     # Text segments
     segments = [("AegisAI", "#555")]
+    if system_name:
+        segments.append((system_name, "#444"))
     if risk_label:
         segments.append((risk_label, "#444"))
     segments.append((status_label, color))
@@ -77,10 +101,11 @@ def generate_badge_svg(
     for i, (text, _) in enumerate(segments):
         w = segment_widths[i]
         center_x = current_x + w / 2
+        safe_text = _escape_svg_text(text)
         svg.append(
-            f'<text x="{center_x}" y="15" fill="#010101" fill-opacity=".3">{text}</text>'
+            f'<text x="{center_x}" y="15" fill="#010101" fill-opacity=".3">{safe_text}</text>'
         )
-        svg.append(f'<text x="{center_x}" y="14">{text}</text>')
+        svg.append(f'<text x="{center_x}" y="14">{safe_text}</text>')
         current_x += w
 
     svg.append("</g>")

--- a/backend/tests/test_badge.py
+++ b/backend/tests/test_badge.py
@@ -12,6 +12,7 @@ def test_generate_badge_svg_compliant():
     assert svg.startswith("<svg")
     assert svg.endswith("</svg>")
     assert f'fill="{STATUS_COLORS["compliant"]}"' in svg
+    assert system_name in svg
     assert "Compliant" in svg
     assert "High Risk" in svg
     assert "AegisAI" in svg
@@ -30,3 +31,12 @@ def test_generate_badge_svg_unknown_status():
     svg = generate_badge_svg("My AI", None, "unknown")
     assert f'fill="{STATUS_COLORS["not_started"]}"' in svg
     assert "Unknown" in svg
+
+
+def test_generate_badge_svg_escapes_untrusted_text():
+    system_name = '</text><script>alert("xss")</script><text>'
+    compliance_status = '<script>alert("xss")</script>'
+    svg = generate_badge_svg(system_name, None, compliance_status)
+
+    assert "<script>" not in svg
+    assert "&lt;script&gt;" in svg


### PR DESCRIPTION
## Summary

Closes #757

This PR fixes an SVG injection risk in the public compliance badge by escaping all dynamic text rendered into the SVG. It also prevents reflecting unknown `compliance_status` values by mapping known statuses to fixed labels and rendering unknown values as `Unknown` (with the default color), plus adds focused unit tests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Screenshots (if UI change)

N/A (no UI change)