### PR TITLE
fix: remove dead rag query response path

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -204,7 +204,6 @@ def query_knowledge_base(
             pass
 
         return RAGQueryResponse(answer=answer, sources=sources, answer_id=feedback.id)
-        return RAGQueryResponse(answer=result["result"], sources=sources, answer_id=answer_id)
     except FileNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,


### PR DESCRIPTION
## What changed

- Removed a dead return path from the AegisAI RAG query flow.

- This keeps the response path simpler and avoids dropping query results unexpectedly.


## Validation

- Not rerun in this session.
