### PR TITLE
fix(frontend): replace useState with useRef for auto-save timeout in DocumentEditor

### DIFF
--- a/frontend/src/components/DocumentEditor.tsx
+++ b/frontend/src/components/DocumentEditor.tsx
@@ -22,8 +22,8 @@ export default function DocumentEditor({
   const [content, setContent] = useState(initialContent)
   const [showPreview, setShowPreview] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const [saveTimeout, setSaveTimeout] = useState<ReturnType<typeof setTimeout> | null>(null)
-  const [saveError, setSaveError] = useState('')
   const previewHtml = useMemo(
     () => DOMPurify.sanitize(marked.parse(content, { async: false }) as string),
     [content]
@@ -31,18 +31,16 @@ export default function DocumentEditor({
 
   const handleSave = useCallback(async () => {
     setIsSaving(true)
+    setSaveError(null)
     try {
       await api.put(`/documents/${documentId}`, { content })
       onSave?.(content)
-      setSaveError('')
     } catch (error) {
-  console.error('Save failed:', error)
-  setSaveError(
-    error instanceof Error
-      ? error.message
-      : 'Failed to save changes'
-  )
-}
+      console.error('Save failed:', error)
+      setSaveError(
+        error instanceof Error ? error.message : 'Failed to save changes'
+      )
+    }
     setIsSaving(false)
   }, [content, documentId, onSave])
 
@@ -78,16 +76,8 @@ export default function DocumentEditor({
           {showPreview ? 'Edit' : 'Preview'}
         </button>
         <div className="flex items-center gap-3">
-         {saveError && (
-            <span className="text-sm text-red-500">
-              {saveError}
-            </span>
-          )}
-          {isSaving && (
-            <span className="text-sm text-gray-500">
-              Saving...
-            </span>
-          )} 
+          {saveError && <span className="text-sm text-red-600">{saveError}</span>}
+          {isSaving && <span className="text-sm text-gray-500">Saving...</span>}
           <button
             type="button"
             onClick={handleSave}

--- a/frontend/src/components/DocumentEditor.tsx
+++ b/frontend/src/components/DocumentEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Save, Eye, EyeOff } from 'lucide-react'
 import CodeMirror from '@uiw/react-codemirror'
 import { markdown } from '@codemirror/lang-markdown'
@@ -23,7 +23,7 @@ export default function DocumentEditor({
   const [showPreview, setShowPreview] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
-  const [saveTimeout, setSaveTimeout] = useState<ReturnType<typeof setTimeout> | null>(null)
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const previewHtml = useMemo(
     () => DOMPurify.sanitize(marked.parse(content, { async: false }) as string),
     [content]
@@ -48,20 +48,16 @@ export default function DocumentEditor({
   useEffect(() => {
     if (content === initialContent) return
 
-    if (saveTimeout) clearTimeout(saveTimeout)
+    if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
 
-    const timeout = setTimeout(async () => {
-      setIsSaving(true)
+    saveTimeoutRef.current = setTimeout(async () => {
       await handleSave()
-      setIsSaving(false)
     }, 2000)
 
-    setSaveTimeout(timeout)
-
     return () => {
-      if (timeout) clearTimeout(timeout)
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
     }
-  }, [content, handleSave, initialContent, saveTimeout])
+  }, [content, handleSave, initialContent])
 
   return (
     <div className="flex flex-col h-full border border-gray-200 rounded-xl overflow-hidden">


### PR DESCRIPTION
## Summary

Fixes #325

- `saveTimeout` was `useState` → every `setSaveTimeout` call triggered `useEffect` re-run → infinite debounce loop (new timeout created before old one fires)
- Replaced with `useRef` — stores timer ID without causing re-renders
- Removed redundant `setIsSaving(true/false)` in timeout callback (`handleSave` already manages this)

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/DocumentEditor.tsx` | `useState` → `useRef` for timeout; remove redundant state calls; `saveTimeout` removed from effect deps |

## Before / After

**Before** — effect deps included `saveTimeout`:
```ts
const [saveTimeout, setSaveTimeout] = useState<...>(null)
// ...
setSaveTimeout(timeout)          // ← triggers effect re-run → infinite loop
// ...
}, [content, handleSave, initialContent, saveTimeout])
```

**After** — ref never triggers re-render:
```ts
const saveTimeoutRef = useRef<...>(null)
// ...
saveTimeoutRef.current = setTimeout(...)   // ← no re-render
// ...
}, [content, handleSave, initialContent])
```

## Test Plan
- [ ] Edit document → auto-save fires once after 2s (not repeatedly)
- [ ] Disconnect backend → save error banner appears in toolbar
- [ ] Manual Save button → shows "Saving…" then error on failure
- [ ] No console errors on mount or typing

## AI Disclosure
Fix implemented with Claude Code (claude-sonnet-4-6).