### PR TITLE
fix: configure frontend api base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ npm install
 npm run dev
 ```
 
+For hosted frontend deployments, set `VITE_API_BASE_URL` to the backend API origin, for example `http://localhost:8000/api/v1` locally or your deployed backend URL in production.
+
 ### Option 3 — Ollama (free, no API key)
 
 ```bash

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000/api/v1

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,8 +1,16 @@
 import axios, { InternalAxiosRequestConfig, AxiosResponse } from 'axios'
 import { useAuthStore } from '../stores/authStore'
 
+const configuredApiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim()
+const API_BASE_URL = configuredApiBaseUrl ? configuredApiBaseUrl.replace(/\/$/, '') : '/api/v1'
+
+function buildApiUrl(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${API_BASE_URL}${normalizedPath}`
+}
+
 const api = axios.create({
-  baseURL: '/api/v1',
+  baseURL: API_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -341,7 +349,7 @@ export const ragApi = {
     signal?: AbortSignal,
   ): Promise<void> => {
     const token = useAuthStore.getState().token
-    const resp = await fetch('/api/v1/rag/query/stream', {
+    const resp = await fetch(buildApiUrl('/rag/query/stream'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Closes #995\n\nSummary:\n- make the frontend API client read VITE_API_BASE_URL so hosted deployments can point at the backend origin instead of assuming same-origin /api/v1\n- route the RAG stream fetch through the same base URL helper so all API calls stay aligned\n- add frontend/.env.example and Vite ambient typing so the new env variable is discoverable and type-safe\n- document the production setup note in the README\n\nValidation:\n- git diff --check\n- node_modules/.bin/tsc --noEmit --ignoreDeprecations 5.0 2>&1 | grep 'src/services/api.ts\|src/vite-env.d.ts' (no output, touched files clear)\n\nNote:\n- the repo's full frontend build currently fails in this checkout because of pre-existing TypeScript config / unused-react-import issues in untouched files, so I kept validation focused on the modified client files.