### PR TITLE
[codex] replace analytics placeholders with live data

### DIFF
--- a/frontend/src/components/BackendStatus.tsx
+++ b/frontend/src/components/BackendStatus.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useQuery } from "@tanstack/react-query";
 import { checkHealth } from "../services/api";
 
@@ -54,5 +53,4 @@ export default function BackendStatus() {
     </div>
   );
 }
-
 

--- a/frontend/src/components/ComplianceChecklist.tsx
+++ b/frontend/src/components/ComplianceChecklist.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { CheckSquare, Square } from 'lucide-react'
 
 export interface ChecklistItem {

--- a/frontend/src/components/ComplianceRiskChart.tsx
+++ b/frontend/src/components/ComplianceRiskChart.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   PieChart,
   Pie,

--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Check, Copy } from 'lucide-react'
 import { notify } from '../utils/toast'
 import { copyTextToClipboard } from '../utils/clipboard'

--- a/frontend/src/components/DocumentEditor.tsx
+++ b/frontend/src/components/DocumentEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Save, Eye, EyeOff } from 'lucide-react'
 import CodeMirror from '@uiw/react-codemirror'
 import { markdown } from '@codemirror/lang-markdown'

--- a/frontend/src/components/GuardExplanation.tsx
+++ b/frontend/src/components/GuardExplanation.tsx
@@ -10,7 +10,7 @@
  * shows the predicted label, confidence, and explanation latency.
  */
 
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import { Brain, Clock } from 'lucide-react'
 
 import type { GuardExplainResponse, GuardTokenAttribution } from '../services/api'

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Outlet, Link, useLocation } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
 import ThemeToggle from './ThemeToggle'

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Bell, Clock, X } from 'lucide-react'
 import { Link } from 'react-router-dom'

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { Sun, Moon } from 'lucide-react'
 
 export default function ThemeToggle() {

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,168 +1,275 @@
-import React, { useEffect, useState } from "react";
-
-import ComplianceRiskChart from "../components/ComplianceRiskChart";
-
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import {
-  BarChart2,
-  TrendingUp,
   AlertTriangle,
-  ShieldCheck,
   Activity,
-} from "lucide-react";
-
+  BarChart2,
+  RefreshCw,
+  ShieldCheck,
+  TrendingUp,
+} from 'lucide-react'
 import {
-  LineChart,
-  Line,
-  BarChart,
   Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
-} from "recharts";
+} from 'recharts'
 
-const lineChartData = [
-  { name: "Jan", score: 65 },
-  { name: "Feb", score: 72 },
-  { name: "Mar", score: 68 },
-  { name: "Apr", score: 85 },
-  { name: "May", score: 82 },
-  { name: "Jun", score: 90 },
-];
+import ComplianceRiskChart from '../components/ComplianceRiskChart'
+import {
+  aiSystemsApi,
+  analyticsApi,
+  type AiSystemListItem,
+  type AnalyticsSummaryResponse,
+  type AnalyticsTimelineResponse,
+} from '../services/api'
 
-const barChartData = [
-  { name: "System A", risk: 45 },
-  { name: "System B", risk: 80 },
-  { name: "System C", risk: 30 },
-  { name: "System D", risk: 65 },
-  { name: "System E", risk: 20 },
-];
-
-const summaryStats = [
-  {
-    label: "Total Systems",
-    value: "12",
-    icon: Activity,
-    color: "text-blue-600 dark:text-blue-400",
-    bg: "bg-blue-50 dark:bg-blue-500/10",
-  },
-  {
-    label: "Avg Score",
-    value: "84%",
-    icon: TrendingUp,
-    color: "text-green-600 dark:text-green-400",
-    bg: "bg-green-50 dark:bg-green-500/10",
-  },
-  {
-    label: "Compliant",
-    value: "10",
-    icon: ShieldCheck,
-    color: "text-emerald-600 dark:text-emerald-400",
-    bg: "bg-emerald-50 dark:bg-emerald-500/10",
-  },
-  {
-    label: "High Risk",
-    value: "2",
-    icon: AlertTriangle,
-    color: "text-red-600 dark:text-red-400",
-    bg: "bg-red-50 dark:bg-red-500/10",
-  },
-];
-
-type RiskData = {
-  name: string;
-  value: number;
-};
+type RiskDatum = {
+  name: string
+  value: number
+}
 
 const chartThemes = {
   light: {
-    grid: "rgb(229 231 235)",
-    axis: "rgb(75 85 99)",
-    tooltipBackground: "rgb(255 255 255)",
-    tooltipBorder: "rgb(229 231 235)",
-    tooltipText: "rgb(17 24 39)",
-    legendText: "rgb(55 65 81)",
-    line: "rgb(37 99 235)",
-    bar: "rgb(225 29 72)",
+    grid: 'rgb(229 231 235)',
+    axis: 'rgb(75 85 99)',
+    tooltipBackground: 'rgb(255 255 255)',
+    tooltipBorder: 'rgb(229 231 235)',
+    tooltipText: 'rgb(17 24 39)',
+    legendText: 'rgb(55 65 81)',
+    line: 'rgb(37 99 235)',
+    bar: 'rgb(225 29 72)',
   },
   dark: {
-    grid: "rgb(55 65 81)",
-    axis: "rgb(209 213 219)",
-    tooltipBackground: "rgb(31 41 55)",
-    tooltipBorder: "rgb(75 85 99)",
-    tooltipText: "rgb(243 244 246)",
-    legendText: "rgb(229 231 235)",
-    line: "rgb(96 165 250)",
-    bar: "rgb(251 113 133)",
+    grid: 'rgb(55 65 81)',
+    axis: 'rgb(209 213 219)',
+    tooltipBackground: 'rgb(31 41 55)',
+    tooltipBorder: 'rgb(75 85 99)',
+    tooltipText: 'rgb(243 244 246)',
+    legendText: 'rgb(229 231 235)',
+    line: 'rgb(96 165 250)',
+    bar: 'rgb(251 113 133)',
   },
-};
+}
 
-const getChartTheme = (isDark: boolean) =>
-  isDark ? chartThemes.dark : chartThemes.light;
+const summaryCards = [
+  {
+    label: 'Total Systems',
+    icon: Activity,
+    color: 'text-blue-600 dark:text-blue-400',
+    bg: 'bg-blue-50 dark:bg-blue-500/10',
+  },
+  {
+    label: 'Avg Score',
+    icon: TrendingUp,
+    color: 'text-green-600 dark:text-green-400',
+    bg: 'bg-green-50 dark:bg-green-500/10',
+  },
+  {
+    label: 'Compliant',
+    icon: ShieldCheck,
+    color: 'text-emerald-600 dark:text-emerald-400',
+    bg: 'bg-emerald-50 dark:bg-emerald-500/10',
+  },
+  {
+    label: 'High Risk',
+    icon: AlertTriangle,
+    color: 'text-red-600 dark:text-red-400',
+    bg: 'bg-red-50 dark:bg-red-500/10',
+  },
+]
+
+const riskScoreByLevel: Record<string, number> = {
+  minimal: 20,
+  limited: 45,
+  high: 75,
+  unacceptable: 95,
+}
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+})
+
+function getChartTheme(isDark: boolean) {
+  return isDark ? chartThemes.dark : chartThemes.light
+}
+
+function getRiskScore(system: AiSystemListItem): number {
+  if (typeof system.compliance_score === 'number') {
+    return Math.max(0, Math.min(100, Math.round(100 - system.compliance_score)))
+  }
+
+  if (system.risk_level && system.risk_level in riskScoreByLevel) {
+    return riskScoreByLevel[system.risk_level]
+  }
+
+  return 0
+}
+
+function formatTimelineLabel(value: string): string {
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return dateFormatter.format(date)
+}
 
 export default function Analytics() {
-  const [riskPieData, setRiskPieData] = useState<RiskData[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [isDark, setIsDark] = useState(false);
+  const [isDark, setIsDark] = useState(false)
+  const [selectedSystemId, setSelectedSystemId] = useState<number | null>(null)
+
+  const summaryQuery = useQuery<AnalyticsSummaryResponse>({
+    queryKey: ['analytics-summary'],
+    queryFn: () => analyticsApi.summary(),
+  })
+
+  const systemsQuery = useQuery({
+    queryKey: ['analytics-systems'],
+    queryFn: () =>
+      aiSystemsApi.list({
+        sort_by: 'compliance_score',
+        order: 'desc',
+        limit: 100,
+      }),
+  })
+
+  const systems = (systemsQuery.data ?? []) as AiSystemListItem[]
 
   useEffect(() => {
-    fetchRiskDistribution();
-  }, []);
+    if (systems.length === 0) {
+      setSelectedSystemId(null)
+      return
+    }
+
+    const hasSelection = selectedSystemId
+      ? systems.some((system) => system.id === selectedSystemId)
+      : false
+
+    if (!hasSelection) {
+      setSelectedSystemId(systems[0].id)
+    }
+  }, [systems, selectedSystemId])
+
+  const timelineQuery = useQuery<AnalyticsTimelineResponse>({
+    queryKey: ['analytics-timeline', selectedSystemId],
+    queryFn: () => analyticsApi.timeline(selectedSystemId as number),
+    enabled: selectedSystemId !== null,
+  })
 
   useEffect(() => {
     const checkTheme = () => {
-      setIsDark(document.documentElement.classList.contains("dark"));
-    };
+      setIsDark(document.documentElement.classList.contains('dark'))
+    }
 
-    checkTheme();
+    checkTheme()
 
-    const observer = new MutationObserver(checkTheme);
+    const observer = new MutationObserver(checkTheme)
     observer.observe(document.documentElement, {
       attributes: true,
-      attributeFilter: ["class"],
-    });
+      attributeFilter: ['class'],
+    })
 
-    return () => observer.disconnect();
-  }, []);
+    return () => observer.disconnect()
+  }, [])
 
-  const chartTheme = getChartTheme(isDark);
-  const chartRemountKey = isDark ? "dark" : "light";
+  const chartTheme = getChartTheme(isDark)
+  const chartRemountKey = isDark ? 'dark' : 'light'
+  const summary = summaryQuery.data
+  const selectedSystem = useMemo(
+    () => systems.find((system) => system.id === selectedSystemId) ?? null,
+    [systems, selectedSystemId]
+  )
 
-  const fetchRiskDistribution = async () => {
-    try {
-      const res = await fetch("/api/v1/analytics/summary");
+  const riskPieData = useMemo<RiskDatum[]>(() => {
+    const counts = summary?.counts
 
-      if (res.ok) {
-        const json = await res.json();
-        const mapped: RiskData[] = [
-          { name: "Minimal Risk", value: json.counts?.minimal || 0 },
-          { name: "Limited Risk", value: json.counts?.limited || 0 },
-          { name: "High Risk", value: json.counts?.high || 0 },
-          { name: "Unacceptable Risk", value: json.counts?.unacceptable || 0 },
-        ];
-
-        setRiskPieData(mapped);
-      } else {
-        setRiskPieData([
-          { name: "Minimal Risk", value: 4 },
-          { name: "Limited Risk", value: 3 },
-          { name: "High Risk", value: 2 },
-          { name: "Unacceptable Risk", value: 1 },
-        ]);
-      }
-    } catch {
-      setRiskPieData([
-        { name: "Minimal Risk", value: 4 },
-        { name: "Limited Risk", value: 3 },
-        { name: "High Risk", value: 2 },
-        { name: "Unacceptable Risk", value: 1 },
-      ]);
-    } finally {
-      setLoading(false);
+    if (!counts) {
+      return []
     }
-  };
+
+    return [
+      { name: 'Minimal Risk', value: counts.minimal ?? 0 },
+      { name: 'Limited Risk', value: counts.limited ?? 0 },
+      { name: 'High Risk', value: counts.high ?? 0 },
+      { name: 'Unacceptable Risk', value: counts.unacceptable ?? 0 },
+    ]
+  }, [summary])
+
+  const timelineData = useMemo(
+    () =>
+      (timelineQuery.data?.snapshots ?? []).map((snapshot) => ({
+        name: formatTimelineLabel(snapshot.snapshotted_at),
+        score: snapshot.compliance_score ?? 0,
+      })),
+    [timelineQuery.data]
+  )
+
+  const systemRiskData = useMemo(
+    () =>
+      [...systems]
+        .map((system) => ({
+          name: system.name,
+          risk: getRiskScore(system),
+        }))
+        .sort((a, b) => b.risk - a.risk)
+        .slice(0, 5),
+    [systems]
+  )
+
+  const summaryCardsWithValues = useMemo(
+    () => [
+      {
+        ...summaryCards[0],
+        value: summary?.total_systems ?? 0,
+      },
+      {
+        ...summaryCards[1],
+        value: summary ? `${summary.average_compliance_score.toFixed(1)}%` : '0.0%',
+      },
+      {
+        ...summaryCards[2],
+        value: summary?.compliance_statuses?.compliant ?? 0,
+      },
+      {
+        ...summaryCards[3],
+        value: summary?.counts?.high ?? 0,
+      },
+    ],
+    [summary]
+  )
+
+  const renderSectionError = (
+    title: string,
+    message: string,
+    onRetry: () => void
+  ) => (
+    <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-red-900 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-100">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+        <div className="min-w-0">
+          <h3 className="font-semibold">{title}</h3>
+          <p className="mt-1 text-sm text-red-800 dark:text-red-200">{message}</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-4 inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </button>
+        </div>
+      </div>
+    </div>
+  )
 
   return (
     <div className="space-y-8">
@@ -173,135 +280,239 @@ export default function Analytics() {
         </p>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
-        {summaryStats.map((stat) => (
-          <div
-            key={stat.label}
-            className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 flex items-center gap-4 shadow-sm"
-          >
-            <div className={`shrink-0 p-3 rounded-lg ${stat.bg}`}>
-              <stat.icon className={`w-6 h-6 ${stat.color}`} />
+      {summaryQuery.isLoading ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {[...Array(4)].map((_, index) => (
+            <div
+              key={index}
+              className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+            >
+              <div className="flex items-center gap-4">
+                <div className="h-12 w-12 rounded-lg bg-gray-200 dark:bg-gray-700" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-2/3 rounded bg-gray-200 dark:bg-gray-700" />
+                  <div className="h-8 w-1/3 rounded bg-gray-200 dark:bg-gray-700" />
+                </div>
+              </div>
             </div>
-            <div>
-              <p className="text-sm text-gray-500 dark:text-gray-400 font-medium">{stat.label}</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{stat.value}</p>
+          ))}
+        </div>
+      ) : summaryQuery.isError ? (
+        renderSectionError(
+          'Unable to load analytics summary',
+          summaryQuery.error instanceof Error
+            ? summaryQuery.error.message
+            : 'We could not fetch your aggregate compliance metrics.',
+          () => summaryQuery.refetch()
+        )
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {summaryCardsWithValues.map((stat) => (
+            <div
+              key={stat.label}
+              className="flex items-center gap-4 rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+            >
+              <div className={`shrink-0 rounded-lg p-3 ${stat.bg}`}>
+                <stat.icon className={`h-6 w-6 ${stat.color}`} />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  {stat.label}
+                </p>
+                <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
+                  {stat.value}
+                </p>
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm min-w-0">
-          <div className="flex items-center gap-2 mb-6">
-            <TrendingUp className="w-5 h-5 text-primary-600" />
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <div className="min-w-0 rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <TrendingUp className="h-5 w-5 text-primary-600" />
+              <h2 className="font-semibold text-gray-900 dark:text-white">
+                Compliance Score Timeline
+              </h2>
+            </div>
+
+            <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+              <span className="whitespace-nowrap">System</span>
+              <select
+                value={selectedSystemId ?? ''}
+                onChange={(event) => setSelectedSystemId(Number(event.target.value))}
+                disabled={systems.length === 0}
+                className="min-w-0 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-500/20 disabled:cursor-not-allowed disabled:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:disabled:bg-gray-800"
+              >
+                {systems.map((system) => (
+                  <option key={system.id} value={system.id}>
+                    {system.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          {!selectedSystemId ? (
+            <div className="flex h-72 items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 text-center text-sm text-gray-500 dark:border-gray-600 dark:bg-gray-900/40 dark:text-gray-400">
+              Add an AI system to start tracking compliance snapshots.
+            </div>
+          ) : timelineQuery.isLoading ? (
+            <div className="flex h-72 items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 text-center text-sm text-gray-500 dark:border-gray-600 dark:bg-gray-900/40 dark:text-gray-400">
+              Loading timeline for {selectedSystem?.name ?? 'selected system'}...
+            </div>
+          ) : timelineQuery.isError ? (
+            renderSectionError(
+              'Unable to load compliance timeline',
+              timelineQuery.error instanceof Error
+                ? timelineQuery.error.message
+                : 'We could not fetch the selected system timeline.',
+              () => timelineQuery.refetch()
+            )
+          ) : timelineData.length === 0 ? (
+            <div className="flex h-72 items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 text-center text-sm text-gray-500 dark:border-gray-600 dark:bg-gray-900/40 dark:text-gray-400">
+              No compliance snapshots are available yet for{' '}
+              {selectedSystem?.name ?? 'this system'}.
+            </div>
+          ) : (
+            <div className="h-72 w-full">
+              <ResponsiveContainer
+                key={`${chartRemountKey}-timeline`}
+                width="100%"
+                height="100%"
+              >
+                <LineChart data={timelineData}>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    vertical={false}
+                    stroke={chartTheme.grid}
+                  />
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fill: chartTheme.axis, fontSize: 12 }}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <YAxis
+                    domain={[0, 100]}
+                    tick={{ fill: chartTheme.axis, fontSize: 12 }}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: chartTheme.tooltipBackground,
+                      borderColor: chartTheme.tooltipBorder,
+                      color: chartTheme.tooltipText,
+                    }}
+                    itemStyle={{ color: chartTheme.tooltipText }}
+                    labelStyle={{ color: chartTheme.tooltipText }}
+                  />
+                  <Legend wrapperStyle={{ color: chartTheme.legendText }} />
+                  <Line
+                    type="monotone"
+                    dataKey="score"
+                    name="Compliance Score"
+                    stroke={chartTheme.line}
+                    strokeWidth={3}
+                    activeDot={{ r: 6 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </div>
+
+        <div className="min-w-0 rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div className="mb-4 flex items-center gap-2">
+            <BarChart2 className="h-5 w-5 text-primary-600" />
             <h2 className="font-semibold text-gray-900 dark:text-white">
-              Compliance Score Timeline
+              Risk Score by System
             </h2>
           </div>
 
-          <div className="h-72 w-full">
-            <ResponsiveContainer
-              key={`${chartRemountKey}-timeline`}
-              width="100%"
-              height="100%"
-            >
-              <LineChart data={lineChartData}>
-                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={chartTheme.grid} />
-                <XAxis
-                  dataKey="name"
-                  tick={{ fill: chartTheme.axis, fontSize: 12 }}
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <YAxis
-                  tick={{ fill: chartTheme.axis, fontSize: 12 }}
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: chartTheme.tooltipBackground,
-                    borderColor: chartTheme.tooltipBorder,
-                    color: chartTheme.tooltipText,
-                  }}
-                  itemStyle={{ color: chartTheme.tooltipText }}
-                  labelStyle={{ color: chartTheme.tooltipText }}
-                />
-                <Legend wrapperStyle={{ color: chartTheme.legendText }} />
-                <Line
-                  type="monotone"
-                  dataKey="score"
-                  name="Avg Score"
-                  stroke={chartTheme.line}
-                  strokeWidth={3}
-                  activeDot={{ r: 6 }}
-                />
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
-        </div>
-
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm min-w-0">
-          <div className="flex items-center gap-2 mb-6">
-            <BarChart2 className="w-5 h-5 text-primary-600" />
-            <h2 className="font-semibold text-gray-900 dark:text-white">
-              Risk Distribution by System
-            </h2>
-          </div>
-
-          <div className="h-72 w-full">
-            <ResponsiveContainer
-              key={`${chartRemountKey}-systems`}
-              width="100%"
-              height="100%"
-            >
-              <BarChart data={barChartData}>
-                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={chartTheme.grid} />
-                <XAxis
-                  dataKey="name"
-                  tick={{ fill: chartTheme.axis, fontSize: 12 }}
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <YAxis
-                  tick={{ fill: chartTheme.axis, fontSize: 12 }}
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: chartTheme.tooltipBackground,
-                    borderColor: chartTheme.tooltipBorder,
-                    color: chartTheme.tooltipText,
-                  }}
-                  itemStyle={{ color: chartTheme.tooltipText }}
-                  labelStyle={{ color: chartTheme.tooltipText }}
-                />
-                <Legend wrapperStyle={{ color: chartTheme.legendText }} />
-                <Bar
-                  dataKey="risk"
-                  name="Risk Score"
-                  fill={chartTheme.bar}
-                  radius={[4, 4, 0, 0]}
-                  maxBarSize={40}
-                />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
+          {systemsQuery.isLoading ? (
+            <div className="flex h-72 items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 text-center text-sm text-gray-500 dark:border-gray-600 dark:bg-gray-900/40 dark:text-gray-400">
+              Loading AI systems...
+            </div>
+          ) : systemsQuery.isError ? (
+            renderSectionError(
+              'Unable to load AI systems',
+              systemsQuery.error instanceof Error
+                ? systemsQuery.error.message
+                : 'We could not fetch the system list for the risk chart.',
+              () => systemsQuery.refetch()
+            )
+          ) : systemRiskData.length === 0 ? (
+            <div className="flex h-72 items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 text-center text-sm text-gray-500 dark:border-gray-600 dark:bg-gray-900/40 dark:text-gray-400">
+              No AI systems are available to chart yet.
+            </div>
+          ) : (
+            <div className="h-72 w-full">
+              <ResponsiveContainer
+                key={`${chartRemountKey}-systems`}
+                width="100%"
+                height="100%"
+              >
+                <BarChart data={systemRiskData}>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    vertical={false}
+                    stroke={chartTheme.grid}
+                  />
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fill: chartTheme.axis, fontSize: 12 }}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <YAxis
+                    domain={[0, 100]}
+                    tick={{ fill: chartTheme.axis, fontSize: 12 }}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: chartTheme.tooltipBackground,
+                      borderColor: chartTheme.tooltipBorder,
+                      color: chartTheme.tooltipText,
+                    }}
+                    itemStyle={{ color: chartTheme.tooltipText }}
+                    labelStyle={{ color: chartTheme.tooltipText }}
+                  />
+                  <Legend wrapperStyle={{ color: chartTheme.legendText }} />
+                  <Bar
+                    dataKey="risk"
+                    name="Risk Score"
+                    fill={chartTheme.bar}
+                    radius={[4, 4, 0, 0]}
+                    maxBarSize={40}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
         </div>
       </div>
 
-      {loading ? (
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm h-80 flex items-center justify-center text-gray-500 dark:text-gray-400">
+      {summaryQuery.isLoading ? (
+        <div className="flex h-80 items-center justify-center rounded-xl border border-gray-200 bg-white p-6 text-gray-500 shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
           Loading risk distribution...
         </div>
-      ) : riskPieData.length === 0 ? (
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm h-80 flex items-center justify-center text-gray-500 dark:text-gray-400">
-          No analytics data available.
-        </div>
+      ) : summaryQuery.isError ? (
+        renderSectionError(
+          'Unable to load risk distribution',
+          summaryQuery.error instanceof Error
+            ? summaryQuery.error.message
+            : 'We could not fetch the aggregate risk breakdown.',
+          () => summaryQuery.refetch()
+        )
       ) : (
         <ComplianceRiskChart data={riskPieData} />
       )}
     </div>
-  );
+  )
 }

--- a/frontend/src/pages/Classification.tsx
+++ b/frontend/src/pages/Classification.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useMutation } from '@tanstack/react-query'
 import { classificationApi } from '../services/api'

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import { aiSystemsApi, documentsApi } from '../services/api'

--- a/frontend/src/pages/Documents.tsx
+++ b/frontend/src/pages/Documents.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { aiSystemsApi, documentsApi } from '../services/api'
 import { FileText, Download, Trash2, Plus, Edit, Copy, Check } from 'lucide-react'

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Link } from 'react-router-dom'
 import { Shield, AlertTriangle } from 'lucide-react'
 

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Bell, Check, Trash2 } from 'lucide-react'
 
 /**

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   Shield,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -106,6 +106,49 @@ function ensureStringArrayField(
   }
 }
 
+function unwrapPaginatedItems<T>(data: unknown): T[] | unknown {
+  if (isRecord(data) && Array.isArray((data as { items?: unknown }).items)) {
+    return (data as { items: T[] }).items
+  }
+
+  return data
+}
+
+export interface AiSystemListItem {
+  id: number
+  name: string
+  description: string | null
+  version: string | null
+  use_case: string | null
+  sector: string | null
+  risk_level: string | null
+  compliance_status: string
+  compliance_score: number | null
+  created_at: string
+  updated_at: string
+}
+
+export interface AnalyticsSummaryResponse {
+  total_systems: number
+  average_compliance_score: number
+  counts: Record<string, number>
+  compliance_statuses: Record<string, number>
+}
+
+export interface AnalyticsTimelineSnapshot {
+  ai_system_id: number
+  compliance_score: number | null
+  compliance_status: string
+  risk_level: string | null
+  snapshotted_at: string
+}
+
+export interface AnalyticsTimelineResponse {
+  ai_system_id: number
+  ai_system_name: string
+  snapshots: AnalyticsTimelineSnapshot[]
+}
+
 // Auth API
 export const authApi = {
   login: async (email: string, password: string) => {
@@ -147,14 +190,24 @@ export const aiSystemsApi = {
   list: async (params?: {
     sort_by?: string
     order?: string
+    skip?: number
     page?: number
     limit?: number
     search?: string
     risk_level?: string
     compliance_status?: string
   }) => {
-    const { data } = await api.get('/ai-systems/', { params })
-    return data
+    const queryParams = params
+      ? {
+          ...params,
+          ...(typeof params.page === 'number'
+            ? { skip: Math.max(0, (params.page - 1) * (params.limit ?? 50)) }
+            : {}),
+        }
+      : undefined
+
+    const { data } = await api.get('/ai-systems/', { params: queryParams })
+    return unwrapPaginatedItems<AiSystemListItem>(data) as AiSystemListItem[]
   },
   get: async (id: number) => {
     const { data } = await api.get(`/ai-systems/${id}`)
@@ -210,9 +263,9 @@ export const classificationApi = {
 
 // Documents API
 export const documentsApi = {
-  list: async () => {
-    const { data } = await api.get('/documents/')
-    return data
+  list: async (params?: { skip?: number; limit?: number }) => {
+    const { data } = await api.get('/documents/', { params })
+    return unwrapPaginatedItems(data)
   },
   get: async (id: number) => {
     const { data } = await api.get(`/documents/${id}`)
@@ -471,8 +524,17 @@ export const guardApi = {
 }
 
 export const analyticsApi = {
-  summary: async () => {
+  summary: async (): Promise<AnalyticsSummaryResponse> => {
     const { data } = await api.get('/analytics/summary')
+    return data
+  },
+  timeline: async (
+    systemId: number,
+    days = 30,
+  ): Promise<AnalyticsTimelineResponse> => {
+    const { data } = await api.get('/analytics/compliance-timeline', {
+      params: { system_id: systemId, days },
+    })
     return data
   },
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,7 +15,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## What changed

- Replaced the hardcoded analytics summary cards with live data from `/api/v1/analytics/summary`.
- Wired the compliance timeline chart to `/api/v1/analytics/compliance-timeline` for the currently selected AI system.
- Replaced the fake per-system bar chart data with real system risk scores derived from the backend AI-system list.
- Normalized the shared AI system/document list helpers so pages consume the paginated API responses as arrays.
- Added proper loading and error states for the summary, timeline, and system risk sections.

## Validation

- `git diff --check`
- `npm run build` in `frontend/`

Closes #921
