### PR TITLE
fix: sanitize CSV export against formula injection (#793)

### DIFF
--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -298,6 +298,16 @@ def bulk_import_systems(
     return BulkImportResponse(created=created_count, errors=errors)
 
 
+def _sanitize_csv_cell(value: str) -> str:
+    """Prevent CSV formula injection by prefixing dangerous leading characters."""
+    if not value:
+        return value
+    dangerous = {"=", "+", "-", "@", "\t", "\r"}
+    if value and value[0] in dangerous:
+        return "'" + value
+    return value
+
+
 @router.get("/export")
 def export_ai_systems(
     risk_level: Optional[str] = Query(None, description="Filter by risk level: minimal, limited, high, unacceptable"),
@@ -339,13 +349,13 @@ def export_ai_systems(
     for s in systems:
         writer.writerow([
             s.id,
-            s.name,
-            s.description or "",
-            s.version or "",
-            s.use_case or "",
-            s.sector or "",
-            s.risk_level.value if s.risk_level else "",
-            s.compliance_status.value if s.compliance_status else "",
+            _sanitize_csv_cell(s.name or ""),
+            _sanitize_csv_cell(s.description or ""),
+            _sanitize_csv_cell(s.version or ""),
+            _sanitize_csv_cell(s.use_case or ""),
+            _sanitize_csv_cell(s.sector or ""),
+            _sanitize_csv_cell(s.risk_level.value if s.risk_level else ""),
+            _sanitize_csv_cell(s.compliance_status.value if s.compliance_status else ""),
             s.compliance_score if s.compliance_score is not None else "",
             s.created_at.isoformat() if s.created_at else "",
         ])

--- a/backend/tests/test_csv_export.py
+++ b/backend/tests/test_csv_export.py
@@ -119,3 +119,46 @@ class TestCSVExport:
         resp = c.get("/api/v1/ai-systems/export?risk_level=banana")
         assert resp.status_code == 400
         assert "risk_level" in resp.json()["detail"].lower()
+
+    def test_export_sanitizes_formula_injection(self, client):
+        c, db, user = client
+        db.add(AISystem(
+            owner_id=user.id,
+            name="=CMD",
+            description="+DANGER",
+            use_case="-FORMULA",
+            sector="@SPREADSHEET",
+            risk_level=RiskLevel.HIGH,
+        ))
+        db.flush()
+
+        resp = c.get("/api/v1/ai-systems/export")
+        assert resp.status_code == 200
+
+        reader = csv.DictReader(io.StringIO(resp.text))
+        rows = list(reader)
+        assert len(rows) == 1
+
+        assert rows[0]["name"] == "'=CMD"
+        assert rows[0]["description"] == "'+DANGER"
+        assert rows[0]["use_case"] == "'-FORMULA"
+        assert rows[0]["sector"] == "'@SPREADSHEET"
+
+    def test_export_does_not_mangle_safe_values(self, client):
+        c, db, user = client
+        db.add(AISystem(
+            owner_id=user.id,
+            name="Safe System",
+            description="Normal description",
+            risk_level=RiskLevel.MINIMAL,
+        ))
+        db.flush()
+
+        resp = c.get("/api/v1/ai-systems/export")
+        assert resp.status_code == 200
+
+        reader = csv.DictReader(io.StringIO(resp.text))
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Safe System"
+        assert rows[0]["description"] == "Normal description"


### PR DESCRIPTION
## Summary

Prevents CSV formula injection (aka CSV injection) in the `/api/v1/ai-systems/export` endpoint by prefixing dangerous cell values with a single quote.

Fixes #793 

## Background

Spreadsheet programs (Excel, Google Sheets, LibreOffice Calc) evaluate cells starting with `=`, `+`, `-`, or `@` as formulas. A malicious user who names their AI system `=cmd|' /C calc'!A0` could trigger arbitrary code execution when an admin opens the exported CSV.

## Changes

### `backend/app/api/v1/ai_systems.py` — Cell sanitization
- Added `_sanitize_csv_cell(value)` helper that prepends `'` to values whose first character is in `{=, +, -, @, \t, \r}`
- Applied the helper to all user-supplied string fields in the export CSV: `name`, `description`, `version`, `use_case`, `sector`, `risk_level`, `compliance_status`

### `tests/test_csv_export.py` — Test coverage
- `test_export_sanitizes_formula_injection` — Creates systems with `=`, `+`, `-`, `@` prefixes and asserts they appear as `'=...` in the export
- `test_export_does_not_mangle_safe_values` — Verifies that normal values are unchanged
