### PR TITLE
fix: hash RAG question/answer before persisting to database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Unit and integration tests for bypass payloads (`test_normalizer.py` and `test_guard.py`)
 
 ### Fixed
+- **RAG Plaintext Privacy (#1034)** — Replaced plaintext question/answer storage with SHA-256 hashes in `RagQuery` and `RAGFeedback` models; history endpoint returns hashes and lengths instead of raw text, preventing accidental plaintext exposure in the database and API responses.
 - **Per-user FAISS Isolation (#920)** — Added `FAISS_INDEX_BASE_PATH` config and `_get_index_path(user_id)` helper. Vector store functions now accept a `user_id` parameter to store/load indexes under `{FAISS_INDEX_BASE_PATH}/user_{user_id}/`, preventing cross-user data leakage in RAG queries.
 - **Frontend Theme** — Fixed dark mode flash of unstyled content (FOUC), eliminated duplicate CSS, fixed React state overwrite bugs, and improved system preference synchronization.
 - **Documents API** — Validate `ai_system_id` ownership before creating documents so users cannot link documents to another user's AI system.

--- a/backend/alembic/versions/4d8e9f0a1b2c_hash_rag_plaintext.py
+++ b/backend/alembic/versions/4d8e9f0a1b2c_hash_rag_plaintext.py
@@ -1,0 +1,71 @@
+"""hash rag_queries and rag_feedback plaintext columns
+
+Revision ID: 4d8e9f0a1b2c
+Revises: 7f3b2e91a6d4
+Create Date: 2026-06-19 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # --- rag_queries ---
+    op.add_column("rag_queries", sa.Column("question_hash", sa.String(64), nullable=True))
+    op.add_column("rag_queries", sa.Column("question_length", sa.Integer(), nullable=True))
+    op.add_column("rag_queries", sa.Column("answer_hash", sa.String(64), nullable=True))
+    op.add_column("rag_queries", sa.Column("answer_length", sa.Integer(), nullable=True))
+
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("""
+            UPDATE rag_queries
+            SET question_hash = encode(sha256(question::bytea), 'hex'),
+                question_length = length(question)
+        """)
+    )
+
+    op.alter_column("rag_queries", "question_hash", nullable=False)
+    op.drop_column("rag_queries", "question")
+    op.drop_column("rag_queries", "answer_summary")
+
+    # --- rag_feedback ---
+    op.add_column("rag_feedback", sa.Column("question_hash", sa.String(64), nullable=True))
+    op.add_column("rag_feedback", sa.Column("answer_hash", sa.String(64), nullable=True))
+
+    conn.execute(
+        sa.text("""
+            UPDATE rag_feedback
+            SET question_hash = encode(sha256(question::bytea), 'hex'),
+                answer_hash = encode(sha256(answer::bytea), 'hex')
+            WHERE question IS NOT NULL
+        """)
+    )
+
+    op.drop_column("rag_feedback", "question")
+    op.drop_column("rag_feedback", "answer")
+
+
+def downgrade():
+    # --- rag_feedback ---
+    op.add_column("rag_feedback", sa.Column("answer", sa.String(4000), nullable=True))
+    op.add_column("rag_feedback", sa.Column("question", sa.String(2000), nullable=True))
+    op.drop_column("rag_feedback", "answer_hash")
+    op.drop_column("rag_feedback", "question_hash")
+
+    # --- rag_queries ---
+    op.add_column("rag_queries", sa.Column("answer_summary", sa.String(200), nullable=True))
+    op.add_column("rag_queries", sa.Column("question", sa.Text(), nullable=True))
+
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("""
+            UPDATE rag_queries
+            SET question = ''
+        """)
+    )
+    op.alter_column("rag_queries", "question", nullable=False)
+
+    op.drop_column("rag_queries", "answer_length")
+    op.drop_column("rag_queries", "answer_hash")
+    op.drop_column("rag_queries", "question_length")
+    op.drop_column("rag_queries", "question_hash")

--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -565,16 +565,18 @@ def query_knowledge_base(
             pass
 
         feedback = RAGFeedback(
-            question=guarded_question.question,
-            answer=answer,
+            question_hash=hashlib.sha256(guarded_question.question.encode("utf-8")).hexdigest(),
+            answer_hash=hashlib.sha256(answer.encode("utf-8")).hexdigest(),
             source_chunks=source_labels,
         )
         db.add(feedback)
         db.add(
             RagQuery(
                 user_id=current_user.id,
-                question=guarded_question.question,
-                answer_summary=answer[:200],
+                question_hash=hashlib.sha256(guarded_question.question.encode("utf-8")).hexdigest(),
+                question_length=len(guarded_question.question),
+                answer_hash=hashlib.sha256(answer.encode("utf-8")).hexdigest(),
+                answer_length=len(answer),
                 source_count=len(sources),
             )
         )
@@ -784,8 +786,10 @@ def get_rag_history(
         "results": [
             {
                 "id": query.id,
-                "question": query.question,
-                "answer_summary": query.answer_summary,
+                "question_hash": query.question_hash,
+                "question_length": query.question_length,
+                "answer_hash": query.answer_hash,
+                "answer_length": query.answer_length,
                 "source_count": query.source_count,
                 "created_at": query.created_at,
             }

--- a/backend/app/models/rag_feedback.py
+++ b/backend/app/models/rag_feedback.py
@@ -8,8 +8,8 @@ class RAGFeedback(Base):
     __tablename__ = "rag_feedback"
 
     id = Column(String(64), primary_key=True, default=lambda: str(uuid.uuid4()))
-    question = Column(String(2000), nullable=True)
-    answer = Column(String(4000), nullable=True)
+    question_hash = Column(String(64), nullable=True)
+    answer_hash = Column(String(64), nullable=True)
     thumbs_up = Column(Integer, default=0)
     thumbs_down = Column(Integer, default=0)
     source_chunks = Column(JSON, default=list)

--- a/backend/app/models/rag_query.py
+++ b/backend/app/models/rag_query.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from datetime import datetime
 from app.core.database import Base
 
@@ -8,7 +8,9 @@ class RagQuery(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    question = Column(Text, nullable=False)
-    answer_summary = Column(String(200), nullable=True)
+    question_hash = Column(String(64), nullable=False)
+    question_length = Column(Integer, nullable=True)
+    answer_hash = Column(String(64), nullable=True)
+    answer_length = Column(Integer, nullable=True)
     source_count = Column(Integer, default=0)
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/backend/app/modules/rag/streaming.py
+++ b/backend/app/modules/rag/streaming.py
@@ -40,6 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import time
@@ -191,8 +192,7 @@ async def stream_rag_answer(
 
         # --- 2. Persist placeholder so we have an answer_id ----------------
         feedback = RAGFeedback(
-            question=question,
-            answer="",
+            question_hash=hashlib.sha256(question.encode("utf-8")).hexdigest(),
             source_chunks=[c["source"] for c in citations if c["source"]],
         )
         db.add(feedback)
@@ -255,7 +255,8 @@ async def stream_rag_answer(
         # may want to thumbs-up/down a partial answer.
         if feedback is not None and answer_buf:
             try:
-                feedback.answer = "".join(answer_buf)
+                full_answer = "".join(answer_buf)
+                feedback.answer_hash = hashlib.sha256(full_answer.encode("utf-8")).hexdigest()
                 db.add(feedback)
                 db.commit()
             except Exception:

--- a/backend/tests/test_rag_stream.py
+++ b/backend/tests/test_rag_stream.py
@@ -8,6 +8,7 @@ without an OpenAI key, a running DB, or a real FAISS index.
 
 from __future__ import annotations
 from app.core.config import settings
+import hashlib
 import json
 from dataclasses import dataclass, field
 from typing import Iterator
@@ -204,8 +205,8 @@ class TestStreamRagAnswer:
         answer_id = events[0]["data"]["answer_id"]
         row = db_session.query(RAGFeedback).filter(RAGFeedback.id == answer_id).first()
         assert row is not None
-        assert row.question == "hi"
-        assert row.answer == "Hello world."
+        assert row.question_hash == hashlib.sha256("hi".encode("utf-8")).hexdigest()
+        assert row.answer_hash == hashlib.sha256("Hello world.".encode("utf-8")).hexdigest()
         assert row.source_chunks == ["doc.pdf"]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Description
The RAG module stored user questions and LLM-generated answers as **plaintext** in `rag_queries` and `rag_feedback` tables, violating data minimization principles (GDPR Article 5(1)(c)). Unlike the Guard module which hashes prompt content (`prompt_hash`), the RAG module exposed sensitive data. A database breach would leak proprietary queries, trade secrets, and compliance analysis.

### Changes
- **`backend/app/models/rag_query.py`** — Replaced `question` (Text) and `answer_summary` (String) with `question_hash` (SHA-256), `question_length`, `answer_hash`, `answer_length`.
- **`backend/app/models/rag_feedback.py`** — Replaced `question` and `answer` plaintext columns with `question_hash` and `answer_hash`.
- **`backend/app/api/v1/rag.py`** — Updated `query_knowledge_base` endpoint and `get_rag_history` to hash before persisting and return hashes.
- **`backend/app/modules/rag/streaming.py`** — Updated streaming pipeline to store hashes instead of plaintext.
- **`backend/tests/test_rag_stream.py`** — Updated assertions to use hash comparison.
- **`backend/alembic/versions/4d8e9f0a1b2c_hash_rag_plaintext.py`** — Migration to add new columns, backfill existing records with SHA-256 hashes, and drop old plaintext columns.

### Files Changed
- `backend/app/models/rag_query.py`
- `backend/app/models/rag_feedback.py`
- `backend/app/api/v1/rag.py`
- `backend/app/modules/rag/streaming.py`
- `backend/tests/test_rag_stream.py`
- `backend/alembic/versions/4d8e9f0a1b2c_hash_rag_plaintext.py`

Closes #1034