### PR TITLE
fix: enable RAG router registration (#964)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Unit and integration tests for bypass payloads (`test_normalizer.py` and `test_guard.py`)
 
 ### Fixed
+- **RAG Router** — Restored the RAG router import and registration in `backend/app/api/v1/__init__.py` so all `/api/v1/rag/*` endpoints are reachable again (#964).
 - **Frontend Theme** — Fixed dark mode flash of unstyled content (FOUC), eliminated duplicate CSS, fixed React state overwrite bugs, and improved system preference synchronization.
 - **Documents API** — Validate `ai_system_id` ownership before creating documents so users cannot link documents to another user's AI system.
 - **PDF Export** — Escape user-controlled document text before ReportLab rendering and sanitize generated download filenames.

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api.v1 import auth, ai_systems, documents, classification, guard, badge, analytics, notifications, webhooks
+from app.api.v1 import auth, ai_systems, documents, classification, guard, badge, analytics, notifications, webhooks, rag
 
 api_router = APIRouter()
 
@@ -11,7 +11,7 @@ api_router.include_router(
 )
 api_router.include_router(documents.router, prefix="/documents", tags=["Documents"])
 api_router.include_router(guard.router, prefix="/guard", tags=["LLM Guard"])
-#api_router.include_router(rag.router, prefix="/rag", tags=["RAG Intelligence"])
+api_router.include_router(rag.router, prefix="/rag", tags=["RAG Intelligence"])
 api_router.include_router(analytics.router, prefix="/analytics", tags=["Analytics"])
 api_router.include_router(notifications.router, prefix="/notifications", tags=["Notifications"])
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["Webhooks"])


### PR DESCRIPTION
## Summary

Closes #964

The RAG router import was missing and its registration was commented out in ackend/app/api/v1/__init__.py, causing all /api/v1/rag/* endpoints to be unreachable. This restores the import and uncomments the router registration line.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Screenshots (if UI change)

N/A — backend-only change.