### PR TITLE
Add breadcrumb navigation

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
-import { Outlet, Link, useLocation } from 'react-router-dom'
-import { useAuthStore } from '../stores/authStore'
-import ThemeToggle from './ThemeToggle'
+import { useState } from "react";
+import { Outlet, Link, useLocation } from "react-router-dom";
+import { useAuthStore } from "../stores/authStore";
+import ThemeToggle from "./ThemeToggle";
 import {
   LayoutDashboard,
   Bot,
@@ -14,38 +14,35 @@ import {
   ChevronLeft,
   ChevronRight,
   BarChart,
-} from 'lucide-react'
-import NotificationBell from './NotificationBell'
+} from "lucide-react";
+import NotificationBell from "./NotificationBell";
 
 const navigation = [
-  { name: 'Dashboard', href: '/', icon: LayoutDashboard },
-  { name: 'Analytics', href: '/analytics', icon: BarChart },
-  { name: 'AI Systems', href: '/ai-systems', icon: Bot },
-  { name: 'Risk Classification', href: '/classification', icon: FileCheck },
-  { name: 'Documents', href: '/documents', icon: FileText },
-  { name: 'LLM Guard', href: '/guard', icon: ShieldCheck },
-  { name: 'Chatbot', href: '/rag-chat', icon: MessageSquareText },
-]
+  { name: "Dashboard", href: "/", icon: LayoutDashboard },
+  { name: "Analytics", href: "/analytics", icon: BarChart },
+  { name: "AI Systems", href: "/ai-systems", icon: Bot },
+  { name: "Risk Classification", href: "/classification", icon: FileCheck },
+  { name: "Documents", href: "/documents", icon: FileText },
+  { name: "LLM Guard", href: "/guard", icon: ShieldCheck },
+  { name: "Chatbot", href: "/rag-chat", icon: MessageSquareText },
+];
 
 export default function Layout() {
-  const location = useLocation()
-  const { user, logout } = useAuthStore()
-  const displayName = user?.full_name || user?.email || 'Demo User'
-  const companyName = user?.company_name || 'Free Plan'
-  const [isCollapsed, setIsCollapsed] = useState(false)
-  const pathnames = location.pathname.split('/').filter(Boolean)
+  const location = useLocation();
+  const { user, logout } = useAuthStore();
+  const displayName = user?.full_name || user?.email || "Demo User";
+  const companyName = user?.company_name || "Free Plan";
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const pathnames = location.pathname.split("/").filter(Boolean);
   const formatBreadcrumb = (value: string) =>
-  value
-    .replace(/-/g, ' ')
-    .replace(/\b\w/g, (char) => char.toUpperCase())
+    value.replace(/-/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-black dark:text-white">
-      
       {/* Sidebar */}
       <div
         className={`fixed inset-y-0 left-0 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transition-[width] duration-200 z-40 ${
-          isCollapsed ? 'w-20' : 'w-64'
+          isCollapsed ? "w-20" : "w-64"
         }`}
       >
         {/* Logo */}
@@ -55,7 +52,7 @@ export default function Layout() {
 
             <span
               className={`text-lg font-semibold text-gray-900 dark:text-white ${
-                isCollapsed ? 'sr-only' : ''
+                isCollapsed ? "sr-only" : ""
               }`}
             >
               AI Compliance
@@ -66,7 +63,7 @@ export default function Layout() {
             type="button"
             onClick={() => setIsCollapsed((prev) => !prev)}
             className="p-2 text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-white rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
           >
             {isCollapsed ? (
               <ChevronRight className="w-5 h-5" />
@@ -79,7 +76,7 @@ export default function Layout() {
         {/* Navigation */}
         <nav className="flex flex-col gap-1 p-4">
           {navigation.map((item) => {
-            const isActive = location.pathname === item.href
+            const isActive = location.pathname === item.href;
 
             return (
               <Link
@@ -88,16 +85,16 @@ export default function Layout() {
                 title={item.name}
                 className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
                   isActive
-                    ? 'bg-primary-50 text-primary-700 dark:bg-primary-900 dark:text-white'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                } ${isCollapsed ? 'justify-center' : ''}`}
+                    ? "bg-primary-50 text-primary-700 dark:bg-primary-900 dark:text-white"
+                    : "text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                } ${isCollapsed ? "justify-center" : ""}`}
               >
                 <item.icon className="w-5 h-5" />
-                <span className={isCollapsed ? 'sr-only' : ''}>
+                <span className={isCollapsed ? "sr-only" : ""}>
                   {item.name}
                 </span>
               </Link>
-            )
+            );
           })}
         </nav>
 
@@ -105,10 +102,10 @@ export default function Layout() {
         <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 dark:border-gray-700">
           <div
             className={`flex items-center ${
-              isCollapsed ? 'justify-center' : 'justify-between'
+              isCollapsed ? "justify-center" : "justify-between"
             }`}
           >
-            <div className={isCollapsed ? 'sr-only' : 'truncate'}>
+            <div className={isCollapsed ? "sr-only" : "truncate"}>
               <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
                 {displayName}
               </p>
@@ -131,12 +128,12 @@ export default function Layout() {
       {/* Main content */}
       <div
         className={`transition-[padding] duration-200 ${
-          isCollapsed ? 'pl-20' : 'pl-64'
+          isCollapsed ? "pl-20" : "pl-64"
         }`}
       >
         {/* Header */}
         <header className="sticky top-0 z-30 flex items-center justify-end gap-3 px-8 py-3 bg-white/80 dark:bg-gray-800/80 backdrop-blur-md border-b border-gray-200/60 dark:border-gray-700">
-          <NotificationBell /> 
+          <NotificationBell />
 
           {/* ✅ FINAL THEME BUTTON (clean placement) */}
           <ThemeToggle />
@@ -144,40 +141,37 @@ export default function Layout() {
 
         {/* Content */}
         <div className="px-8 py-4 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-  <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
-    <Link to="/" className="hover:text-primary-600">
-      Dashboard
-    </Link>
-
-    {pathnames.map((value, index) => {
-      const to = `/${pathnames.slice(0, index + 1).join('/')}`
-      const isLast = index === pathnames.length - 1
-
-      return (
-        <div key={to} className="flex items-center gap-2">
-          <ChevronRight className="w-4 h-4" />
-
-          {isLast ? (
-            <span className="font-medium text-gray-900 dark:text-white capitalize">
-              {formatBreadcrumb(value)}
-            </span>
-          ) : (
-            <Link
-              to={to}
-              className="hover:text-primary-600 capitalize"
-            >
-              {formatBreadcrumb(value)}
+          <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+            <Link to="/" className="hover:text-primary-600">
+              Dashboard
             </Link>
-          )}
+
+            {pathnames.map((value, index) => {
+              const to = `/${pathnames.slice(0, index + 1).join("/")}`;
+              const isLast = index === pathnames.length - 1;
+
+              return (
+                <div key={to} className="flex items-center gap-2">
+                  <ChevronRight className="w-4 h-4" />
+
+                  {isLast ? (
+                    <span className="font-medium text-gray-900 dark:text-white capitalize">
+                      {formatBreadcrumb(value)}
+                    </span>
+                  ) : (
+                    <Link to={to} className="hover:text-primary-600 capitalize">
+                      {formatBreadcrumb(value)}
+                    </Link>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
-      )
-    })}
-  </div>
-</div>
         <main className="p-8 min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
           <Outlet />
         </main>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -33,6 +33,11 @@ export default function Layout() {
   const displayName = user?.full_name || user?.email || 'Demo User'
   const companyName = user?.company_name || 'Free Plan'
   const [isCollapsed, setIsCollapsed] = useState(false)
+  const pathnames = location.pathname.split('/').filter(Boolean)
+  const formatBreadcrumb = (value: string) =>
+  value
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase())
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-black dark:text-white">
@@ -131,13 +136,44 @@ export default function Layout() {
       >
         {/* Header */}
         <header className="sticky top-0 z-30 flex items-center justify-end gap-3 px-8 py-3 bg-white/80 dark:bg-gray-800/80 backdrop-blur-md border-b border-gray-200/60 dark:border-gray-700">
-          <NotificationBell />
+          <NotificationBell /> 
 
           {/* ✅ FINAL THEME BUTTON (clean placement) */}
           <ThemeToggle />
         </header>
 
         {/* Content */}
+        <div className="px-8 py-4 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+  <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+    <Link to="/" className="hover:text-primary-600">
+      Dashboard
+    </Link>
+
+    {pathnames.map((value, index) => {
+      const to = `/${pathnames.slice(0, index + 1).join('/')}`
+      const isLast = index === pathnames.length - 1
+
+      return (
+        <div key={to} className="flex items-center gap-2">
+          <ChevronRight className="w-4 h-4" />
+
+          {isLast ? (
+            <span className="font-medium text-gray-900 dark:text-white capitalize">
+              {formatBreadcrumb(value)}
+            </span>
+          ) : (
+            <Link
+              to={to}
+              className="hover:text-primary-600 capitalize"
+            >
+              {formatBreadcrumb(value)}
+            </Link>
+          )}
+        </div>
+      )
+    })}
+  </div>
+</div>
         <main className="p-8 min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
           <Outlet />
         </main>

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -13,8 +13,6 @@ interface RagSource {
   excerpt: string
 }
 
-type RagSourceResponse = string | RagSource
-
 interface RagAnswer {
   answer: string
   sources: RagSource[]
@@ -55,23 +53,6 @@ function buildAnswerExport(
   ].join('\n')
 }
 
-function normalizeSources(
-  sources: RagSourceResponse[] = []
-): RagSource[] {
-  return sources
-    .map((source) => {
-      if (typeof source === 'string') {
-        return {
-          title: source,
-          excerpt: '',
-        }
-      }
-
-      return source
-    })
-    .filter((source) => source.title.trim())
-}
-
 export default function RagChat() {
   const [question, setQuestion] = useState('')
   const [submittedQuestion, setSubmittedQuestion] =
@@ -107,7 +88,7 @@ export default function RagChat() {
 
       setAnswer({
         answer: data.answer,
-        sources: normalizeSources(data.sources),
+        sources: data.sources || [],
         answer_id: data.answer_id,
       })
     } catch (err: unknown) {
@@ -290,11 +271,9 @@ export default function RagChat() {
                                 {source.title}
                               </p>
 
-                              {source.excerpt && (
-                                <p className="text-sm text-gray-600 mt-1">
-                                  {source.excerpt}
-                                </p>
-                              )}
+                              <p className="text-sm text-gray-600 mt-1">
+                                {source.excerpt}
+                              </p>
                             </div>
                           )
                         )}

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -115,7 +115,7 @@ export default function RagChat() {
 
       setAnswer({
         answer: data.answer,
-        sources: data.sources || [],
+        sources: normalizeSources(data.sources || []),
         answer_id: data.answer_id,
       })
     } catch (err: unknown) {

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -37,7 +37,34 @@ function isApiError(
     error !== null
   )
 }
+const normalizeSources = (sources: unknown[]): RagSource[] => {
+  return sources.map((source, index) => {
+    if (typeof source === 'string') {
+      return {
+        title: `Source ${index + 1}`,
+        excerpt: source,
+      }
+    }
 
+    if (typeof source === 'object' && source !== null) {
+      return {
+        title:
+          'title' in source && typeof source.title === 'string'
+            ? source.title
+            : `Source ${index + 1}`,
+        excerpt:
+          'excerpt' in source && typeof source.excerpt === 'string'
+            ? source.excerpt
+            : '',
+      }
+    }
+
+    return {
+      title: `Source ${index + 1}`,
+      excerpt: '',
+    }
+  })
+}
 function buildAnswerExport(
   answer: RagAnswer
 ): string {
@@ -88,7 +115,7 @@ export default function RagChat() {
 
       setAnswer({
         answer: data.answer,
-        sources: data.sources || [],
+        sources: normalizeSources(data.sources),
         answer_id: data.answer_id,
       })
     } catch (err: unknown) {

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -349,3 +349,4 @@ export default function RagChat() {
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary

Closes #21 

Added a breadcrumb navigation bar to improve user orientation and navigation across the application. The breadcrumb dynamically reflects the current route (for example: Dashboard > AI Systems > My CV Screener) and was implemented in Layout.tsx to keep navigation consistent across pages.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots (if UI change)


