### PR TITLE
fix(documents): add missing generate_compliance_narrative import

### DIFF
--- a/backend/app/api/v1/documents.py
+++ b/backend/app/api/v1/documents.py
@@ -48,6 +48,7 @@ from app.schemas.document import (
     DocumentUpdateRequest,
 )
 from app.schemas.pagination import PaginatedResponse
+from app.modules.llm.document_generator import generate_compliance_narrative
 
 # PDF generation
 from reportlab.lib.pagesizes import letter, A4


### PR DESCRIPTION
## Summary

Fixes a missing import in `backend/app/api/v1/documents.py`.

The `generate_document()` endpoint calls
`generate_compliance_narrative(...)`, but the function was never imported,
causing a `NameError` and forcing the code to fall back to template generation.

## Changes Made

Added:

```python
from app.modules.llm.document_generator import generate_compliance_narrative
```

## Root Cause

The function was defined in:

`app/modules/llm/document_generator.py`

but was not imported into:

`app/api/v1/documents.py`

As a result, LLM-powered document generation could not execute successfully.

## Verification

- Verified function definition exists
- Added missing import
- Verified syntax using:

```bash
python -m py_compile backend/app/api/v1/documents.py
python -m py_compile backend/app/modules/llm/document_generator.py
```

## Issue

Closes #931