### PR TITLE
fix : added proper async lifecycle for MCP server stdio_server

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -335,13 +335,18 @@ async def handle_query_regulations(arguments: dict) -> list[TextContent]:
         )]
 
 
-def main():
+async def main():
     """Run the MCP server with stdio transport."""
     from mcp.server.stdio import stdio_server
-    
-    # Run server with stdio
-    stdio_server(server)
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
 
 
 if __name__ == "__main__":
-    main()
+    import asyncio
+    asyncio.run(main())


### PR DESCRIPTION
Closes #1079.

Summary of What Has Been Done:
Fixed the MCP server main() function which was calling stdio_server(server) without await, silently discarding the coroutine and causing the server to exit immediately with code 0. The server is now fully functional.

Changes Made:
- mcp/server.py: Made main() async, wrapped stdio_server in 'async with' for proper async context manager lifecycle, and called server.run() with the correct initialization options inside the context. The entry point now uses asyncio.run().

Impact it Made:
- The MCP server binary now starts and processes requests instead of exiting immediately.
- Claude Desktop, VS Code extensions, and other MCP clients can use AegisAI tools.
- Server exit code reflects actual failures instead of silent success.