### PR TITLE
Fix Windows venv activation commands in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,12 @@ Examples:
 ```bash
 cd backend
 python -m venv venv
-source venv/bin/activate  # Windows: venv\Scripts\activate
+# macOS / Linux
+source venv/bin/activate
+# Windows CMD
+# venv\Scripts\activate.bat
+# Windows PowerShell
+# venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 cp .env.example .env      # fill in your keys
 uvicorn app.main:app --reload

--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ docker compose up -d
 ```bash
 # Backend
 cd backend
-python -m venv venv && source venv/bin/activate  # Windows: venv\Scripts\activate
+python -m venv venv
+# macOS / Linux
+source venv/bin/activate
+# Windows CMD
+# venv\Scripts\activate.bat
+# Windows PowerShell
+# venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 cp .env.example .env   # fill in values
 uvicorn app.main:app --reload


### PR DESCRIPTION

Summary:

Closes #851 

Fix Windows virtual environment activation instructions in README.md and CONTRIBUTING.md. The docs now include the correct shell-specific commands for macOS/Linux, Windows CMD, and Windows PowerShell.

Type of Change:

- Documentation update

Checklist:

- I have read CONTRIBUTING.md
- My code follows the project style (PEP 8 for Python, ESLint for TS)
- I have added/updated tests where relevant
- pytest backend/tests/ passes locally
- I have not committed .env or any secrets
- I have updated documentation if needed


## Screenshots (if UI change)
<img width="879" height="730" alt="Screenshot 2026-05-31 202351" src="https://github.com/user-attachments/assets/36057429-5c06-4b00-83e9-948d1569c25d" />


<!-- Add before/after screenshots here -->
