### PR TITLE
fix: remove closed db session from deliver_webhook background task

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -242,7 +242,6 @@ def scan_prompt(
             try:
                 background_tasks.add_task(
                     deliver_webhook,
-                    db,
                     current_user.id,
                     "guard_block",
                     {
@@ -828,7 +827,6 @@ def bulk_scan_prompts(
                 )
                 background_tasks.add_task(
                     deliver_webhook,
-                    db,
                     current_user.id,
                     "guard_block",
                     {

--- a/backend/app/api/v1/webhooks.py
+++ b/backend/app/api/v1/webhooks.py
@@ -59,33 +59,40 @@ async def _post_webhook(
 
 
 def deliver_webhook(
-    db: Session,
     user_id: int,
     event: str,
     payload: dict[str, Any],
     background_tasks: BackgroundTasks,
 ) -> None:
-    """Schedule delivery to active user webhooks subscribed to the event."""
-    webhooks = (
-        db.query(WebhookConfig)
-        .filter(
-            WebhookConfig.user_id == user_id,
-            WebhookConfig.is_active.is_(True),
-        )
-        .all()
-    )
+    """Schedule delivery to active user webhooks subscribed to the event.
 
-    for webhook in webhooks:
-        if event not in (webhook.events or []):
-            continue
+    Opens its own database session so this function is safe to call from
+    a background task, where the request-scoped session is already closed.
+    """
+    from app.core.database import SessionLocal
 
-        background_tasks.add_task(
-            _post_webhook,
-            url=webhook.url,
-            event=event,
-            payload=payload,
-            secret=webhook.secret,
+    db = SessionLocal()
+    try:
+        webhooks = (
+            db.query(WebhookConfig)
+            .filter(
+                WebhookConfig.user_id == user_id,
+                WebhookConfig.is_active.is_(True),
+            )
+            .all()
         )
+        for webhook in webhooks:
+            if event not in (webhook.events or []):
+                continue
+            background_tasks.add_task(
+                _post_webhook,
+                url=webhook.url,
+                event=event,
+                payload=payload,
+                secret=webhook.secret,
+            )
+    finally:
+        db.close()
 
 
 @router.post("", response_model=WebhookResponse, status_code=status.HTTP_201_CREATED)


### PR DESCRIPTION
## Summary
Closes #796

Fixes a bug where `deliver_webhook` was passed a request-scoped `db` session via `background_tasks.add_task`, but that session is already closed by the time the background task runs. The function now opens its own `SessionLocal()` internally and closes it in a `finally` block. The `db` argument was removed from both call sites in `guard.py`.

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed