### PR TITLE
Fix NameError in scan_prompt by adding db dependency

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -170,6 +170,7 @@ def scan_prompt(
     request: ScanRequest,
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),              # added this for fixing nameerror crash
 ):
     """Scan a prompt for injection risks.
 

--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -10,17 +10,12 @@ TODO for contributors (medium difficulty):
 """
 
 import hashlib
-from collections import Counter, defaultdict, deque
-from datetime import datetime, timedelta, timezone
-from threading import Lock
-from typing import Optional
-
-from app.api.v1.webhooks import deliver_webhook
 import logging
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 from typing import Optional, TypedDict
 
+from app.api.v1.webhooks import deliver_webhook
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel


### PR DESCRIPTION
Added database dependency to scan_prompt function to fix NameError.


fixes #807 

## Type of Change

- [ x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [ x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x ] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x ] I have not committed `.env` or any secrets
- [ x] I have updated documentation if needed

## Screenshots (if UI change)

<!-- Add before/after screenshots here -->
