### PR TITLE
fix: handle duplicate name collision in AI system clone endpoint

### DIFF
--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -446,18 +446,36 @@ def clone_ai_system(
             detail="AI system not found"
         )
 
-    cloned = AISystem(
-        owner_id=current_user.id,
-        name=f"{original.name} (copy)",
-        description=original.description,
-        version=original.version,
-        use_case=original.use_case,
-        sector=original.sector,
-        compliance_status=ComplianceStatus.NOT_STARTED,
-    )
+        base_name = f"{original.name} (copy)"
+        clone_name = base_name
+        counter = 2
 
-    db.add(cloned)
-    db.commit()
+        while db.query(AISystem).filter(
+            AISystem.owner_id == current_user.id,
+            AISystem.name == clone_name,
+        ).first():
+            clone_name = f"{original.name} (copy {counter})"
+            counter += 1
+
+        cloned = AISystem(
+            owner_id=current_user.id,
+            name=clone_name,
+            description=original.description,
+            version=original.version,
+            use_case=original.use_case,
+            sector=original.sector,
+            compliance_status=ComplianceStatus.NOT_STARTED,
+        )
+
+        db.add(cloned)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Could not create a unique clone name.",
+        )
     db.refresh(cloned)
     return cloned
 


### PR DESCRIPTION
Fixes #795

## Problem
When cloning an AI system multiple times, the endpoint would crash with 
an IntegrityError because "Alpha (copy)" already existed.

## Solution
- Added a while loop to check if the clone name already exists
- If "Alpha (copy)" exists, tries "Alpha (copy 2)", "Alpha (copy 3)" etc.
- Added try/except IntegrityError as a safety net

## Testing
- Clone same system twice → should create "Alpha (copy)" and "Alpha (copy 2)"