### PR TITLE
feat(k8s): add startupProbe to backend deployment

### DIFF
--- a/infra/deployment.yaml
+++ b/infra/deployment.yaml
@@ -31,6 +31,12 @@ spec:
           limits:
             cpu: "1000m"
             memory: "2Gi"
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          failureThreshold: 30
+          periodSeconds: 10    
         readinessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
## Summary

Closes #755

This PR adds a `startupProbe` to the backend deployment configuration in `infra/deployment.yaml` using the existing `/health` endpoint.

The backend currently defines `readinessProbe` and `livenessProbe`, but lacks a dedicated startup probe. For AI/ML workloads, vector database initialization, or other startup-intensive operations, Kubernetes may perform health checks before the application has fully initialized, potentially causing unnecessary restarts.

To address this, a `startupProbe` has been added to provide a dedicated startup window before liveness checks become active. This improves startup stability while preserving the existing readiness and liveness behavior.

This change remains intentionally focused on the scope of Issue #755 and reuses the existing health endpoint without introducing additional infrastructure changes.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [x] Infra / DevOps

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] The change follows the existing project configuration style
* [x] The existing `/health` endpoint is reused for consistency
* [x] No unrelated files or infrastructure components were modified
* [x] No secrets or environment variables were committed


