### PR TITLE
feat: add AISystemSummarySchema for list views

### DIFF
--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -20,6 +20,7 @@ from app.schemas.ai_system import (
     AISystemCreate,
     AISystemUpdate,
     AISystemResponse,
+    AISystemSummarySchema,
     BulkImportResponse,
     ComplianceStatusUpdateSchema,
 )
@@ -173,7 +174,7 @@ _SORTABLE_FIELDS = {
 }
 
 
-@router.get("/", response_model=PaginatedResponse[AISystemResponse])
+@router.get("/", response_model=PaginatedResponse[AISystemSummarySchema])
 def list_ai_systems(
     sort_by: Optional[str] = Query("created_at", description="Sort field: name, risk_level, compliance_score, created_at"),
     order: Optional[str] = Query("desc", description="Sort direction: asc, desc"),

--- a/backend/app/schemas/ai_system.py
+++ b/backend/app/schemas/ai_system.py
@@ -37,6 +37,20 @@ class AISystemResponse(BaseModel):
     class Config:
         from_attributes = True
 
+class AISystemSummarySchema(BaseModel):
+    """Lighter schema for list views."""
+
+    id: int
+    name: str
+    use_case: Optional[str]
+    sector: Optional[str]
+    risk_level: Optional[RiskLevel]
+    compliance_status: ComplianceStatus
+    compliance_score: Optional[float] = None
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
 
 # Risk Classification
 class RiskClassificationRequest(BaseModel):


### PR DESCRIPTION
## Summary

Closes #34 

Introduces a dedicated `AISystemSummarySchema` for list views and updates the AI systems list endpoint to use it. This keeps collection responses lightweight by returning only the fields needed for summary displays while maintaining the full `AISystemResponse` schema for detailed views.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [ ] I have added/updated tests where relevant
* [ ] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [ ] I have updated documentation if needed

## Screenshots (if UI change)

N/A – backend-only change.
