### PR TITLE
fix: validate document ai system ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Retains both `normalized_prompt` and `user_prompt` in orchestrator response
 - Unit and integration tests for bypass payloads (`test_normalizer.py` and `test_guard.py`)
 
+### Fixed
+- **Documents API** — Validate `ai_system_id` ownership before creating documents so users cannot link documents to another user's AI system.
+
 ---
 
 ## [Unreleased]

--- a/backend/app/api/v1/documents.py
+++ b/backend/app/api/v1/documents.py
@@ -176,6 +176,21 @@ def create_document(
     Returns:
         The created document serialized as DocumentResponse.
     """
+    if doc_data.ai_system_id is not None:
+        ai_system = (
+            db.query(AISystem)
+            .filter(
+                AISystem.id == doc_data.ai_system_id,
+                AISystem.owner_id == current_user.id,
+            )
+            .first()
+        )
+        if not ai_system:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="AI system not found",
+            )
+
     document = Document(
         owner_id=current_user.id,
         title=doc_data.title,

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -51,6 +51,47 @@ def test_list_document_templates(client):
         assert template["description"]
 
 
+def test_create_document_with_owned_ai_system(client):
+    headers = register_and_login(client, "create_owned_doc@example.com")
+    system_id = create_ai_system(client, headers)
+
+    response = client.post(
+        "/api/v1/documents/",
+        json={
+            "title": "Owned system document",
+            "document_type": "technical_documentation",
+            "ai_system_id": system_id,
+            "content": "# Owned system document",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["ai_system_id"] == system_id
+    assert data["title"] == "Owned system document"
+
+
+def test_create_document_rejects_another_users_ai_system(client):
+    headers_user1 = register_and_login(client, "doc_owner@example.com")
+    system_id = create_ai_system(client, headers_user1)
+
+    headers_user2 = register_and_login(client, "doc_attacker@example.com")
+    response = client.post(
+        "/api/v1/documents/",
+        json={
+            "title": "Cross-user document",
+            "document_type": "technical_documentation",
+            "ai_system_id": system_id,
+            "content": "# Cross-user document",
+        },
+        headers=headers_user2,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "AI system not found"
+
+
 # ✅ Test 1: Generate Technical Documentation → 201
 def test_generate_technical_documentation(client):
     headers = register_and_login(client, "tech_doc@example.com")


### PR DESCRIPTION
## Summary

Closes #764

This PR validates `ai_system_id` during document creation before the document row is inserted. If an AI system id is provided, it must belong to the authenticated user; otherwise the endpoint returns `404`, matching the existing generate-document ownership behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Testing

- `python -m py_compile backend/app/api/v1/documents.py backend/tests/test_documents.py` passes.
- Tried running `pytest backend/tests/test_documents.py -q`, but local system Python is 3.13 and the project pins `pydantic==2.5.3`; installing the pinned backend test environment fails because `pydantic-core==2.14.6` has no Python 3.13 wheel here and requires a Rust toolchain to build.

## Notes

This PR was raised as part of a GSSoC 2026 contribution. Could you please add the appropriate GSSoC label if applicable?

## Screenshots (if UI change)

N/A — backend-only change.