### PR TITLE
fix(schemas): resolve NISTMapping NameError using forward reference

### DIFF
--- a/backend/app/schemas/ai_system.py
+++ b/backend/app/schemas/ai_system.py
@@ -93,7 +93,7 @@ class RiskClassificationResponse(BaseModel):
     reasons: List[str]
     requirements: List[str]
     next_steps: List[str]
-    nist_mapping: Optional[NISTMapping] = None
+    nist_mapping: Optional["NISTMapping"] = None
 
 
 class RiskAssessmentResponse(BaseModel):


### PR DESCRIPTION
### Summary

This pull request resolves a backend startup failure caused by a `NameError` in `app/schemas/ai_system.py`. The error occurred because `RiskClassificationResponse` referenced `NISTMapping` before it was defined, leading to a module import failure during FastAPI application startup.

### Root Cause

Python evaluates type annotations at import time. In this case, `RiskClassificationResponse` referenced `NISTMapping` before its definition was parsed, resulting in a runtime failure during module initialization.

Error observed:

```
NameError: name 'NISTMapping' is not defined
```

### Changes Introduced

* Replaced direct class reference with a forward reference string annotation:

```python
nist_mapping: Optional["NISTMapping"] = None
```

* Ensured schema initialization order does not affect runtime evaluation.
* Preserved existing schema structure without introducing unnecessary refactoring.

### Rationale for Approach

The forward reference approach was chosen over reordering or modular refactoring because it:

* Prevents import-time evaluation errors
* Avoids tight coupling between schema definitions
* Eliminates potential circular import risks in larger schema modules
* Aligns with FastAPI and Pydantic best practices for type hint resolution

### Validation

* Backend service starts successfully in Docker environment
* FastAPI application initializes without import errors
* `/docs` endpoint loads correctly
* Related unit tests for NIST mapping pass successfully

### Impact

* No breaking changes to API contracts
* No database schema modifications
* Fully backward compatible
* Safe for production deployment

### Notes

This fix ensures schema stability during application startup and improves resilience against future schema ordering issues.
