### PR TITLE
[codex] add auth rate limiting

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -12,9 +12,11 @@ Dependencies:
   - pydantic      : request/response schema validation
 """
 
-from datetime import timedelta
+from collections import defaultdict, deque
+from datetime import datetime, timedelta, timezone
+from threading import Lock
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from sqlalchemy.orm import Session
@@ -39,26 +41,117 @@ from app.schemas.user import UserCreate, UserResponse, UserUpdateSchema, Token, 
 # email addresses by measuring response latency.
 _DUMMY_HASH = get_password_hash("dummy-timing-safe-placeholder")
 
+_AUTH_LOGIN_RATE_LIMIT_REQUESTS = 5
+_AUTH_LOGIN_RATE_LIMIT_WINDOW_SECONDS = 60
+_AUTH_REGISTER_RATE_LIMIT_REQUESTS = 3
+_AUTH_REGISTER_RATE_LIMIT_WINDOW_SECONDS = 3600
+
+_auth_login_failures_by_key: dict[str, deque[datetime]] = defaultdict(deque)
+_auth_registration_attempts_by_ip: dict[str, deque[datetime]] = defaultdict(deque)
+_auth_rate_limit_lock = Lock()
+
 router = APIRouter()
 users_router = APIRouter()
+
+
+def _get_request_ip(request: Request) -> str:
+    client = request.client
+    return client.host if client and client.host else "unknown"
+
+
+def _prune_attempts(
+    attempts: deque[datetime],
+    window_seconds: int,
+    now: datetime,
+) -> None:
+    cutoff = now - timedelta(seconds=window_seconds)
+    while attempts and attempts[0] <= cutoff:
+        attempts.popleft()
+
+
+def _retry_after_seconds(
+    attempts: deque[datetime],
+    window_seconds: int,
+    now: datetime,
+) -> int:
+    if not attempts:
+        return window_seconds
+
+    oldest = attempts[0]
+    return max(1, int((window_seconds - (now - oldest).total_seconds()) + 0.999))
+
+
+def _is_rate_limited(
+    store: dict[str, deque[datetime]],
+    key: str,
+    limit: int,
+    window_seconds: int,
+) -> tuple[bool, int]:
+    now = datetime.now(timezone.utc)
+    with _auth_rate_limit_lock:
+        attempts = store[key]
+        _prune_attempts(attempts, window_seconds, now)
+        if len(attempts) >= limit:
+            return True, _retry_after_seconds(attempts, window_seconds, now)
+        return False, 0
+
+
+def _record_attempt(
+    store: dict[str, deque[datetime]],
+    key: str,
+    window_seconds: int,
+) -> None:
+    now = datetime.now(timezone.utc)
+    with _auth_rate_limit_lock:
+        attempts = store[key]
+        _prune_attempts(attempts, window_seconds, now)
+        attempts.append(now)
+
+
+def clear_auth_rate_limits() -> None:
+    """Reset in-memory auth rate limit state for tests."""
+    with _auth_rate_limit_lock:
+        _auth_login_failures_by_key.clear()
+        _auth_registration_attempts_by_ip.clear()
 
 
 @router.post(
     "/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED
 )
-def register(user_data: UserCreate, db: Session = Depends(get_db)):
+def register(
+    user_data: UserCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+):
     """Register a new user account."""
-    existing_user = db.query(User).filter(User.email == user_data.email).first()
-    if existing_user:
+    client_ip = _get_request_ip(request)
+    limited, retry_after = _is_rate_limited(
+        _auth_registration_attempts_by_ip,
+        client_ip,
+        _AUTH_REGISTER_RATE_LIMIT_REQUESTS,
+        _AUTH_REGISTER_RATE_LIMIT_WINDOW_SECONDS,
+    )
+    if limited:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail={
                 "field": "general",
-                "message": "This email is already registered. Please use a different email or try logging in."
-            }
+                "message": "Too many registration attempts from this IP. Please try again later.",
+            },
+            headers={"Retry-After": str(retry_after)},
         )
 
     try:
+        existing_user = db.query(User).filter(User.email == user_data.email).first()
+        if existing_user:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "field": "general",
+                    "message": "This email is already registered. Please use a different email or try logging in."
+                }
+            )
+
         user = User(
             email=user_data.email,
             hashed_password=get_password_hash(user_data.password),
@@ -69,6 +162,8 @@ def register(user_data: UserCreate, db: Session = Depends(get_db)):
         db.commit()
         db.refresh(user)
         return user
+    except HTTPException:
+        raise
     except Exception:
         db.rollback()
         # Generic database error handler
@@ -79,13 +174,39 @@ def register(user_data: UserCreate, db: Session = Depends(get_db)):
                 "message": "An error occurred during registration. Please try again."
             }
         )
+    finally:
+        _record_attempt(
+            _auth_registration_attempts_by_ip,
+            client_ip,
+            _AUTH_REGISTER_RATE_LIMIT_WINDOW_SECONDS,
+        )
 
 
 @router.post("/login", response_model=Token)
 def login(
-    form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
+    request: Request,
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
 ):
     """Authenticate a user and return an access token."""
+    client_ip = _get_request_ip(request)
+    login_key = f"{form_data.username.lower()}:{client_ip}"
+    limited, retry_after = _is_rate_limited(
+        _auth_login_failures_by_key,
+        login_key,
+        _AUTH_LOGIN_RATE_LIMIT_REQUESTS,
+        _AUTH_LOGIN_RATE_LIMIT_WINDOW_SECONDS,
+    )
+    if limited:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "field": "general",
+                "message": "Too many login attempts. Please try again later.",
+            },
+            headers={"Retry-After": str(retry_after)},
+        )
+
     user = db.query(User).filter(User.email == form_data.username).first()
 
     # Always run a constant-time bcrypt comparison regardless of whether the
@@ -96,6 +217,11 @@ def login(
     password_ok = verify_password(form_data.password, hashed)
 
     if not user or not user.is_active or not password_ok:
+        _record_attempt(
+            _auth_login_failures_by_key,
+            login_key,
+            _AUTH_LOGIN_RATE_LIMIT_WINDOW_SECONDS,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail={

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -172,3 +172,13 @@ def clear_guard_rate_limits():
     guard_scan_rate_limiter._local_attempts_by_key.clear()
     if redis_client is not None:
         redis_client.flushdb()
+
+
+@pytest.fixture(autouse=True)
+def clear_auth_rate_limits():
+    """Keep in-memory auth rate limits isolated between tests."""
+    from app.api.v1.auth import clear_auth_rate_limits as reset_auth_rate_limits
+
+    reset_auth_rate_limits()
+    yield
+    reset_auth_rate_limits()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -224,3 +224,66 @@ def test_register_password_too_long(client):
         }
     )
     assert response.status_code == 422
+
+
+def test_login_rate_limit_triggers_after_five_failures(client):
+    """Test repeated login failures from the same email/IP return 429."""
+    email = "ratelimit-login@example.com"
+    client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": VALID_TEST_PASSWORD,
+        },
+    )
+
+    for _ in range(5):
+        response = client.post(
+            "/api/v1/auth/login",
+            data={
+                "username": email,
+                "password": "WrongPass123!",
+            },
+        )
+        assert response.status_code == 401
+
+    response = client.post(
+        "/api/v1/auth/login",
+        data={
+            "username": email,
+            "password": "WrongPass123!",
+        },
+    )
+    assert response.status_code == 429
+    detail = response.json()["detail"]
+    assert detail["field"] == "general"
+    assert "Too many login attempts" in detail["message"]
+    assert "Retry-After" in response.headers
+    assert int(response.headers["Retry-After"]) >= 1
+
+
+def test_register_rate_limit_triggers_after_three_attempts(client):
+    """Test repeated registrations from the same IP return 429 on the fourth attempt."""
+    for index in range(3):
+        response = client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": f"ratelimit-register-{index}@example.com",
+                "password": VALID_TEST_PASSWORD,
+            },
+        )
+        assert response.status_code == 201
+
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "ratelimit-register-3@example.com",
+            "password": VALID_TEST_PASSWORD,
+        },
+    )
+    assert response.status_code == 429
+    detail = response.json()["detail"]
+    assert detail["field"] == "general"
+    assert "Too many registration attempts" in detail["message"]
+    assert "Retry-After" in response.headers
+    assert int(response.headers["Retry-After"]) >= 1


### PR DESCRIPTION
## What changed

- Added in-memory auth rate limiting for login and registration.
- Login now limits repeated failures by email + IP.
- Registration now limits repeated attempts by IP and returns `Retry-After` on 429 responses.
- Added test isolation so auth rate-limit state does not leak across test cases.

## Why

- This closes the brute-force and signup-abuse gap in the auth flow.
- It matches the issue acceptance rules for GSSoC 2026 issue #929.

## Validation

- `git diff --check`
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest backend/tests/test_auth.py backend/tests/test_change_password.py -q`

Closes #929
