### PR TITLE
Fix/login auth race condition

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -21,20 +21,16 @@ export default function Login() {
     try {
       const tokenData = await authApi.login(email, password)
 
-      // 1. Immediately store token
-      setAuth(tokenData.access_token, null)
+setAuth(tokenData.access_token, null)
 
-      // 2. FORCE attach token for immediate next request
-      axios.defaults.headers.common[
-        'Authorization'
-      ] = `Bearer ${tokenData.access_token}`
+axios.defaults.headers.common['Authorization'] =
+  `Bearer ${tokenData.access_token}`
 
-      // 3. Now safely call getMe
-      const user = await authApi.getMe()
+const user = await authApi.getMe()
 
-      setAuth(tokenData.access_token, user)
+setAuth(tokenData.access_token, user)
 
-      navigate('/')
+navigate('/')
     } catch (err) {
       if (axios.isAxiosError(err) && err.response?.data?.detail) {
         setError(err.response.data.detail)

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -20,9 +20,20 @@ export default function Login() {
 
     try {
       const tokenData = await authApi.login(email, password)
-      setAuth(tokenData.access_token, null)  
-      const user = await authApi.getMe()     
-      setAuth(tokenData.access_token, user)  
+
+      // 1. Immediately store token
+      setAuth(tokenData.access_token, null)
+
+      // 2. FORCE attach token for immediate next request
+      axios.defaults.headers.common[
+        'Authorization'
+      ] = `Bearer ${tokenData.access_token}`
+
+      // 3. Now safely call getMe
+      const user = await authApi.getMe()
+
+      setAuth(tokenData.access_token, user)
+
       navigate('/')
     } catch (err) {
       if (axios.isAxiosError(err) && err.response?.data?.detail) {


### PR DESCRIPTION
## Summary

Closes #306

This PR fixes a login race condition where `getMe()` was called before the authentication token was stored in the Zustand auth store. This caused the axios interceptor to send unauthenticated requests and resulted in 401 errors on fresh logins. The fix ensures the token is stored before any authenticated API calls are made, allowing `getMe()` to work correctly after login.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] My code follows the project style (ESLint for TS)
* [ ] I have added/updated tests where relevant
* [x] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [ ] I have updated documentation if needed

## Screenshots (if UI change)

Not applicable