### PR TITLE
fix: reject passwords over bcrypt byte limit

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -21,7 +21,6 @@ from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.core.security import (
-    validate_password_strength,
     verify_password,
     get_password_hash,
     create_access_token,

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -30,8 +30,8 @@ def _get_credentials_exception() -> HTTPException:
 
 def validate_password_strength(password: str) -> str:
     errors = []
-    if len(password) > 128:
-        raise ValueError("Password must not exceed 128 characters")
+    if len(password.encode("utf-8")) > 72:
+        raise ValueError("Password must be 72 bytes or fewer due to bcrypt limitations")
     if len(password) < 8:
         errors.append("at least 8 characters")
     if not re.search(r'[A-Z]', password):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -40,6 +40,21 @@ def test_register_weak_password(client):
     assert isinstance(data["detail"], list) or "Password must contain" in str(data["detail"])
 
 
+def test_register_password_over_72_bytes_returns_422(client):
+    """Test registration rejects passwords that exceed bcrypt's 72-byte limit."""
+    long_password = ("é" * 36) + "A1!"
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "longpass@example.com",
+            "password": long_password,
+        }
+    )
+
+    assert response.status_code == 422
+    assert "72 bytes" in str(response.json())
+
+
 def test_register_duplicate_email(client):
     """Test registration fails when email already exists."""
     user_data = {

--- a/backend/tests/test_change_password.py
+++ b/backend/tests/test_change_password.py
@@ -91,6 +91,16 @@ class TestChangePassword:
         assert resp.status_code == 422
         assert "at least 8 characters" in str(resp.json())
 
+    def test_long_new_password_returns_422(self, client):
+        c, user = client
+        long_password = ("é" * 36) + "A1!"
+        resp = c.post(
+            "/api/v1/auth/change-password",
+            json={"current_password": "OldPass1!", "new_password": long_password},
+        )
+        assert resp.status_code == 422
+        assert "72 bytes" in str(resp.json())
+
     def test_missing_uppercase_returns_422(self, client):
         c, user = client
         resp = c.post(


### PR DESCRIPTION
Closes #932\n\nSummary:\n- reject passwords over bcrypt's 72-byte bcrypt limit in the shared password validator\n- keep registration and change-password paths on the shared validation path\n- add regressions for register and change-password using a UTF-8 password over 72 bytes\n\nValidation:\n- git diff --check\n- /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest backend/tests/test_auth.py backend/tests/test_change_password.py -q