### PR TITLE
feat(rag): add query response cache for repeated questions

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -191,11 +191,12 @@ async def guard_rag_question(
         guard = get_rag_guard()
         result = await loop.run_in_executor(None, guard.guard, payload.question)
     except Exception as exc:
+        logger.warning("RAG guard unavailable; allowing query. Error: %s", exc)
         return GuardedRAGQuestion(
             question=payload.question,
             original_question=payload.question,
-            guard_triggered=True,
-            guard_decision="ERROR",
+            guard_triggered=False,
+            guard_decision="ALLOW",
             reasoning=str(exc),
         )
 
@@ -259,7 +260,10 @@ def _valid_text_chunks(file_paths: list[str]):
     ]
 
 
-def _rebuild_index_from_documents(documents: list[RAGDocument]) -> int:
+def _rebuild_index_from_documents(
+        documents: list[RAGDocument],
+        user_id: int | None = None,
+    ) -> int:
     file_paths = [doc.storage_path for doc in documents if os.path.exists(doc.storage_path)]
     if not file_paths:
         shutil.rmtree(settings.FAISS_INDEX_PATH, ignore_errors=True)
@@ -270,7 +274,7 @@ def _rebuild_index_from_documents(documents: list[RAGDocument]) -> int:
         shutil.rmtree(settings.FAISS_INDEX_PATH, ignore_errors=True)
         return 0
 
-    create_vector_store(chunks)
+    create_vector_store(chunks, user_id=user_id)
     return _index_size_bytes()
 
 
@@ -383,7 +387,10 @@ def ingest_documents(
 
         try:
             all_documents = db.query(RAGDocument).order_by(RAGDocument.id.asc()).all()
-            index_size_bytes = _rebuild_index_from_documents(all_documents)
+            index_size_bytes = _rebuild_index_from_documents(
+                all_documents,
+                user_id=current_user.id,
+            )
         except Exception as exc:
             db.rollback()
             raise HTTPException(
@@ -434,7 +441,10 @@ def delete_rag_document(
 
     remaining_documents = db.query(RAGDocument).order_by(RAGDocument.id.asc()).all()
     try:
-        index_size_bytes = _rebuild_index_from_documents(remaining_documents)
+        index_size_bytes = _rebuild_index_from_documents(
+            remaining_documents,
+            user_id=current_user.id,
+        )
     except Exception as exc:
         db.rollback()
         raise HTTPException(

--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -519,7 +519,10 @@ def query_knowledge_base(
 
         from app.core.database import Base
 
-        cached_response = get_cached_answer(guarded_question.question)
+        cached_response = get_cached_answer(
+            guarded_question.question,
+            current_user.id,
+        )
         if cached_response:
             return RAGQueryResponse(**cached_response)
 
@@ -617,7 +620,11 @@ def query_knowledge_base(
             flagged_reason=warning,
         )
 
-        set_cached_answer(guarded_question.question, response.model_dump())
+        set_cached_answer(
+            guarded_question.question,
+            current_user.id,
+            response.model_dump(),
+        )
         return response
     except HTTPException:
         raise

--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -39,6 +39,7 @@ from app.models.user import SubscriptionTier, User
 from app.modules.llm.llm_client import LLMClient
 from app.modules.rag.document_loader import load_documents_from_paths
 from app.modules.rag.streaming import stream_rag_answer
+from app.modules.rag.cache import get_cached_answer, set_cached_answer
 from app.modules.rag.vector_store import create_vector_store, load_vector_store
 from app.schemas.rag import RAGQueryRequest, RAGQueryResponse
 
@@ -518,6 +519,10 @@ def query_knowledge_base(
 
         from app.core.database import Base
 
+        cached_response = get_cached_answer(guarded_question.question)
+        if cached_response:
+            return RAGQueryResponse(**cached_response)
+
         qa_chain = get_qa_chain(user_id=current_user.id)
         t_start = time.monotonic()
         result = qa_chain({"query": guarded_question.question})
@@ -595,7 +600,7 @@ def query_knowledge_base(
         except Exception:
             pass
 
-        return RAGQueryResponse(
+        response = RAGQueryResponse(
             answer=answer,
             sources=sources,
             answer_id=feedback.id,
@@ -611,6 +616,9 @@ def query_knowledge_base(
             confidence_tier=grounding_confidence.lower(),
             flagged_reason=warning,
         )
+
+        set_cached_answer(guarded_question.question, response.model_dump())
+        return response
     except HTTPException:
         raise
     except FileNotFoundError as exc:

--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -191,12 +191,11 @@ async def guard_rag_question(
         guard = get_rag_guard()
         result = await loop.run_in_executor(None, guard.guard, payload.question)
     except Exception as exc:
-        logger.warning("RAG guard unavailable; allowing query. Error: %s", exc)
         return GuardedRAGQuestion(
             question=payload.question,
             original_question=payload.question,
-            guard_triggered=False,
-            guard_decision="ALLOW",
+            guard_triggered=True,
+            guard_decision="ERROR",
             reasoning=str(exc),
         )
 

--- a/backend/app/modules/rag/cache.py
+++ b/backend/app/modules/rag/cache.py
@@ -12,13 +12,13 @@ def normalize_question(question: str) -> str:
     return " ".join(question.lower().strip().split())
 
 
-def question_hash(question: str) -> str:
+def question_hash(question: str, user_id: int) -> str:
     normalized = normalize_question(question)
-    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return hashlib.sha256(f"{user_id}:{normalized}".encode("utf-8")).hexdigest()
 
 
-def get_cached_answer(question: str) -> dict[str, Any] | None:
-    key = question_hash(question)
+def get_cached_answer(question: str, user_id: int) -> dict[str, Any] | None:
+    key = question_hash(question, user_id)
     cached = _CACHE.get(key)
 
     if not cached:
@@ -31,8 +31,8 @@ def get_cached_answer(question: str) -> dict[str, Any] | None:
     return cached["response"]
 
 
-def set_cached_answer(question: str, response: dict[str, Any]) -> None:
-    key = question_hash(question)
+def set_cached_answer(question: str, user_id: int, response: dict[str, Any]) -> None:
+    key = question_hash(question, user_id)
     _CACHE[key] = {
         "response": response,
         "expires_at": time.time() + TTL_SECONDS,

--- a/backend/app/modules/rag/cache.py
+++ b/backend/app/modules/rag/cache.py
@@ -1,0 +1,43 @@
+"""Lightweight in-memory cache for repeated RAG queries."""
+
+import hashlib
+import time
+from typing import Any
+
+_CACHE: dict[str, dict[str, Any]] = {}
+TTL_SECONDS = 300
+
+
+def normalize_question(question: str) -> str:
+    return " ".join(question.lower().strip().split())
+
+
+def question_hash(question: str) -> str:
+    normalized = normalize_question(question)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def get_cached_answer(question: str) -> dict[str, Any] | None:
+    key = question_hash(question)
+    cached = _CACHE.get(key)
+
+    if not cached:
+        return None
+
+    if time.time() > cached["expires_at"]:
+        _CACHE.pop(key, None)
+        return None
+
+    return cached["response"]
+
+
+def set_cached_answer(question: str, response: dict[str, Any]) -> None:
+    key = question_hash(question)
+    _CACHE[key] = {
+        "response": response,
+        "expires_at": time.time() + TTL_SECONDS,
+    }
+
+
+def clear_cache() -> None:
+    _CACHE.clear()

--- a/backend/tests/test_rag_cache.py
+++ b/backend/tests/test_rag_cache.py
@@ -1,0 +1,44 @@
+import time
+
+from app.modules.rag.cache import (
+    clear_cache,
+    get_cached_answer,
+    question_hash,
+    set_cached_answer,
+)
+
+
+def test_cache_returns_none_on_miss():
+    clear_cache()
+
+    assert get_cached_answer("What is Article 6?") is None
+
+
+def test_cache_returns_answer_for_exact_question():
+    clear_cache()
+    response = {
+        "answer": "Article 6 defines high-risk classification.",
+        "sources": [{"source": "eu-ai-act.pdf"}],
+    }
+
+    set_cached_answer("What is Article 6?", response)
+
+    assert get_cached_answer("What is Article 6?") == response
+
+
+def test_cache_normalizes_question_before_hashing():
+    assert question_hash(" What   Is Article 6? ") == question_hash(
+        "what is article 6?"
+    )
+
+
+def test_cache_expires(monkeypatch):
+    clear_cache()
+    now = 1000.0
+
+    monkeypatch.setattr(time, "time", lambda: now)
+    set_cached_answer("What is Article 6?", {"answer": "cached"})
+
+    monkeypatch.setattr(time, "time", lambda: now + 301)
+
+    assert get_cached_answer("What is Article 6?") is None

--- a/backend/tests/test_rag_cache.py
+++ b/backend/tests/test_rag_cache.py
@@ -11,7 +11,7 @@ from app.modules.rag.cache import (
 def test_cache_returns_none_on_miss():
     clear_cache()
 
-    assert get_cached_answer("What is Article 6?") is None
+    assert get_cached_answer("What is Article 6?", 1) is None
 
 
 def test_cache_returns_answer_for_exact_question():
@@ -21,14 +21,15 @@ def test_cache_returns_answer_for_exact_question():
         "sources": [{"source": "eu-ai-act.pdf"}],
     }
 
-    set_cached_answer("What is Article 6?", response)
+    set_cached_answer("What is Article 6?", 1, response)
 
-    assert get_cached_answer("What is Article 6?") == response
+    assert get_cached_answer("What is Article 6?", 1) == response
 
 
 def test_cache_normalizes_question_before_hashing():
-    assert question_hash(" What   Is Article 6? ") == question_hash(
-        "what is article 6?"
+    assert question_hash(" What   Is Article 6? ", 1) == question_hash(
+    "what is article 6?",
+    1,
     )
 
 
@@ -37,8 +38,13 @@ def test_cache_expires(monkeypatch):
     now = 1000.0
 
     monkeypatch.setattr(time, "time", lambda: now)
-    set_cached_answer("What is Article 6?", {"answer": "cached"})
+    set_cached_answer("What is Article 6?", 1, {"answer": "cached"})
 
     monkeypatch.setattr(time, "time", lambda: now + 301)
 
-    assert get_cached_answer("What is Article 6?") is None
+    assert get_cached_answer("What is Article 6?", 1) is None
+
+def test_question_hash_is_user_scoped():
+    question = "What is Article 6?"
+
+    assert question_hash(question, 1) != question_hash(question, 2)

--- a/backend/tests/test_rag_guard.py
+++ b/backend/tests/test_rag_guard.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from app.modules.rag.cache import clear_cache
 import pytest_asyncio
 from sqlalchemy.orm import Session
 
@@ -80,6 +81,13 @@ def reset_rag_guard_singleton():
     yield
     rag_api._RAG_GUARD = None
 
+
+
+@pytest.fixture(autouse=True)
+def clear_rag_cache_between_tests():
+    clear_cache()
+    yield
+    clear_cache()
 
 def guard_result(decision: str, sanitized_prompt: str | None = None) -> dict[str, Any]:
     """Build a representative guard result."""

--- a/backend/tests/test_rag_ingest.py
+++ b/backend/tests/test_rag_ingest.py
@@ -393,7 +393,10 @@ class TestRagDocuments:
         assert data["documents_remaining"] == 1
         assert data["index_rebuilt"] is True
         assert not os.path.exists(deleted_path)
-        mock_create.assert_called_once_with([remaining_chunk])
+        mock_create.assert_called_once_with(
+            [remaining_chunk],
+            user_id="test-user-id",
+        )
 
     def test_delete_missing_document_returns_404(self, client, mock_rag_user):
         response = client.delete("/api/v1/rag/documents/999999")

--- a/backend/tests/test_rag_query.py
+++ b/backend/tests/test_rag_query.py
@@ -8,6 +8,7 @@ Verifies that the endpoint does not crash with a NameError when using
 import sys
 import types
 from unittest.mock import MagicMock, patch
+from app.modules.rag.cache import clear_cache
 
 import pytest
 
@@ -42,8 +43,7 @@ def mock_rag_user():
 
 @pytest.fixture
 def mock_rag_modules():
-    """Patch the lazily-imported RAG modules so the endpoint runs without
-    external dependencies (OpenAI, FAISS, etc.)."""
+    """Patch RAG and guard modules so tests avoid external dependencies."""
     retrieval_chain = types.ModuleType("app.modules.rag.retrieval_chain")
 
     def _qa_chain(payload):
@@ -63,18 +63,40 @@ def mock_rag_modules():
         }
 
     retrieval_chain.get_qa_chain = lambda user_id=None: _qa_chain
+
     ml_flow = types.ModuleType("app.modules.rag.ml_flow")
     ml_flow.log_query = lambda question, answer, sources, latency_ms: None
+
+    guard_module = types.ModuleType("app.modules.guard.llm_guard")
+
+    class MockGuard:
+        def guard(self, text):
+            return {
+                "decision": "ALLOW",
+                "sanitized_prompt": text,
+                "metadata": {
+                    "decision_reasoning": {"reasoning": "test allow"},
+                    "sanitization": {"changes": None},
+                },
+            }
+
+    guard_module.LLMGuard = MockGuard
 
     with patch.dict(
         sys.modules,
         {
             "app.modules.rag.retrieval_chain": retrieval_chain,
             "app.modules.rag.ml_flow": ml_flow,
+            "app.modules.guard.llm_guard": guard_module,
         },
     ):
         yield
 
+@pytest.fixture(autouse=True)
+def clear_rag_cache_between_tests():
+    clear_cache()
+    yield
+    clear_cache()
 
 class TestRagQuery:
     """Integration-style tests for the /rag/query endpoint."""

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,6 @@
         "lucide-react": "^0.314.0",
         "marked": "^18.0.3",
         "react": "^18.2.0",
-        "react-diff-viewer-continued": "^4.2.2",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.49.3",
         "react-hot-toast": "^2.6.0",
@@ -59,6 +58,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -81,6 +81,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -116,6 +117,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -153,6 +155,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -160,6 +163,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.28.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -195,6 +199,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -202,6 +207,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -229,6 +235,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -277,6 +284,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.28.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -289,6 +297,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -305,6 +314,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -436,145 +446,13 @@
     "node_modules/@codemirror/view": {
       "version": "6.42.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
-    },
-    "node_modules/@emotion/babel-plugin": {
-      "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/runtime": "^7.18.3",
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/serialize": "^1.3.3",
-        "babel-plugin-macros": "^3.1.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/cache": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/css": {
-      "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
-      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/cache": "^11.13.5",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
-      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "hoist-non-react-statics": "^3.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.2",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -1099,6 +977,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1116,6 +995,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1123,10 +1003,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1704,21 +1586,16 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT"
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1782,6 +1659,7 @@
       "version": "6.21.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2003,6 +1881,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2079,6 +1958,7 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -2135,21 +2015,6 @@
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
       }
     },
     "node_modules/balanced-match": {
@@ -2216,6 +2081,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2243,6 +2109,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2324,12 +2191,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "license": "MIT",
@@ -2394,22 +2255,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "license": "MIT"
@@ -2440,7 +2285,8 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -2553,6 +2399,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2586,15 +2433,6 @@
       "version": "1.2.2",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/diff": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
-      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2656,15 +2494,6 @@
       "version": "1.5.335",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2750,6 +2579,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2762,6 +2592,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3012,12 +2843,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -3310,21 +3135,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "dev": true,
@@ -3335,6 +3145,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -3376,12 +3187,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT"
-    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "dev": true,
@@ -3395,6 +3200,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -3450,6 +3256,7 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3460,6 +3267,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3470,6 +3278,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -3481,12 +3290,6 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -3543,6 +3346,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -3610,12 +3414,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/memoize-one": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
-      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
-      "license": "MIT"
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "dev": true,
@@ -3669,6 +3467,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -3785,30 +3584,13 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -3837,10 +3619,12 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3848,6 +3632,7 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -3895,6 +3680,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4084,6 +3870,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4091,30 +3878,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-diff-viewer-continued": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/react-diff-viewer-continued/-/react-diff-viewer-continued-4.2.2.tgz",
-      "integrity": "sha512-8wT0/smXGox70oXJ7SZkTYF1p1Uh7jNGXhN7ykqrqPven0sZ+wM2c62SG3ZqORx5aW75te+WhmUWo0E4NyoSvg==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "classnames": "^2.5.1",
-        "diff": "^9.0.0",
-        "js-yaml": "^4.1.1",
-        "memoize-one": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4126,6 +3893,7 @@
     "node_modules/react-hook-form": {
       "version": "7.72.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4270,6 +4038,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -4288,6 +4057,7 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4426,15 +4196,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "dev": true,
@@ -4467,12 +4228,6 @@
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
-      "license": "MIT"
-    },
-    "node_modules/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
       "license": "MIT"
     },
     "node_modules/sucrase": {
@@ -4509,6 +4264,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4624,6 +4380,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4684,6 +4441,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4765,6 +4523,7 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4854,15 +4613,6 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "AegisAI",
+  "name": "AegisAI-aishwarya",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -19,6 +19,7 @@
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }


### PR DESCRIPTION
## Summary

Closes #957

This PR adds a lightweight response cache for RAG queries to avoid repeated processing of identical regulatory questions.

The implementation introduces question normalization, SHA256-based cache keys, TTL-based expiration, and integration with the existing RAG query flow. On cache hits, responses are returned immediately without re-running the retrieval chain.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor
* [x] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [x] I have added/updated tests where relevant
* [x] pytest backend/tests/ passes locally
* [x] I have not committed .env or any secrets
* [ ] I have updated documentation if needed

## Implementation Details

### Added

* `app/modules/rag/cache.py`
* SHA256-based question hashing
* Question normalization before hashing
* TTL-based cache expiration
* Cache lookup before RAG chain execution
* Cache storage after successful response generation

### Tests

* Added `tests/test_rag_cache.py`
* Updated RAG tests to clear cache between test runs
* Verified existing RAG functionality remains unchanged

### Test Results

```text
17 passed, 13 warnings
```

Test command:

```bash
pytest tests/test_rag_cache.py tests/test_rag_query.py tests/test_rag_guard.py tests/test_rag_ml_flow.py -q
```

## Screenshots (if UI change)

N/A – Backend-only change.
