### PR TITLE
feat(frontend): add copy actions for generated content

### DIFF
--- a/frontend/src/components/DocumentEditor.tsx
+++ b/frontend/src/components/DocumentEditor.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Save, Eye, EyeOff } from 'lucide-react'
 import CodeMirror from '@uiw/react-codemirror'
 import { markdown } from '@codemirror/lang-markdown'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import api from '../services/api'
+import CopyButton from './CopyButton'
 
 interface DocumentEditorProps {
   documentId: number
@@ -36,13 +37,11 @@ export default function DocumentEditor({
       onSave?.(content)
       setSaveError('')
     } catch (error) {
-  console.error('Save failed:', error)
-  setSaveError(
-    error instanceof Error
-      ? error.message
-      : 'Failed to save changes'
-  )
-}
+      console.error('Save failed:', error)
+      setSaveError(
+        error instanceof Error ? error.message : 'Failed to save changes'
+      )
+    }
     setIsSaving(false)
   }, [content, documentId, onSave])
 
@@ -78,7 +77,14 @@ export default function DocumentEditor({
           {showPreview ? 'Edit' : 'Preview'}
         </button>
         <div className="flex items-center gap-3">
-         {saveError && (
+          <CopyButton
+            text={content}
+            label="Copy"
+            copiedLabel="Copied!"
+            successMessage="Document copied!"
+            iconOnly
+          />
+          {saveError && (
             <span className="text-sm text-red-500">
               {saveError}
             </span>
@@ -87,7 +93,7 @@ export default function DocumentEditor({
             <span className="text-sm text-gray-500">
               Saving...
             </span>
-          )} 
+          )}
           <button
             type="button"
             onClick={handleSave}

--- a/frontend/src/pages/Documents.tsx
+++ b/frontend/src/pages/Documents.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { aiSystemsApi, documentsApi } from '../services/api'
-import { FileText, Download, Trash2, Plus, Edit, Copy, Check } from 'lucide-react'
+import { FileText, Download, Trash2, Plus, Edit } from 'lucide-react'
 import DocumentEditor from '../components/DocumentEditor'
 import CopyButton from '../components/CopyButton'
 
@@ -30,24 +30,9 @@ export default function Documents() {
   const [filterStatus, setFilterStatus] = useState('all')
   const [editingDoc, setEditingDoc] = useState<Document | null>(null)
   const [documentToDelete, setDocumentToDelete] = useState<Document | null>(null)
-  const [copiedDocId, setCopiedDocId] = useState<number | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const limit = 10
-
-  const handleCopy = async (docId: number, content: string) => {
-    try {
-      await navigator.clipboard.writeText(content)
-
-      setCopiedDocId(docId)
-
-      setTimeout(() => {
-        setCopiedDocId(null)
-      }, 2000)
-    } catch (error) {
-      console.error('Failed to copy content:', error)
-    }
-  }
 
   const {
     data: documentsData,
@@ -327,18 +312,6 @@ export default function Documents() {
                     title="Edit"
                   >
                     <Edit className="w-5 h-5" />
-                  </button>
-
-                  <button
-                    onClick={() => handleCopy(doc.id, doc.content || '')}
-                    className="p-2 text-gray-400 hover:text-green-600 rounded-lg hover:bg-green-50"
-                    title={copiedDocId === doc.id ? 'Copied!' : 'Copy Markdown'}
-                  >
-                    {copiedDocId === doc.id ? (
-                      <Check className="w-5 h-5" />
-                    ) : (
-                      <Copy className="w-5 h-5" />
-                    )}
                   </button>
 
                   <button

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react'
 
 import { useRagStream } from '../hooks/useRagStream'
+import CopyButton from '../components/CopyButton'
 
 export default function RagChat() {
   const [question, setQuestion] = useState('')
@@ -185,6 +186,19 @@ export default function RagChat() {
                         <Bot className="w-5 h-5 text-primary-600" />
                       </div>
                       <div className="space-y-5 min-w-0 flex-1">
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+                            Answer
+                          </p>
+                          <CopyButton
+                            text={tokens}
+                            label="Copy answer"
+                            copiedLabel="Copied!"
+                            successMessage="Answer copied!"
+                            iconOnly
+                          />
+                        </div>
+
                         <p className="text-gray-700 leading-7 whitespace-pre-wrap">
                           {tokens}
                           {isStreaming && (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -210,9 +210,12 @@ export const classificationApi = {
 
 // Documents API
 export const documentsApi = {
-  list: async () => {
-    const { data } = await api.get('/documents/')
-    return data
+  list: async (params?: {
+    skip?: number
+    limit?: number
+  }) => {
+    const { data } = await api.get('/documents/', { params })
+    return Array.isArray(data?.items) ? data.items : data
   },
   get: async (id: number) => {
     const { data } = await api.get(`/documents/${id}`)


### PR DESCRIPTION
## Summary\n\nCloses #993\n\nAdds reusable copy-to-clipboard actions for the generated content surfaces that matter most:\n- RAG answer bubble\n- Document editor toolbar\n- Document list cards continue to use the shared copy button\n\nAlso aligns the documents API helper with the paginated backend response shape so the page keeps its existing skip/limit flow working cleanly.\n\n## Validation\n\n- \n- \n\n## Notes\n\nA full frontend typecheck in this checkout still reports unrelated pre-existing React import warnings outside the touched files, so I kept validation scoped to the changed surfaces.