### PR TITLE
Fix/update copyright

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,12 @@ Examples:
 ```bash
 cd backend
 python -m venv venv
-source venv/bin/activate  # Windows: venv\Scripts\activate
+# macOS / Linux
+source venv/bin/activate
+# Windows CMD
+# venv\Scripts\activate.bat
+# Windows PowerShell
+# venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 cp .env.example .env      # fill in your keys
 uvicorn app.main:app --reload

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: AGPL-3.0-only
 
-Copyright (C) 2024 Sarthak Doshi (https://github.com/SdSarthak)
+Copyright (C) 2024–2026 Sarthak Doshi (https://github.com/SdSarthak)
 
 AegisAI is free software: you can redistribute it and/or modify it under
 the terms of the GNU Affero General Public License as published by the Free

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ AegisAI is licensed under **AGPL-3.0-only**.
 - If you run a modified version as a SaaS, you must release your source code.
 - For commercial licensing, contact the author.
 
-Copyright (C) 2024 **Sarthak Doshi** ([@SdSarthak](https://github.com/SdSarthak))
+Copyright (C) 2024–2026 **Sarthak Doshi** ([@SdSarthak](https://github.com/SdSarthak))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ docker compose up -d
 ```bash
 # Backend
 cd backend
-python -m venv venv && source venv/bin/activate  # Windows: venv\Scripts\activate
+python -m venv venv
+# macOS / Linux
+source venv/bin/activate
+# Windows CMD
+# venv\Scripts\activate.bat
+# Windows PowerShell
+# venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 cp .env.example .env   # fill in values
 uvicorn app.main:app --reload

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -289,5 +289,5 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on contributing to the 
 
 ## License
 
-Copyright (C) 2024 Sarthak Doshi  
+Copyright (C) 2024–2026 Sarthak Doshi  
 SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION
## Summary

Closes #852 

This PR updates the outdated copyright year notice from 2024 to the active range of 2024–2026 across the project documentation. Specifically, it updates the main `README.md`, the `LICENSE` file, and the `mcp/README.md` file to reflect standard open-source conventions for multi-year active projects.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed
