### PR TITLE
docs: add module-level docstring to documents.py

### DIFF
--- a/backend/app/api/v1/documents.py
+++ b/backend/app/api/v1/documents.py
@@ -1,3 +1,21 @@
+"""
+Document Generation API — compliance document creation, management, and export.
+
+This module provides endpoints for:
+  - POST /documents/generate  : Generate AI compliance documents using LLM
+  - GET  /documents/           : List all documents for the authenticated user
+  - GET  /documents/{id}       : Retrieve a specific document
+  - PATCH /documents/{id}      : Update document content or metadata
+  - DELETE /documents/{id}     : Delete a document
+  - GET  /documents/{id}/pdf   : Export document as PDF
+  - POST /documents/{id}/share : Generate a shareable link for a document
+
+Dependencies:
+  - reportlab  : PDF generation
+  - SQLAlchemy : ORM session for Document persistence
+  - pydantic   : request/response schema validation
+  - python-jose: JWT token for document sharing
+"""
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query


### PR DESCRIPTION

## Summary
Closes #287

Added a module-level docstring to `backend/app/api/v1/documents.py` which previously had no description at the top.

## Type of Change
- [x] Documentation update

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed
