### PR TITLE
fix(rag): handle malformed PDF parser failures

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -11,6 +11,7 @@ Contributor note:
   - TODO: Integrate MLflow tracking from modules/rag/ml_flow.py
 """
 
+import logging
 import os
 import shutil
 import tempfile
@@ -20,6 +21,7 @@ import mimetypes
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from pypdf.errors import PdfReadError
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -34,6 +36,7 @@ from app.modules.rag.streaming import stream_rag_answer
 from app.modules.rag.vector_store import create_vector_store, load_vector_store
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 class RAGQueryRequest(BaseModel):
@@ -114,7 +117,22 @@ def ingest_documents(
             saved_paths.append(dest)
 
         # ── 3. Chunk documents (gives us the accurate chunk count) ────────
-        raw_chunks = load_documents_from_paths(saved_paths)
+        try:
+            raw_chunks = load_documents_from_paths(saved_paths)
+        except PdfReadError:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Could not read one or more uploaded PDFs. Ensure the files "
+                    "are valid and not password-protected."
+                ),
+            )
+        except Exception:
+            logger.exception("Failed to load uploaded RAG documents")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Unable to process uploaded PDF documents right now.",
+            )
         
         # Filter out chunks with empty or whitespace-only page_content
         chunks = [

--- a/backend/tests/test_rag_ingest.py
+++ b/backend/tests/test_rag_ingest.py
@@ -9,7 +9,9 @@ run without an OpenAI key, a running DB, or any real PDFs on disk.
 import io
 import pytest
 from unittest.mock import MagicMock, patch
+from fastapi import HTTPException, UploadFile
 from pypdf.errors import PdfReadError
+from app.api.v1.rag import ingest_documents
 from app.core.security import get_current_user
 from app.main import app
 
@@ -196,34 +198,44 @@ class TestRagIngest:
 
     @patch(PATCH_CREATE_VS)
     @patch(PATCH_LOAD_DOCS)
-    def test_pdf_parser_failure_returns_400(self, mock_load, mock_create, client, mock_rag_user):
+    def test_pdf_parser_failure_returns_400(self, mock_load, mock_create):
         """Malformed or encrypted PDFs should return a sanitized client error."""
         mock_load.side_effect = PdfReadError("sensitive parser detail")
 
-        with patch(PATCH_AUTH, return_value=_mock_current_user()):
-            response = client.post(
-                "/api/v1/rag/ingest",
-                files={"files": _make_pdf_upload("broken.pdf")},
+        with pytest.raises(HTTPException) as exc_info:
+            ingest_documents(
+                files=[
+                    UploadFile(
+                        filename="broken.pdf",
+                        file=io.BytesIO(b"%PDF-1.4 broken"),
+                    )
+                ],
+                current_user=_mock_current_user(),
             )
 
-        assert response.status_code == 400
-        assert "sensitive parser detail" not in response.json()["detail"]
+        assert exc_info.value.status_code == 400
+        assert "sensitive parser detail" not in exc_info.value.detail
         mock_create.assert_not_called()
 
     @patch(PATCH_CREATE_VS)
     @patch(PATCH_LOAD_DOCS)
-    def test_unexpected_loader_failure_returns_503(self, mock_load, mock_create, client, mock_rag_user):
+    def test_unexpected_loader_failure_returns_503(self, mock_load, mock_create):
         """Unexpected loader failures should be logged without leaking details."""
         mock_load.side_effect = RuntimeError("sensitive storage detail")
 
-        with patch(PATCH_AUTH, return_value=_mock_current_user()):
-            response = client.post(
-                "/api/v1/rag/ingest",
-                files={"files": _make_pdf_upload("valid.pdf")},
+        with pytest.raises(HTTPException) as exc_info:
+            ingest_documents(
+                files=[
+                    UploadFile(
+                        filename="valid.pdf",
+                        file=io.BytesIO(b"%PDF-1.4 valid"),
+                    )
+                ],
+                current_user=_mock_current_user(),
             )
 
-        assert response.status_code == 503
-        assert "sensitive storage detail" not in response.json()["detail"]
+        assert exc_info.value.status_code == 503
+        assert "sensitive storage detail" not in exc_info.value.detail
         mock_create.assert_not_called()
 
     # ------------------------------------------------------------------

--- a/backend/tests/test_rag_ingest.py
+++ b/backend/tests/test_rag_ingest.py
@@ -9,6 +9,7 @@ run without an OpenAI key, a running DB, or any real PDFs on disk.
 import io
 import pytest
 from unittest.mock import MagicMock, patch
+from pypdf.errors import PdfReadError
 from app.core.security import get_current_user
 from app.main import app
 
@@ -192,6 +193,38 @@ class TestRagIngest:
         assert response.status_code == 503
         assert "FAISS" in response.json()["detail"]
         assert "Embedding model unavailable" in response.json()["detail"]
+
+    @patch(PATCH_CREATE_VS)
+    @patch(PATCH_LOAD_DOCS)
+    def test_pdf_parser_failure_returns_400(self, mock_load, mock_create, client, mock_rag_user):
+        """Malformed or encrypted PDFs should return a sanitized client error."""
+        mock_load.side_effect = PdfReadError("sensitive parser detail")
+
+        with patch(PATCH_AUTH, return_value=_mock_current_user()):
+            response = client.post(
+                "/api/v1/rag/ingest",
+                files={"files": _make_pdf_upload("broken.pdf")},
+            )
+
+        assert response.status_code == 400
+        assert "sensitive parser detail" not in response.json()["detail"]
+        mock_create.assert_not_called()
+
+    @patch(PATCH_CREATE_VS)
+    @patch(PATCH_LOAD_DOCS)
+    def test_unexpected_loader_failure_returns_503(self, mock_load, mock_create, client, mock_rag_user):
+        """Unexpected loader failures should be logged without leaking details."""
+        mock_load.side_effect = RuntimeError("sensitive storage detail")
+
+        with patch(PATCH_AUTH, return_value=_mock_current_user()):
+            response = client.post(
+                "/api/v1/rag/ingest",
+                files={"files": _make_pdf_upload("valid.pdf")},
+            )
+
+        assert response.status_code == 503
+        assert "sensitive storage detail" not in response.json()["detail"]
+        mock_create.assert_not_called()
 
     # ------------------------------------------------------------------
     # Auth


### PR DESCRIPTION
## Summary

Closes #975

Handles malformed or encrypted PDF parser failures as sanitized client errors, and maps unexpected document-loader failures to logged, generic service-unavailable responses. Adds focused regression coverage for both failure paths so parser and infrastructure details are not exposed to API clients.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally (local checkout does not have pytest installed)
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Testing

- `git diff --check`
- `python3 -m compileall backend/app/api/v1/rag.py backend/tests/test_rag_ingest.py`
- `python3 -m pytest backend/tests/test_rag_ingest.py -q` *(not run: local Python environment has no pytest module)*

## Screenshots (if UI change)

Not applicable.