### PR TITLE
Add biometric categorisation risk

### DIFF
--- a/backend/app/api/v1/classification.py
+++ b/backend/app/api/v1/classification.py
@@ -32,6 +32,12 @@ QUESTIONNAIRE_RISK_FACTORS: List[QuestionnaireRiskFactor] = [
         triggers_level=RiskLevel.UNACCEPTABLE,
     ),
     QuestionnaireRiskFactor(
+        id="biometric_categorisation",
+        question="Does the system categorise individuals based on biometric data to infer sensitive attributes such as race, political opinions, religion, or sexual orientation?",
+        article="Article 5(1)(g)",
+        triggers_level=RiskLevel.UNACCEPTABLE,
+    ),
+    QuestionnaireRiskFactor(
         id="subliminal_manipulation",
         question="Does the system use subliminal techniques or manipulative methods that impair a person's ability to make free decisions, causing them harm?",
         article="Article 5(1)(a)",
@@ -172,6 +178,7 @@ def classify_risk(data: RiskClassificationRequest) -> RiskClassificationResponse
     prohibited_flags = {
         "social_scoring": "Social scoring by public authorities (Article 5(1)(c))",
         "realtime_biometric_public": "Real-time remote biometric identification in public spaces (Article 5(1)(h))",
+        "biometric_categorisation": "Biometric categorisation using sensitive attributes (Article 5(1)(g))",
         "subliminal_manipulation": "Subliminal manipulation of behaviour (Article 5(1)(a))",
         "exploits_vulnerable_groups": "Exploitation of vulnerabilities of specific groups (Article 5(1)(b))",
     }

--- a/backend/app/schemas/ai_system.py
+++ b/backend/app/schemas/ai_system.py
@@ -47,6 +47,8 @@ class RiskClassificationRequest(BaseModel):
     # AI used by public authorities to evaluate/classify people based on social behaviour
     realtime_biometric_public: bool = False
     # Real-time remote biometric identification in publicly accessible spaces
+    biometric_categorisation: bool = False
+    # Categorises people using biometric data to infer sensitive attributes
     subliminal_manipulation: bool = False
     # Techniques that manipulate behaviour subliminally causing harm
     exploits_vulnerable_groups: bool = False

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -13,8 +13,6 @@ interface RagSource {
   excerpt: string
 }
 
-type RagSourceResponse = string | RagSource
-
 interface RagAnswer {
   answer: string
   sources: RagSource[]
@@ -55,23 +53,6 @@ function buildAnswerExport(
   ].join('\n')
 }
 
-function normalizeSources(
-  sources: RagSourceResponse[] = []
-): RagSource[] {
-  return sources
-    .map((source) => {
-      if (typeof source === 'string') {
-        return {
-          title: source,
-          excerpt: '',
-        }
-      }
-
-      return source
-    })
-    .filter((source) => source.title.trim())
-}
-
 export default function RagChat() {
   const [question, setQuestion] = useState('')
   const [submittedQuestion, setSubmittedQuestion] =
@@ -107,7 +88,7 @@ export default function RagChat() {
 
       setAnswer({
         answer: data.answer,
-        sources: normalizeSources(data.sources),
+        sources: data.sources || [],
         answer_id: data.answer_id,
       })
     } catch (err: unknown) {
@@ -290,11 +271,9 @@ export default function RagChat() {
                                 {source.title}
                               </p>
 
-                              {source.excerpt && (
-                                <p className="text-sm text-gray-600 mt-1">
-                                  {source.excerpt}
-                                </p>
-                              )}
+                              <p className="text-sm text-gray-600 mt-1">
+                                {source.excerpt}
+                              </p>
                             </div>
                           )
                         )}


### PR DESCRIPTION
## Summary

Closes #641 

<!-- What does this PR do? 2-3 sentences. -->
This PR adds a separate `biometric_categorisation` risk factor to distinguish biometric categorisation systems from real-time remote biometric identification in public spaces.

The new classification covers systems that infer sensitive attributes such as race, political opinions, religion, sexual orientation, or other protected characteristics from biometric data, aligning with Annex III point 1(b) of the EU AI Act.
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)

<!-- Add before/after screenshots here -->
N/A