### PR TITLE
fix: make RAG index rebuild atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - **Documents API** — Validate `ai_system_id` ownership before creating documents so users cannot link documents to another user's AI system.
+- **RAG FAISS index rebuilds** — Stage, validate, and swap rebuilt indexes under thread/process locking so concurrent ingests cannot write directly into the shared live index.
 
 ---
 

--- a/backend/app/modules/rag/vector_store.py
+++ b/backend/app/modules/rag/vector_store.py
@@ -1,10 +1,25 @@
 """FAISS vector store creation and persistence."""
 
 import os
+import shutil
+import tempfile
+import threading
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+
 from langchain_community.vectorstores import FAISS
 from langchain_openai import OpenAIEmbeddings
 from app.core.config import settings
 from .document_loader import load_documents_from_paths
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback
+    fcntl = None
+
+_INDEX_REBUILD_LOCK = threading.Lock()
+_INDEX_PATH_LOCK = threading.Lock()
 
 
 def get_embeddings():
@@ -25,11 +40,32 @@ def create_vector_store(file_paths: list[str]):
     Returns:
         The populated FAISS vector store
     """
-    documents = load_documents_from_paths(file_paths)
-    embeddings = get_embeddings()
-    vector_store = FAISS.from_documents(documents, embeddings)
-    vector_store.save_local(settings.FAISS_INDEX_PATH)
-    return vector_store
+    index_path = Path(settings.FAISS_INDEX_PATH)
+
+    with _locked_index_path(index_path, _INDEX_REBUILD_LOCK, "rebuild"):
+        staged_index_path = Path(
+            tempfile.mkdtemp(
+                prefix=f".{index_path.name}-staged-",
+                dir=str(index_path.parent),
+            )
+        )
+
+        try:
+            documents = load_documents_from_paths(file_paths)
+            embeddings = get_embeddings()
+            vector_store = FAISS.from_documents(documents, embeddings)
+            vector_store.save_local(str(staged_index_path))
+
+            FAISS.load_local(
+                str(staged_index_path),
+                embeddings,
+                allow_dangerous_deserialization=True,
+            )
+            with _locked_index_path(index_path, _INDEX_PATH_LOCK, "path"):
+                _replace_index_directory(staged_index_path, index_path)
+            return vector_store
+        finally:
+            _remove_path(staged_index_path)
 
 
 def load_vector_store():
@@ -39,19 +75,72 @@ def load_vector_store():
     Raises:
         FileNotFoundError: if the index has not been created yet
     """
-    index_path = settings.FAISS_INDEX_PATH
-    if not os.path.exists(index_path):
-        raise FileNotFoundError(
-            f"FAISS index not found at '{index_path}'. "
-            "The RAG module requires regulatory documents to be ingested first. "
-            "Please contact your administrator or check the documentation for setup instructions."
+    index_path = Path(settings.FAISS_INDEX_PATH)
+    with _locked_index_path(index_path, _INDEX_PATH_LOCK, "path"):
+        if not os.path.exists(index_path):
+            raise FileNotFoundError(
+                f"FAISS index not found at '{index_path}'. "
+                "The RAG module requires regulatory documents to be ingested first. "
+                "Please contact your administrator or check the documentation for setup instructions."
+            )
+        embeddings = get_embeddings()
+        return FAISS.load_local(
+            str(index_path), embeddings, allow_dangerous_deserialization=True
         )
-    embeddings = get_embeddings()
-    return FAISS.load_local(
-        index_path, embeddings, allow_dangerous_deserialization=True
-    )
 
 
 def check_index_exists():
     """Check if FAISS index exists on disk."""
-    return os.path.exists(settings.FAISS_INDEX_PATH)
+    index_path = Path(settings.FAISS_INDEX_PATH)
+    with _locked_index_path(index_path, _INDEX_PATH_LOCK, "path"):
+        return os.path.exists(index_path)
+
+
+def _replace_index_directory(staged_index_path: Path, index_path: Path) -> None:
+    """Replace the live FAISS index with a validated staged index."""
+    backup_path = None
+    if index_path.exists():
+        backup_path = index_path.with_name(
+            f".{index_path.name}-backup-{uuid.uuid4().hex}"
+        )
+        index_path.rename(backup_path)
+
+    try:
+        staged_index_path.rename(index_path)
+    except Exception:
+        if backup_path and backup_path.exists() and not index_path.exists():
+            backup_path.rename(index_path)
+        raise
+    else:
+        if backup_path:
+            _remove_path(backup_path)
+
+
+def _remove_path(path: Path) -> None:
+    """Remove a staged or backup FAISS path if it still exists."""
+    if path.is_dir():
+        shutil.rmtree(path, ignore_errors=True)
+    elif path.exists():
+        path.unlink()
+
+
+@contextmanager
+def _locked_index_path(index_path: Path, local_lock: threading.Lock, lock_name: str):
+    """Serialize FAISS index operations across threads and worker processes."""
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = None
+
+    with local_lock:
+        if fcntl is not None:
+            lock_path = index_path.with_name(f".{index_path.name}.{lock_name}.lock")
+            lock_file = open(lock_path, "w", encoding="utf-8")
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+
+        try:
+            yield
+        finally:
+            if lock_file is not None:
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                finally:
+                    lock_file.close()

--- a/backend/tests/test_vector_store.py
+++ b/backend/tests/test_vector_store.py
@@ -1,0 +1,229 @@
+"""Tests for FAISS vector store persistence helpers."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.rag import vector_store
+
+
+def test_create_vector_store_stages_validates_and_replaces_live_index(
+    tmp_path, monkeypatch
+):
+    """create_vector_store should never save directly into the live index path."""
+    live_index_path = tmp_path / "faiss_index"
+    live_index_path.mkdir()
+    (live_index_path / "old.index").write_text("old")
+    monkeypatch.setattr(
+        vector_store.settings, "FAISS_INDEX_PATH", str(live_index_path)
+    )
+
+    fake_store = MagicMock()
+    save_paths = []
+
+    def save_local(path):
+        save_path = Path(path)
+        save_paths.append(save_path)
+        save_path.mkdir(parents=True, exist_ok=True)
+        (save_path / "index.faiss").write_text("new")
+
+    fake_store.save_local.side_effect = save_local
+    fake_embeddings = object()
+    fake_documents = [MagicMock()]
+
+    with (
+        patch.object(
+            vector_store,
+            "load_documents_from_paths",
+            return_value=fake_documents,
+        ),
+        patch.object(vector_store, "get_embeddings", return_value=fake_embeddings),
+        patch.object(
+            vector_store.FAISS,
+            "from_documents",
+            return_value=fake_store,
+        ) as mock_from_documents,
+        patch.object(vector_store.FAISS, "load_local") as mock_load_local,
+    ):
+        result = vector_store.create_vector_store(["policy.pdf"])
+
+    assert result == fake_store
+    assert save_paths
+    assert save_paths[0] != live_index_path
+    assert save_paths[0].parent == live_index_path.parent
+    assert not save_paths[0].exists()
+    assert (live_index_path / "index.faiss").read_text() == "new"
+    assert not (live_index_path / "old.index").exists()
+    if vector_store.fcntl is not None:
+        assert (tmp_path / ".faiss_index.rebuild.lock").exists()
+        assert (tmp_path / ".faiss_index.path.lock").exists()
+    mock_from_documents.assert_called_once_with(fake_documents, fake_embeddings)
+    mock_load_local.assert_called_once_with(
+        str(save_paths[0]),
+        fake_embeddings,
+        allow_dangerous_deserialization=True,
+    )
+
+
+def test_create_vector_store_validation_failure_keeps_existing_index(
+    tmp_path, monkeypatch
+):
+    """A staged index that cannot be reloaded must not replace the live index."""
+    live_index_path = tmp_path / "faiss_index"
+    live_index_path.mkdir()
+    (live_index_path / "old.index").write_text("old")
+    monkeypatch.setattr(
+        vector_store.settings, "FAISS_INDEX_PATH", str(live_index_path)
+    )
+
+    fake_store = MagicMock()
+
+    def save_local(path):
+        staged_path = Path(path)
+        staged_path.mkdir(parents=True, exist_ok=True)
+        (staged_path / "index.faiss").write_text("new")
+
+    fake_store.save_local.side_effect = save_local
+
+    with (
+        patch.object(vector_store, "load_documents_from_paths", return_value=[]),
+        patch.object(vector_store, "get_embeddings", return_value=object()),
+        patch.object(
+            vector_store.FAISS,
+            "from_documents",
+            return_value=fake_store,
+        ),
+        patch.object(
+            vector_store.FAISS,
+            "load_local",
+            side_effect=RuntimeError("bad staged index"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="bad staged index"):
+            vector_store.create_vector_store(["policy.pdf"])
+
+    assert (live_index_path / "old.index").read_text() == "old"
+    assert not (live_index_path / "index.faiss").exists()
+    assert list(tmp_path.glob(".faiss_index-staged-*")) == []
+
+
+def test_create_vector_store_uses_rebuild_lock(tmp_path, monkeypatch):
+    """The rebuild path should run while the local lock is held."""
+    live_index_path = tmp_path / "faiss_index"
+    monkeypatch.setattr(
+        vector_store.settings, "FAISS_INDEX_PATH", str(live_index_path)
+    )
+
+    events = []
+
+    class TrackingLock:
+        def __enter__(self):
+            events.append("lock-entered")
+
+        def __exit__(self, exc_type, exc, tb):
+            events.append("lock-exited")
+
+    fake_store = MagicMock()
+
+    def save_local(path):
+        events.append("save-local")
+        staged_path = Path(path)
+        staged_path.mkdir(parents=True, exist_ok=True)
+        (staged_path / "index.faiss").write_text("new")
+
+    fake_store.save_local.side_effect = save_local
+    monkeypatch.setattr(vector_store, "_INDEX_REBUILD_LOCK", TrackingLock())
+
+    with (
+        patch.object(
+            vector_store,
+            "load_documents_from_paths",
+            side_effect=lambda _: events.append("load-documents") or [],
+        ),
+        patch.object(vector_store, "get_embeddings", return_value=object()),
+        patch.object(
+            vector_store.FAISS,
+            "from_documents",
+            side_effect=lambda *_: events.append("from-documents") or fake_store,
+        ),
+        patch.object(
+            vector_store.FAISS,
+            "load_local",
+            side_effect=lambda *_args, **_kwargs: events.append("validate"),
+        ),
+    ):
+        vector_store.create_vector_store(["policy.pdf"])
+
+    assert events == [
+        "lock-entered",
+        "load-documents",
+        "from-documents",
+        "save-local",
+        "validate",
+        "lock-exited",
+    ]
+
+
+def test_load_vector_store_uses_index_lock(tmp_path, monkeypatch):
+    """load_vector_store should not read during an unlocked rebuild swap."""
+    live_index_path = tmp_path / "faiss_index"
+    live_index_path.mkdir()
+    monkeypatch.setattr(
+        vector_store.settings, "FAISS_INDEX_PATH", str(live_index_path)
+    )
+
+    events = []
+
+    class TrackingLock:
+        def __enter__(self):
+            events.append("lock-entered")
+
+        def __exit__(self, exc_type, exc, tb):
+            events.append("lock-exited")
+
+    fake_embeddings = object()
+    fake_store = MagicMock()
+    monkeypatch.setattr(vector_store, "_INDEX_PATH_LOCK", TrackingLock())
+
+    with (
+        patch.object(vector_store, "get_embeddings", return_value=fake_embeddings),
+        patch.object(
+            vector_store.FAISS,
+            "load_local",
+            side_effect=lambda *_args, **_kwargs: events.append("load-local")
+            or fake_store,
+        ) as mock_load_local,
+    ):
+        result = vector_store.load_vector_store()
+
+    assert result == fake_store
+    assert events == ["lock-entered", "load-local", "lock-exited"]
+    mock_load_local.assert_called_once_with(
+        str(live_index_path),
+        fake_embeddings,
+        allow_dangerous_deserialization=True,
+    )
+
+
+def test_check_index_exists_uses_index_lock(tmp_path, monkeypatch):
+    """check_index_exists should not inspect the path during a live swap."""
+    live_index_path = tmp_path / "faiss_index"
+    live_index_path.mkdir()
+    monkeypatch.setattr(
+        vector_store.settings, "FAISS_INDEX_PATH", str(live_index_path)
+    )
+
+    events = []
+
+    class TrackingLock:
+        def __enter__(self):
+            events.append("lock-entered")
+
+        def __exit__(self, exc_type, exc, tb):
+            events.append("lock-exited")
+
+    monkeypatch.setattr(vector_store, "_INDEX_PATH_LOCK", TrackingLock())
+
+    assert vector_store.check_index_exists() is True
+    assert events == ["lock-entered", "lock-exited"]


### PR DESCRIPTION
## Summary

Closes #761

This makes RAG FAISS index rebuilds safer under concurrent ingestion. The rebuild now writes to a staged index directory, validates that staged index can be loaded, and then swaps it into the live index path under a short path lock so readers do not observe the backup/swap window.

The implementation also separates the long rebuild lock from the short live-index path lock. That keeps overlapping ingests serialized without blocking RAG reads for the entire embedding/index build.

Hi @maintainer, this PR was raised as part of a GSSoC 2026 contribution for #761. Could you please add the appropriate GSSoC label if applicable? Thanks!

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

Local validation:
- `python3 -m py_compile app/modules/rag/vector_store.py tests/test_vector_store.py`
- `python3 -m compileall app/modules/rag/vector_store.py tests/test_vector_store.py`
- `git diff --check`

I could not run the targeted pytest file in this system environment because backend test dependencies are not installed here (`ModuleNotFoundError: No module named 'jose'` from `tests/conftest.py`). I ran the syntax and diff checks above locally and will rely on CI for the dependency-matched pytest run.

## Screenshots (if UI change)

Not applicable; backend reliability fix.
