### PR TITLE
fix : added correct confidence scoring for ALLOW decisions in DecisionEngine

### DIFF
--- a/backend/app/modules/guard/decision_engine.py
+++ b/backend/app/modules/guard/decision_engine.py
@@ -110,7 +110,7 @@ class DecisionEngine:
         # Default: Allow benign prompts
         return DecisionResult(
             decision=Decision.ALLOW,
-            confidence=1.0 - intent_score if intent == "benign" else 0.5,
+            confidence=intent_score,
             reasoning="Prompt classified as benign - no risk detected",
             rule_matched="default_allow",
         )

--- a/backend/tests/test_decision_engine.py
+++ b/backend/tests/test_decision_engine.py
@@ -29,7 +29,7 @@ def engine():
         (False, 0.0, "malicious", 0.85, Decision.BLOCK, 0.85, "intent_malicious"),
         (False, 0.0, "suspicious", 0.6, Decision.SANITIZE, 0.6, "intent_suspicious"),
         (True, 0.6, "benign", 0.1, Decision.SANITIZE, 0.6, "regex_medium"),
-        (False, 0.0, "benign", 0.1, Decision.ALLOW, 0.9, "default_allow"),
+        (False, 0.0, "benign", 0.1, Decision.ALLOW, 0.1, "default_allow"),
     ],
 )
 def test_decision_engine_branches(


### PR DESCRIPTION
Closes #1078.

Summary of What Has Been Done:
Fixed the confidence inversion bug in the ALLOW branch of DecisionEngine.decide(). The ALLOW branch was computing confidence = 1.0 - intent_score, which inverted the score (a 95%-confident benign classification reported 5% confidence). Now it correctly uses confidence = intent_score, matching the semantics of BLOCK/SANITIZE branches.

Changes Made:
- backend/app/modules/guard/decision_engine.py: Changed confidence = 1.0 - intent_score to confidence = intent_score in the default_allow branch.
- backend/tests/test_decision_engine.py: Updated the test case to expect confidence == 0.1 (not 0.9) for the default_allow branch, verifying the fix is regression-protected.

Impact it Made:
- Audit logs, API responses, analytics dashboards, and feedback loops now receive accurate confidence scores for ALLOW decisions.
- Clients implementing threshold-based blocking will behave correctly.
- The analytics dashboard will accurately reflect guard performance.