### PR TITLE
Add copy to clipboard button for RAG responses

### DIFF
--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -41,11 +41,22 @@ export default function RagChat() {
       setSubmittedQuestion('')
       return
     }
+   
     setValidationError(null)
     setSubmittedQuestion(trimmed)
     setQuestion('')
     ask(trimmed)
   }
+   const handleCopy = async () => {
+  if (!hasAnswer) return
+
+  try {
+    await navigator.clipboard.writeText(tokens)
+    alert('Copied to clipboard!')
+  } catch (error) {
+    alert('Copy failed')
+  }
+}
 
   const handleExport = () => {
     if (!hasAnswer) return
@@ -208,16 +219,26 @@ export default function RagChat() {
                               <h3 className="text-sm font-semibold text-gray-900">
                                 Sources
                               </h3>
-                              {!isStreaming && (
-                                <button
-                                  type="button"
-                                  onClick={handleExport}
-                                  className="inline-flex items-center gap-1.5 text-xs text-primary-600 hover:text-primary-700"
-                                >
-                                  <FileText className="w-3.5 h-3.5" />
-                                  Export
-                                </button>
-                              )}
+                            {!isStreaming && (
+  <>
+    <button
+      type="button"
+      onClick={handleExport}
+      className="inline-flex items-center gap-1.5 text-xs text-primary-600 hover:text-primary-700"
+    >
+      <FileText className="w-3.5 h-3.5" />
+      Export
+    </button>
+
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="inline-flex items-center gap-1.5 text-xs"
+    >
+      Copy
+    </button>
+  </>
+)}
                             </div>
                             <div className="space-y-3">
                               {citations.map((citation, index) => (

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { toast } from 'react-hot-toast'
 import {
   AlertCircle,
   Bot,
@@ -47,16 +48,16 @@ export default function RagChat() {
     setQuestion('')
     ask(trimmed)
   }
-   const handleCopy = async () => {
-  if (!hasAnswer) return
+  const handleCopy = async () => {
+    if (!hasAnswer) return
 
-  try {
-    await navigator.clipboard.writeText(tokens)
-    alert('Copied to clipboard!')
-  } catch (error) {
-    alert('Copy failed')
+    try {
+      await navigator.clipboard.writeText(tokens)
+      toast.success('Copied to clipboard!')
+    } catch (error) {
+      toast.error('Copy failed')
+    }
   }
-}
 
   const handleExport = () => {
     if (!hasAnswer) return
@@ -219,26 +220,26 @@ export default function RagChat() {
                               <h3 className="text-sm font-semibold text-gray-900">
                                 Sources
                               </h3>
-                            {!isStreaming && (
-  <>
-    <button
-      type="button"
-      onClick={handleExport}
-      className="inline-flex items-center gap-1.5 text-xs text-primary-600 hover:text-primary-700"
-    >
-      <FileText className="w-3.5 h-3.5" />
-      Export
-    </button>
+                              {!isStreaming && (
+                                <>
+                                  <button
+                                    type="button"
+                                    onClick={handleExport}
+                                    className="inline-flex items-center gap-1.5 text-xs text-primary-600 hover:text-primary-700"
+                                  >
+                                    <FileText className="w-3.5 h-3.5" />
+                                    Export
+                                  </button>
 
-    <button
-      type="button"
-      onClick={handleCopy}
-      className="inline-flex items-center gap-1.5 text-xs"
-    >
-      Copy
-    </button>
-  </>
-)}
+                                  <button
+                                    type="button"
+                                    onClick={handleCopy}
+                                    className="inline-flex items-center gap-1.5 text-xs"
+                                  >
+                                    Copy
+                                  </button>
+                                </>
+                              )}
                             </div>
                             <div className="space-y-3">
                               {citations.map((citation, index) => (


### PR DESCRIPTION
## Summary

Added a Copy-to-Clipboard button for RAG responses.

### Changes Made

* Added `handleCopy` function using `navigator.clipboard.writeText()`
* Added a Copy button alongside the Export button
* Added basic success and failure alerts for copy action

### Testing

* Frontend application runs successfully with Vite
* Copy button is rendered in the RAG response section

Fixes #993
