### PR TITLE
fix: resolve AI system clone name collision with incremental suffix

### DIFF
--- a/backend/app/api/v1/ai_systems.py
+++ b/backend/app/api/v1/ai_systems.py
@@ -449,16 +449,25 @@ def clone_ai_system(
             detail="AI system not found"
         )
 
+    base_name = f"{original.name} (copy)"
+    candidate = base_name
+    counter = 2
+    while db.query(AISystem).filter(
+        AISystem.owner_id == current_user.id,
+        AISystem.name == candidate,
+    ).first():
+        candidate = f"{original.name} (copy {counter})"
+        counter += 1
+
     cloned = AISystem(
         owner_id=current_user.id,
-        name=f"{original.name} (copy)",
+        name=candidate,
         description=original.description,
         version=original.version,
         use_case=original.use_case,
         sector=original.sector,
         compliance_status=ComplianceStatus.NOT_STARTED,
     )
-
     db.add(cloned)
     db.commit()
     db.refresh(cloned)


### PR DESCRIPTION
## Summary
Fixes #795

When cloning an AI system whose name already has a copy (e.g. "Alpha (copy)"),
the endpoint unconditionally set the name to "{name} (copy)" and crashed with
a database IntegrityError due to the unique (owner_id, name) constraint.

The clone endpoint now checks if the candidate name already exists for the user
and increments a counter suffix until a unique name is found:
"Alpha (copy)" → "Alpha (copy 2)" → "Alpha (copy 3)" etc.

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [x] I have not committed `.env` or any secrets