### PR TITLE
fix : added PDF parse error handling in RAG ingest endpoint

### DIFF
--- a/backend/app/api/v1/rag.py
+++ b/backend/app/api/v1/rag.py
@@ -37,7 +37,7 @@ from app.models.rag_feedback import RAGFeedback
 from app.models.rag_query import RagQuery
 from app.models.user import SubscriptionTier, User
 from app.modules.llm.llm_client import LLMClient
-from app.modules.rag.document_loader import load_documents_from_paths
+from app.modules.rag.document_loader import load_documents_from_paths, PDFParseError
 from app.modules.rag.streaming import stream_rag_answer
 from app.modules.rag.vector_store import create_vector_store, load_vector_store
 from app.schemas.rag import RAGQueryRequest, RAGQueryResponse
@@ -251,7 +251,14 @@ def _index_size_bytes() -> int:
 
 
 def _valid_text_chunks(file_paths: list[str]):
-    raw_chunks = load_documents_from_paths(file_paths)
+    try:
+        raw_chunks = load_documents_from_paths(file_paths)
+    except PDFParseError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="One or more PDF files could not be parsed. "
+            "Ensure the files are not malformed or password-protected.",
+        )
     return [
         chunk for chunk in raw_chunks
         if getattr(chunk, "page_content", None) and chunk.page_content.strip()

--- a/backend/app/modules/rag/document_loader.py
+++ b/backend/app/modules/rag/document_loader.py
@@ -6,6 +6,11 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 from app.core.config import settings
 
 
+class PDFParseError(Exception):
+    """Raised when a PDF file cannot be parsed (malformed, encrypted, etc.)."""
+    pass
+
+
 def load_documents_from_s3():
     """Load documents from the configured S3 bucket."""
     bucket = settings.S3_BUCKET_NAME
@@ -21,11 +26,20 @@ def load_documents_from_s3():
 
 
 def load_documents_from_paths(file_paths: list[str]):
-    """Load documents from a list of local PDF file paths."""
+    """Load documents from a list of local PDF file paths.
+
+    Raises:
+        PDFParseError: If any file cannot be parsed (malformed, encrypted, etc.).
+    """
     documents = []
     for path in file_paths:
         loader = PyPDFLoader(path)
-        documents.extend(loader.load())
+        try:
+            documents.extend(loader.load())
+        except Exception as exc:
+            raise PDFParseError(
+                f"Failed to parse PDF '{os.path.basename(path)}': {exc}"
+            ) from exc
     splitter = RecursiveCharacterTextSplitter(
         chunk_size=settings.RAG_CHUNK_SIZE,
         chunk_overlap=settings.RAG_CHUNK_OVERLAP,

--- a/backend/tests/test_rag_ingest.py
+++ b/backend/tests/test_rag_ingest.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 from app.core.config import settings
 from app.core.security import get_current_user
 from app.main import app
+from app.modules.rag.document_loader import PDFParseError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -176,6 +177,32 @@ class TestRagIngest:
 
         assert response.status_code == 400
         assert "text" in response.json()["detail"].lower()
+        mock_create.assert_not_called()
+
+    @patch(PATCH_CREATE_VS)
+    @patch(PATCH_LOAD_DOCS)
+    def test_malformed_pdf_returns_400(self, mock_load, mock_create, client, mock_rag_user):
+        """
+        6. A PDF that triggers a parser exception (malformed, encrypted) should
+        return 400 with a user-safe message, not a raw 500. create_vector_store
+        must NOT be called.
+        """
+        mock_load.side_effect = PDFParseError(
+            "PdfReadError: file has not been decrypted"
+        )
+
+        with patch(PATCH_AUTH, return_value=_mock_current_user()):
+            response = client.post(
+                "/api/v1/rag/ingest",
+                files={"files": _make_pdf_upload("encrypted.pdf")},
+            )
+
+        assert response.status_code == 400
+        assert "pdf" in response.json()["detail"].lower()
+        # Parser details must not leak to client
+        assert "PdfReadError" not in response.json()["detail"]
+        assert "decrypted" not in response.json()["detail"]
+        # create_vector_store must not run for a bad file
         mock_create.assert_not_called()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Closes #1080.

Summary of What Has Been Done:
Fixed the RAG ingest endpoint to return a controlled HTTP 400 response for malformed or password-protected PDFs instead of an unhandled HTTP 500. The document loader now raises a typed PDFParseError, which the endpoint catches and converts to a generic user-safe message.

Changes Made:
- backend/app/modules/rag/document_loader.py: Added PDFParseError exception class and wrapped PyPDFLoader.load() in a try/except that raises PDFParseError instead of letting raw exceptions bubble through.
- backend/app/api/v1/rag.py: Wrapped the _valid_text_chunks() call in _valid_text_chunks() itself to catch PDFParseError and raise HTTPException(status_code=400) with a safe message. Also imported PDFParseError.
- backend/tests/test_rag_ingest.py: Added test_malformed_pdf_returns_400 verifying status 400, safe detail text, no parser internals leaked, and FAISS not built.

Impact it Made:
- Malformed or password-protected PDFs now return a user-friendly 400 error instead of a raw 500.
- Parser internal details are not exposed to clients.
- create_vector_store is not called when a parse error occurs, avoiding wasted work.