### PR TITLE
Add Guard audit logs dashboard

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -14,7 +14,8 @@ TODO for contributors (help wanted):
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
 from sqlalchemy.orm import Session
-
+from app.models.audit_log import AuditLog
+from app.schemas.audit_log import AuditLogListResponse
 from app.core.database import get_db
 from app.core.security import get_current_user
 from app.models.ai_system import AISystem, ComplianceStatus, RiskLevel
@@ -149,7 +150,6 @@ def get_analytics_summary(
         "compliance_statuses": compliance_statuses,
     }
 
-
 @router.get("/audit-logs", response_model=PaginatedResponse[GuardAuditLogResponse])
 def get_audit_logs(
     skip: int = Query(0, ge=0, description="Items to skip"),
@@ -192,6 +192,11 @@ def get_audit_logs(
 
     base_query = db.query(GuardScanLog).filter(*filters)
     total = base_query.count()
-    logs = base_query.order_by(GuardScanLog.scanned_at.desc()).offset(skip).limit(limit).all()
+    logs = (
+        base_query.order_by(GuardScanLog.scanned_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
 
     return PaginatedResponse(items=logs, total=total, skip=skip, limit=limit)

--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -17,7 +17,7 @@ from collections import Counter, defaultdict, deque
 from datetime import datetime, timedelta, timezone
 from threading import Lock
 from typing import Optional, TypedDict
-
+from app.models.audit_log import AuditLog, ScanStatus
 from app.api.v1.webhooks import deliver_webhook
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Query, status
 from fastapi.responses import JSONResponse
@@ -252,6 +252,22 @@ def scan_prompt(
             ),
         )
 
+        audit_log = AuditLog(
+            user_id=str(current_user.id),
+            raw_prompt=request.prompt,
+            scan_status=ScanStatus.blocked
+            if result["decision"] == "block"
+            else ScanStatus.sanitized
+            if result["decision"] == "sanitize"
+            else ScanStatus.allowed,
+            risk_score=response.confidence,
+            triggered_rules=response.matched_patterns,
+            detection_method="guard",
+        )
+
+        db.add(audit_log)
+        db.commit()
+
         if result["decision"] == "block":
             try:
                 background_tasks.add_task(
@@ -289,13 +305,13 @@ def scan_prompt(
 # ---------------------------------------------------------------------------
 
 
-class _ExplainRateLimitConfig:
-    """Explanations are 50–100x more expensive than a scan — limit them
+class ExplainRateLimitConfig:
+ """Explanations are 50–100x more expensive than a scan — limit them
     aggressively. Tunable via env if needed; defaults are conservative."""
 
-    LIMIT = 10
-    WINDOW_SECONDS = 60
-    TIMEOUT_SECONDS = 15.0
+ LIMIT = 10
+ WINDOW_SECONDS = 60
+ TIMEOUT_SECONDS = 15.0
 
 
 @router.post(

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -83,3 +83,46 @@ def after_ai_system_update(mapper, connection, target):
             )
         )
         
+"""
+
+backend/app/models/audit_log.py
+
+Replace / expand the existing placeholder with the full model.
+
+"""
+import enum
+import uuid
+from datetime import datetime
+from sqlalchemy import Column, DateTime, Enum, Float, JSON, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from app.core.database import Base  # same Base used by all other models
+
+class ScanStatus(str, enum.Enum):
+
+    allowed   = "allowed"
+
+    blocked   = "blocked"
+
+    sanitized = "sanitized"
+class AuditLog(Base):
+
+    __tablename__ = "audit_logs"
+
+    id               = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    user_id          = Column(String, nullable=True)          # None for unauthenticated
+
+    ip_address       = Column(String, nullable=True)
+
+    timestamp        = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+    raw_prompt       = Column(Text, nullable=False)
+
+    scan_status      = Column(Enum(ScanStatus), nullable=False, index=True)
+
+    risk_score       = Column(Float, nullable=True)           # 0.0 – 1.0
+
+    triggered_rules  = Column(JSON, nullable=True)            # ["prompt_injection", ...]
+
+    detection_method = Column(String, nullable=True)          # "regex" | "deberta" | "rate_limit"
+    

--- a/backend/app/schemas/audit_log.py
+++ b/backend/app/schemas/audit_log.py
@@ -1,21 +1,8 @@
+"""
+backend/app/schemas/audit_log.py
+NEW FILE — create this from scratch.
+"""
 from datetime import datetime
-from typing import Dict, Any, List, Optional
-
-from pydantic import BaseModel
-
-
-class AISystemAuditLogResponse(BaseModel):
-    id: int
-    ai_system_id: int
-    changed_by_id: int
-    old_values: Dict[str, Any]
-    new_values: Dict[str, Any]
-    changed_at: datetime
-
-    class Config:
-        from_attributes = True
-
-
 class GuardAuditLogResponse(BaseModel):
     id: int
     user_id: int

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ import GuardConsole from './pages/GuardConsole'
 import NotFound from './pages/NotFound'
 import { Toaster } from 'react-hot-toast'
 import RagChat from './pages/RagChat'
-
+import AuditDashboard from "./pages/AuditDashboard";
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuthStore()
   return isAuthenticated ? <>{children}</> : <Navigate to="/login" />
@@ -59,6 +59,7 @@ function App() {
       />
 
       <Routes>
+        <Route path="/audit" element={<AuditDashboard />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -24,6 +24,7 @@ const navigation = [
   { name: 'Risk Classification', href: '/classification', icon: FileCheck },
   { name: 'Documents', href: '/documents', icon: FileText },
   { name: 'LLM Guard', href: '/guard', icon: ShieldCheck },
+  { name: 'Audit Logs', href: '/audit', icon: BarChart },
   { name: 'Chatbot', href: '/rag-chat', icon: MessageSquareText },
 ]
 

--- a/frontend/src/pages/AuditDashboard.tsx
+++ b/frontend/src/pages/AuditDashboard.tsx
@@ -1,0 +1,288 @@
+/**
+ * frontend/src/pages/AuditDashboard.tsx
+ * NEW FILE — drop this into the pages/ folder.
+ *
+ * Wired to the real API: GET /api/v1/analytics/audit-logs
+ * Uses TanStack Query (already in the project as @tanstack/react-query)
+ */
+
+import { useState, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell,
+  PieChart, Pie, Legend,
+} from "recharts";
+import { auditApi, AuditLogEntry } from "../services/api";
+
+// ─── Colour helpers ────────────────────────────────────────────────────────────
+
+type Decision = "allowed" | "blocked" | "sanitized";
+
+const COLOR: Record<Decision, string> = {
+  allowed:   "#1D9E75",
+  blocked:   "#E24B4A",
+  sanitized: "#EF9F27",
+};
+const BG: Record<Decision, string> = {
+  allowed:   "var(--color-background-success)",
+  blocked:   "var(--color-background-danger)",
+  sanitized: "var(--color-background-warning)",
+};
+const TEXT: Record<Decision, string> = {
+  allowed:   "var(--color-text-success)",
+  blocked:   "var(--color-text-danger)",
+  sanitized: "var(--color-text-warning)",
+};
+
+function fmt(iso: string) {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+  });
+}
+
+function RiskBar({ score }: { score: number | null }) {
+  if (score === null) return <span style={{ color: "var(--color-text-secondary)", fontSize: 12 }}>—</span>;
+  const pct = Math.round(score * 100);
+  const color = pct >= 70 ? COLOR.blocked : pct >= 40 ? COLOR.sanitized : COLOR.allowed;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 100 }}>
+      <div style={{ flex: 1, height: 5, background: "var(--color-background-secondary)", borderRadius: 3, overflow: "hidden" }}>
+        <div style={{ width: `${pct}%`, height: "100%", background: color, borderRadius: 3 }} />
+      </div>
+      <span style={{ fontSize: 12, color: "var(--color-text-secondary)", minWidth: 28 }}>{pct}%</span>
+    </div>
+  );
+}
+
+// ─── Page component ────────────────────────────────────────────────────────────
+
+export default function AuditDashboard() {
+  const [decisionFilter, setDecisionFilter] = useState<Decision | "all">("all");
+  const [search, setSearch] = useState("");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  // Fetch from real backend
+const { data, isLoading, isError, refetch } = useQuery({
+  queryKey: ["auditLogs"],
+  queryFn: () => auditApi.getLogs({ limit: 200 }),
+  staleTime: 30_000,
+});
+
+  const logs: AuditLogEntry[] = data?.items ?? [];
+
+  // Counts
+  const counts = useMemo(() => ({
+    total:     logs.length,
+    allowed:   logs.filter(l => l.scan_status === "allowed").length,
+    blocked:   logs.filter(l => l.scan_status === "blocked").length,
+    sanitized: logs.filter(l => l.scan_status === "sanitized").length,
+  }), [logs]);
+
+  // Filtered logs
+  const filtered = useMemo(() => logs.filter(l => {
+    if (decisionFilter !== "all" && l.scan_status !== decisionFilter) return false;
+    if (search && !l.raw_prompt.toLowerCase().includes(search.toLowerCase()) &&
+        !(l.user_id ?? "").toLowerCase().includes(search.toLowerCase())) return false;
+    return true;
+  }), [logs, decisionFilter, search]);
+
+  // Bar chart: decisions per hour (last 12h)
+  const barData = useMemo(() => {
+    const now = Date.now();
+    return Array.from({ length: 12 }, (_, i) => {
+      const hStart = now - (11 - i) * 3_600_000;
+      const hEnd   = hStart + 3_600_000;
+      const label  = new Date(hStart).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+      const bucket = logs.filter(l => {
+        const t = new Date(l.timestamp).getTime();
+        return t >= hStart && t < hEnd;
+      });
+      return {
+        time:      label,
+        allowed:   bucket.filter(l => l.scan_status === "allowed").length,
+        blocked:   bucket.filter(l => l.scan_status === "blocked").length,
+        sanitized: bucket.filter(l => l.scan_status === "sanitized").length,
+      };
+    });
+  }, [logs]);
+
+  const pieData = [
+    { name: "Allowed",   value: counts.allowed,   color: COLOR.allowed },
+    { name: "Blocked",   value: counts.blocked,   color: COLOR.blocked },
+    { name: "Sanitized", value: counts.sanitized, color: COLOR.sanitized },
+  ];
+
+  const card: React.CSSProperties = {
+    background: "var(--color-background-primary)",
+    border: "0.5px solid var(--color-border-tertiary)",
+    borderRadius: "var(--border-radius-lg)",
+    padding: "1rem 1.25rem",
+  };
+
+  const badge = (d: Decision): React.CSSProperties => ({
+    display: "inline-block", padding: "2px 10px",
+    borderRadius: "var(--border-radius-md)",
+    fontSize: 12, fontWeight: 500,
+    background: BG[d], color: TEXT[d],
+  });
+
+  const selectStyle: React.CSSProperties = {
+    fontSize: 13, padding: "4px 8px",
+    borderRadius: "var(--border-radius-md)",
+    border: "0.5px solid var(--color-border-secondary)",
+    background: "var(--color-background-primary)",
+    color: "var(--color-text-primary)", cursor: "pointer",
+  };
+
+  // Loading / error states
+  if (isLoading) return (
+    <div style={{ padding: "3rem", textAlign: "center", color: "var(--color-text-secondary)" }}>
+      Loading audit logs…
+    </div>
+  );
+
+  if (isError) return (
+    <div style={{ padding: "3rem", textAlign: "center" }}>
+      <p style={{ color: "var(--color-text-danger)" }}>Failed to load audit logs.</p>
+      <button onClick={() => refetch()} style={{ marginTop: 8 }}>Retry</button>
+    </div>
+  );
+
+  return (
+    <div style={{ padding: "2rem", maxWidth: 1100, margin: "0 auto" }}>
+
+      {/* Header */}
+      <div style={{ marginBottom: "1.5rem", display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+        <div>
+          <h1 style={{ fontSize: 22, fontWeight: 500, margin: 0 }}>Audit dashboard</h1>
+          <p style={{ fontSize: 14, color: "var(--color-text-secondary)", marginTop: 4 }}>
+            Guard scan decisions — allowed, blocked, and sanitized actions.
+          </p>
+        </div>
+        <button onClick={() => refetch()} style={{ fontSize: 13 }}>Refresh</button>
+      </div>
+
+      {/* Metric cards */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 12, marginBottom: "1.5rem" }}>
+        {[
+          { label: "Total scans", value: counts.total,     color: "var(--color-text-primary)" },
+          { label: "Allowed",     value: counts.allowed,   color: COLOR.allowed   },
+          { label: "Blocked",     value: counts.blocked,   color: COLOR.blocked   },
+          { label: "Sanitized",   value: counts.sanitized, color: COLOR.sanitized },
+        ].map(m => (
+          <div key={m.label} style={{ background: "var(--color-background-secondary)", borderRadius: "var(--border-radius-md)", padding: "1rem" }}>
+            <p style={{ fontSize: 13, color: "var(--color-text-secondary)", margin: "0 0 4px" }}>{m.label}</p>
+            <p style={{ fontSize: 24, fontWeight: 500, margin: 0, color: m.color }}>{m.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Charts */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 260px", gap: 16, marginBottom: "1.5rem" }}>
+        <div style={card}>
+          <p style={{ fontSize: 14, fontWeight: 500, margin: "0 0 1rem" }}>Decisions over time (last 12 h)</p>
+          <ResponsiveContainer width="100%" height={190}>
+            <BarChart data={barData} barSize={8}>
+              <XAxis dataKey="time" tick={{ fontSize: 10 }} interval={2} />
+              <YAxis tick={{ fontSize: 10 }} allowDecimals={false} />
+              <Tooltip contentStyle={{ fontSize: 12 }} />
+              <Bar dataKey="allowed"   stackId="a" fill={COLOR.allowed} />
+              <Bar dataKey="sanitized" stackId="a" fill={COLOR.sanitized} />
+              <Bar dataKey="blocked"   stackId="a" fill={COLOR.blocked} radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div style={{ ...card, display: "flex", flexDirection: "column", alignItems: "center" }}>
+          <p style={{ fontSize: 14, fontWeight: 500, margin: "0 0 0.5rem" }}>Breakdown</p>
+          <PieChart width={210} height={170}>
+            <Pie data={pieData} dataKey="value" cx="50%" cy="50%" outerRadius={64} label={false}>
+              {pieData.map(e => <Cell key={e.name} fill={e.color} />)}
+            </Pie>
+            <Legend iconSize={10} wrapperStyle={{ fontSize: 12 }} />
+            <Tooltip contentStyle={{ fontSize: 12 }} />
+          </PieChart>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "center", marginBottom: "1rem" }}>
+        <input
+          type="text" placeholder="Search prompt or user ID…"
+          value={search} onChange={e => setSearch(e.target.value)}
+          style={{ ...selectStyle, padding: "5px 10px", flex: "1 1 200px" }}
+        />
+        {(["all", "allowed", "blocked", "sanitized"] as const).map(d => (
+          <button key={d} onClick={() => setDecisionFilter(d)} style={{
+            fontSize: 13, padding: "4px 14px", borderRadius: "var(--border-radius-md)", cursor: "pointer",
+            fontWeight: decisionFilter === d ? 500 : 400,
+            border: decisionFilter === d && d !== "all"
+              ? `1.5px solid ${COLOR[d]}`
+              : decisionFilter === d ? "1.5px solid var(--color-border-primary)" : "0.5px solid var(--color-border-tertiary)",
+            background: decisionFilter === d && d !== "all" ? BG[d] : "var(--color-background-primary)",
+            color: decisionFilter === d && d !== "all" ? TEXT[d] : "var(--color-text-primary)",
+          }}>
+            {d === "all" ? "All" : d.charAt(0).toUpperCase() + d.slice(1)}
+          </button>
+        ))}
+        <span style={{ fontSize: 13, color: "var(--color-text-secondary)" }}>{filtered.length} result{filtered.length !== 1 ? "s" : ""}</span>
+      </div>
+
+      {/* Table */}
+      <div style={card}>
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+            <thead>
+              <tr style={{ borderBottom: "0.5px solid var(--color-border-tertiary)" }}>
+                {["Timestamp", "User", "Prompt preview", "Decision", "Risk", "Method"].map(h => (
+                  <th key={h} style={{ textAlign: "left", padding: "8px 10px", fontWeight: 500, color: "var(--color-text-secondary)", whiteSpace: "nowrap" }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.length === 0 ? (
+                <tr><td colSpan={6} style={{ padding: "2rem", textAlign: "center", color: "var(--color-text-secondary)" }}>
+                  {logs.length === 0 ? "No Guard scans recorded yet. Run a scan via POST /guard/scan to see logs here." : "No results match your filters."}
+                </td></tr>
+              ) : filtered.map(log => (
+                <>
+                  <tr key={log.id} onClick={() => setExpandedId(expandedId === log.id ? null : log.id)} style={{
+                    borderBottom: "0.5px solid var(--color-border-tertiary)", cursor: "pointer",
+                    background: expandedId === log.id ? "var(--color-background-secondary)" : "transparent",
+                  }}>
+                    <td style={{ padding: "10px", whiteSpace: "nowrap", color: "var(--color-text-secondary)" }}>{fmt(log.timestamp)}</td>
+                    <td style={{ padding: "10px", whiteSpace: "nowrap" }}>{log.user_id ?? "—"}</td>
+                    <td style={{ padding: "10px", maxWidth: 240 }}>
+                      <span style={{ display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{log.raw_prompt}</span>
+                    </td>
+                    <td style={{ padding: "10px" }}><span style={badge(log.scan_status as Decision)}>{log.scan_status}</span></td>
+                    <td style={{ padding: "10px", minWidth: 120 }}><RiskBar score={log.risk_score ?? null} /></td>
+                    <td style={{ padding: "10px", color: "var(--color-text-secondary)" }}>{log.detection_method ?? "—"}</td>
+                  </tr>
+                  {expandedId === log.id && (
+                    <tr key={`${log.id}-detail`} style={{ background: "var(--color-background-secondary)" }}>
+                      <td colSpan={6} style={{ padding: "12px 16px" }}>
+                        <p style={{ margin: "0 0 6px", fontSize: 13, fontWeight: 500 }}>Full prompt</p>
+                        <p style={{ margin: "0 0 10px", fontSize: 13, fontFamily: "var(--font-mono)", color: "var(--color-text-secondary)" }}>{log.raw_prompt}</p>
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 20, fontSize: 12, color: "var(--color-text-secondary)" }}>
+                          <span>ID: <strong style={{ color: "var(--color-text-primary)" }}>{log.id}</strong></span>
+                          <span>IP: <strong style={{ color: "var(--color-text-primary)" }}>{log.ip_address ?? "—"}</strong></span>
+                          <span>Triggered rules: <strong style={{ color: "var(--color-text-primary)" }}>{JSON.stringify(log.triggered_rules) ?? "—"}</strong></span>
+                          <span>Time (UTC): <strong style={{ color: "var(--color-text-primary)" }}>{new Date(log.timestamp).toISOString()}</strong></span>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <p style={{ fontSize: 12, color: "var(--color-text-secondary)", marginTop: 10 }}>
+        Click any row to expand details. Data is fetched live from GET /api/v1/analytics/audit-logs.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -1,244 +1,293 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import {
-  AlertCircle,
   Bot,
-  FileText,
   Loader2,
-  Send,
   Sparkles,
-  Square,
   User,
 } from 'lucide-react'
 
-import { useRagStream } from '../hooks/useRagStream'
+import { ragApi } from '../services/api'
+
+interface RagSource {
+  title: string
+  excerpt: string
+}
+
+interface RagAnswer {
+  answer: string
+  sources: RagSource[]
+  answer_id?: string
+}
+
+interface ApiError {
+  response?: {
+    status?: number
+    data?: {
+      detail?: string
+    }
+  }
+  message?: string
+}
+
+function isApiError(
+  error: unknown
+): error is ApiError {
+  return (
+    typeof error === 'object' &&
+    error !== null
+  )
+}
+
+function buildAnswerExport(
+  answer: RagAnswer
+): string {
+  return [
+    'AI Response',
+    answer.answer,
+    '',
+    'Source citations',
+    ...answer.sources.map(
+      (source, index) =>
+        `${index + 1}. ${source.title}\n${source.excerpt}`
+    ),
+  ].join('\n')
+}
 
 export default function RagChat() {
   const [question, setQuestion] = useState('')
-  const [submittedQuestion, setSubmittedQuestion] = useState('')
-  const [validationError, setValidationError] = useState<string | null>(null)
+  const [submittedQuestion, setSubmittedQuestion] =
+    useState('')
+  const [answer, setAnswer] =
+    useState<RagAnswer | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] =
+    useState<string | null>(null)
 
-  const {
-    status,
-    tokens,
-    citations,
-    error: streamError,
-    ask,
-    stop,
-  } = useRagStream()
-
-  const isStreaming = status === 'streaming'
-  // We're "loading" only until the first token arrives. After that we show
-  // the partial answer with a typing caret.
-  const isAwaitingFirstToken = isStreaming && tokens.length === 0
-  const hasAnswer = tokens.length > 0
-  const displayError = validationError ?? streamError
-
-  const handleAsk = (e: React.FormEvent) => {
+  const handleAsk = async (e: React.FormEvent) => {
     e.preventDefault()
-    const trimmed = question.trim()
-    if (!trimmed) {
-      setValidationError('Please enter a question before asking.')
+
+    const trimmedQuestion = question.trim()
+
+    if (!trimmedQuestion) {
+      setError(
+        'Please enter a question before asking.'
+      )
       setSubmittedQuestion('')
+      setAnswer(null)
       return
     }
-    setValidationError(null)
-    setSubmittedQuestion(trimmed)
+
+    setSubmittedQuestion(trimmedQuestion)
     setQuestion('')
-    ask(trimmed)
+    setIsLoading(true)
+    setError(null)
+    setAnswer(null)
+
+    try {
+      const data = await ragApi.query(trimmedQuestion)
+
+      setAnswer({
+  answer: data.answer,
+  sources: (data.sources || []) as RagSource[],
+  answer_id: data.answer_id,
+})
+    } catch (err: unknown) {
+      const apiError = isApiError(err)
+        ? err
+        : {}
+
+      if (
+        apiError.response?.status === 503
+      ) {
+        setError(
+          'Index not ready. Please try again later.'
+        )
+      } else if (
+        apiError.response?.status === 401
+      ) {
+        setError(
+          'Unauthorized. Please login again.'
+        )
+      } else {
+        setError(
+          apiError.response?.data?.detail ||
+            apiError.message ||
+            'Unable to generate an answer right now.'
+        )
+      }
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   const handleExport = () => {
-    if (!hasAnswer) return
+    if (!answer) return
 
-    const exportText = [
-      'AI Response',
-      tokens,
-      '',
-      'Source citations',
-      ...citations.map(
-        (citation, index) =>
-          `${index + 1}. ${citation.source}\n${citation.excerpt}`
-      ),
-    ].join('\n')
+    const blob = new Blob(
+      [buildAnswerExport(answer)],
+      {
+        type: 'text/plain;charset=utf-8',
+      }
+    )
 
-    const blob = new Blob([exportText], {
-      type: 'text/plain;charset=utf-8',
-    })
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
+
     link.href = url
     link.download = 'rag-answer.txt'
     link.click()
+
     URL.revokeObjectURL(url)
   }
 
   return (
     <div className="h-[calc(100vh-2rem)] md:h-[calc(100vh-4rem)] flex flex-col bg-white rounded-xl border border-gray-200 overflow-hidden">
-      {/* Header */}
       <div className="px-4 sm:px-6 py-4 border-b border-gray-200 bg-white">
         <div className="flex items-center gap-3">
           <div className="p-2 sm:p-3 bg-primary-50 rounded-xl">
             <Bot className="w-5 h-5 sm:w-6 sm:h-6 text-primary-600" />
           </div>
+
           <div>
-            <h1 className="text-xl sm:text-2xl font-bold text-gray-900">Chatbot</h1>
+            <h1 className="text-xl sm:text-2xl font-bold text-gray-900">
+              Chatbot
+            </h1>
+
             <p className="text-sm sm:text-base text-gray-600">
-              Ask regulatory and compliance questions with source-backed answers
+              Ask regulatory and compliance questions
+              with source-backed answers
             </p>
           </div>
         </div>
       </div>
 
-      {/* Body */}
       <div className="flex-1 overflow-y-auto bg-gray-50">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6 sm:space-y-8">
-          {/* Empty state */}
-          {!submittedQuestion && !hasAnswer && !isStreaming && !displayError && (
-            <div className="min-h-[320px] sm:min-h-[420px] flex flex-col items-center justify-center text-center">
-              <div className="p-3 sm:p-4 bg-primary-50 rounded-2xl mb-5">
-                <Sparkles className="w-8 h-8 sm:w-10 sm:h-10 text-primary-600" />
-              </div>
-              <h2 className="text-xl sm:text-2xl font-semibold text-gray-900">
-                How can I help with AI compliance?
-              </h2>
-              <p className="text-sm sm:text-base text-gray-500 mt-2 max-w-xl">
-                Ask about EU AI Act risk classification, compliance documentation,
-                human oversight, or source-backed regulatory guidance.
-              </p>
-              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 mt-6 sm:mt-8 w-full">
-                {[
-                  'Does my system qualify as high-risk?',
-                  'Which documents are needed for compliance?',
-                  'What does human oversight require?',
-                ].map((example) => (
-                  <button
-                    key={example}
-                    type="button"
-                    onClick={() => setQuestion(example)}
-                    className="text-left bg-white border border-gray-200 rounded-xl p-4 text-sm text-gray-700 hover:border-primary-200 hover:bg-primary-50 transition-colors"
-                  >
-                    {example}
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
+          {!submittedQuestion &&
+            !answer &&
+            !isLoading &&
+            !error && (
+              <div className="min-h-[320px] sm:min-h-[420px] flex flex-col items-center justify-center text-center">
+                <div className="p-3 sm:p-4 bg-primary-50 rounded-2xl mb-5">
+                  <Sparkles className="w-8 h-8 sm:w-10 sm:h-10 text-primary-600" />
+                </div>
 
-          {/* Conversation */}
-          {(submittedQuestion || hasAnswer || isStreaming || displayError) && (
+                <h2 className="text-xl sm:text-2xl font-semibold text-gray-900">
+                  How can I help with AI compliance?
+                </h2>
+
+                <p className="text-sm sm:text-base text-gray-500 mt-2 max-w-xl">
+                  Ask about EU AI Act risk
+                  classification, compliance
+                  documentation, human oversight, or
+                  source-backed regulatory guidance.
+                </p>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 mt-6 sm:mt-8 w-full">
+                  {[
+                    'Does my system qualify as high-risk?',
+                    'Which documents are needed for compliance?',
+                    'What does human oversight require?',
+                  ].map((example) => (
+                    <button
+                      key={example}
+                      type="button"
+                      onClick={() =>
+                        setQuestion(example)
+                      }
+                      className="text-left bg-white border border-gray-200 rounded-xl p-4 text-sm text-gray-700 hover:border-primary-200 hover:bg-primary-50 transition-colors"
+                    >
+                      {example}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+          {(submittedQuestion ||
+            answer ||
+            isLoading ||
+            error) && (
             <div className="space-y-5 sm:space-y-6">
-              {/* User bubble */}
               {submittedQuestion && (
                 <div className="flex justify-end">
                   <div className="w-full sm:w-auto sm:max-w-2xl bg-primary-600 text-white rounded-2xl sm:rounded-br-md px-4 sm:px-5 py-3 sm:py-4 shadow-sm">
                     <div className="flex items-start gap-3">
                       <User className="w-5 h-5 mt-0.5 flex-shrink-0" />
-                      <p className="text-sm leading-6">{submittedQuestion}</p>
+
+                      <p className="text-sm leading-6">
+                        {submittedQuestion}
+                      </p>
                     </div>
                   </div>
                 </div>
               )}
 
-              {/* Loading skeleton (before first token) */}
-              {isAwaitingFirstToken && (
+              {isLoading && (
                 <div className="flex justify-start">
                   <div className="w-full max-w-3xl bg-white border border-gray-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 shadow-sm">
                     <div className="flex items-center gap-3 mb-4">
                       <div className="p-2 bg-primary-50 rounded-lg">
                         <Bot className="w-5 h-5 text-primary-600" />
                       </div>
+
                       <div className="flex items-center gap-2 text-sm font-medium text-gray-900">
                         <Loader2 className="w-4 h-4 animate-spin text-primary-600" />
                         Searching knowledge base
                       </div>
                     </div>
-                    <div className="space-y-3 animate-pulse">
-                      <div className="h-3 bg-gray-200 rounded-full w-11/12" />
-                      <div className="h-3 bg-gray-200 rounded-full w-full" />
-                      <div className="h-3 bg-gray-200 rounded-full w-9/12" />
-                    </div>
                   </div>
                 </div>
               )}
 
-              {/* Error state (no answer yet) */}
-              {!isAwaitingFirstToken && displayError && !hasAnswer && (
-                <div className="flex justify-start">
-                  <div className="w-full max-w-3xl bg-red-50 border border-red-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 text-red-800">
-                    <div className="flex items-start gap-3">
-                      <AlertCircle className="w-5 h-5 mt-0.5 flex-shrink-0" />
-                      <div>
-                        <h3 className="font-medium">Unable to answer</h3>
-                        <p className="text-sm mt-1">{displayError}</p>
-                      </div>
-                    </div>
-                  </div>
+              {error && (
+                <div className="bg-red-50 border border-red-200 text-red-700 rounded-xl p-4">
+                  {error}
                 </div>
               )}
 
-              {/* Answer bubble */}
-              {hasAnswer && (
-                <div className="flex justify-start">
-                  <div className="w-full max-w-3xl bg-white border border-gray-200 rounded-2xl sm:rounded-bl-md px-4 sm:px-5 py-4 shadow-sm">
-                    <div className="flex items-start gap-3">
-                      <div className="p-2 bg-primary-50 rounded-lg flex-shrink-0">
-                        <Bot className="w-5 h-5 text-primary-600" />
-                      </div>
-                      <div className="space-y-5 min-w-0 flex-1">
-                        <p className="text-gray-700 leading-7 whitespace-pre-wrap">
-                          {tokens}
-                          {isStreaming && (
-                            <span
-                              className="inline-block w-2 h-4 bg-primary-600 ml-0.5 align-text-bottom animate-pulse"
-                              aria-hidden="true"
-                            />
-                          )}
-                        </p>
+              {answer && (
+                <div className="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
+                  <div className="prose max-w-none">
+                    <p className="text-gray-800 whitespace-pre-line">
+                      {answer.answer}
+                    </p>
+                  </div>
 
-                        {streamError && (
-                          <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800">
-                            <span className="font-medium">Stream interrupted: </span>
-                            {streamError}
-                          </div>
-                        )}
+                  {answer.sources.length > 0 && (
+                    <div className="mt-6">
+                      <h3 className="text-sm font-semibold text-gray-900 mb-3">
+                        Sources
+                      </h3>
 
-                        {citations.length > 0 && (
-                          <div className="mt-6">
-                            <div className="flex items-center justify-between mb-3">
-                              <h3 className="text-sm font-semibold text-gray-900">
-                                Sources
-                              </h3>
-                              {!isStreaming && (
-                                <button
-                                  type="button"
-                                  onClick={handleExport}
-                                  className="inline-flex items-center gap-1.5 text-xs text-primary-600 hover:text-primary-700"
-                                >
-                                  <FileText className="w-3.5 h-3.5" />
-                                  Export
-                                </button>
-                              )}
+                      <div className="space-y-3">
+                        {answer.sources.map(
+                          (source, index) => (
+                            <div
+                              key={index}
+                              className="border border-gray-200 rounded-lg p-3 bg-gray-50"
+                            >
+                              <p className="font-medium text-sm text-gray-900">
+                                {source.title}
+                              </p>
+
+                              <p className="text-sm text-gray-600 mt-1">
+                                {source.excerpt}
+                              </p>
                             </div>
-                            <div className="space-y-3">
-                              {citations.map((citation, index) => (
-                                <div
-                                  key={index}
-                                  className="border border-gray-200 rounded-lg p-3 bg-gray-50"
-                                >
-                                  <p className="font-medium text-sm text-gray-900">
-                                    {citation.source}
-                                  </p>
-                                  <p className="text-sm text-gray-600 mt-1">
-                                    {citation.excerpt}
-                                  </p>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
+                          )
                         )}
                       </div>
                     </div>
-                  </div>
+                  )}
+
+                  <button
+                    type="button"
+                    onClick={handleExport}
+                    className="mt-6 inline-flex items-center rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700"
+                  >
+                    Export answer
+                  </button>
                 </div>
               )}
             </div>
@@ -246,55 +295,30 @@ export default function RagChat() {
         </div>
       </div>
 
-      {/* Input form */}
-      <div className="border-t border-gray-200 bg-white px-4 sm:px-6 py-3 sm:py-4">
-        <form onSubmit={handleAsk} className="max-w-4xl mx-auto">
-          <div className="flex items-end gap-2 sm:gap-3 bg-gray-50 border border-gray-300 rounded-2xl px-3 sm:px-4 py-3 focus-within:ring-2 focus-within:ring-primary-500 focus-within:border-primary-500">
-            <label htmlFor="rag-question" className="sr-only">
-              Question
-            </label>
-            <textarea
-              id="rag-question"
-              value={question}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setQuestion(e.target.value)}
-              placeholder="Ask a compliance question..."
-              rows={1}
-              disabled={isStreaming}
-              className="min-w-0 flex-1 resize-none bg-transparent border-0 p-0 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-0 disabled:text-gray-500"
-            />
-            {isStreaming ? (
-              <button
-                type="button"
-                onClick={stop}
-                className="inline-flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 bg-gray-800 text-white rounded-xl hover:bg-gray-700 flex-shrink-0"
-                aria-label="Stop answering"
-                title="Stop answering"
-              >
-                <Square className="w-4 h-4 fill-current" />
-              </button>
-            ) : (
-              <button
-                type="submit"
-                className="inline-flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 bg-primary-600 text-white rounded-xl hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
-                aria-label="Ask question"
-                title="Ask question"
-              >
-                <Send className="w-5 h-5" />
-              </button>
-            )}
-          </div>
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 mt-2">
-            <p className="text-xs text-gray-500">
-              {isStreaming
-                ? 'Streaming answer — click stop to cancel.'
-                : 'Answers stream token-by-token as they are generated.'}
-            </p>
-            <p className="text-xs text-gray-400">
-              Use this assistant to explore risk, documentation, and governance obligations.
-            </p>
-          </div>
-        </form>
-      </div>
+      <form
+        onSubmit={handleAsk}
+        className="border-t border-gray-200 bg-white p-4"
+      >
+        <div className="max-w-4xl mx-auto flex items-center gap-3">
+          <input
+            type="text"
+            value={question}
+            onChange={(e) =>
+              setQuestion(e.target.value)
+            }
+            placeholder="Ask a compliance question..."
+            className="flex-1 rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="bg-primary-600 text-white px-5 py-3 rounded-xl hover:bg-primary-700 disabled:opacity-50"
+          >
+            Ask
+          </button>
+        </div>
+      </form>
     </div>
   )
 }

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -87,10 +87,10 @@ export default function RagChat() {
       const data = await ragApi.query(trimmedQuestion)
 
       setAnswer({
-  answer: data.answer,
-  sources: (data.sources || []) as RagSource[],
-  answer_id: data.answer_id,
-})
+        answer: data.answer,
+        sources: data.sources || [],
+        answer_id: data.answer_id,
+      })
     } catch (err: unknown) {
       const apiError = isApiError(err)
         ? err

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -476,6 +476,17 @@ export const analyticsApi = {
     return data
   },
 }
+export interface AuditLogEntry {
+  id: string
+  user_id?: string | null
+  ip_address?: string | null
+  timestamp: string
+  raw_prompt: string
+  scan_status: 'allowed' | 'blocked' | 'sanitized'
+  risk_score?: number | null
+  triggered_rules?: unknown
+  detection_method?: string | null
+}
 
 export const guardHistoryApi = {
   list: async (params?: {


### PR DESCRIPTION
## Summary

Closes #447

Added Guard audit logging support and an audit dashboard for scan decisions. This includes backend audit log storage/API support and a frontend dashboard with metrics, charts, filters, and expandable log rows.

Type of Change


- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if need

Testing:

Frontend build passes with npm run build
Backend starts until database initialization
End-to-end database testing was not completed locally because PostgreSQL was not fully available in my setup
