### PR TITLE
fix(auth): prevent duplicate handling of concurrent 401 responses

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -4,6 +4,9 @@ import { useAuthStore } from '../stores/authStore'
 const configuredApiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim()
 const API_BASE_URL = configuredApiBaseUrl ? configuredApiBaseUrl.replace(/\/$/, '') : '/api/v1'
 
+// Tracks whether the global 401-response handler is currently executing.
+let isUnauthorizedHandlerRunning = false
+
 function buildApiUrl(path: string): string {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
   return `${API_BASE_URL}${normalizedPath}`
@@ -36,7 +39,13 @@ api.interceptors.response.use(
 }
     const url = error.config?.url || ''
     const isAuthEndpoint = AUTH_ENDPOINTS.some((endpoint) => url.includes(endpoint))
-    if (error.response?.status === 401 && !isAuthEndpoint) {
+    const isUnAuthorized = error.response?.status === 401 && !isAuthEndpoint
+
+    if (isUnAuthorized && !isUnauthorizedHandlerRunning) {
+
+      // Block concurrent 401 responses from entering the unauthorized handler.
+      isUnauthorizedHandlerRunning = true
+
       // Logout and navigate to login without forcing a full page reload.
       useAuthStore.getState().logout()
       try {
@@ -46,6 +55,10 @@ api.interceptors.response.use(
       } catch (e) {
         // Fallback: if SPA navigation fails, perform a safe replace.
         window.location.replace('/login')
+      }
+      finally {
+        // Allow future unauthorized responses after current logout/navigation flow has finished.
+        isUnauthorizedHandlerRunning = false
       }
     }
     return Promise.reject(error)


### PR DESCRIPTION
## Summary

- Closes #1046 

- This PR adds a concurrency guard to the global Axios `401 Unauthorized` response interceptor to prevent duplicate execution of the unauthorized-response handling flow when multiple requests fail simultaneously.

## Implementation Details

- A module-level execution guard was introduced to allow execution on only the first eligible `401 response`.
- During the interval in which the first unauthorized-response handler invocation is actively executing, any `401` responses arriving will be deduplicated.
- The execution quard is released once the current handling cycle completes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [x] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [x] I have updated documentation if needed

## Additional details

- Label: GSSoC'2026, type:enhancement
