### PR TITLE
fix: normalize notifications API response to prevent filter crash

### DIFF
--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -49,11 +49,16 @@ export default function NotificationBell() {
 
   // Live data via useQuery
   const queryClient = useQueryClient()
-  const { data: notifications = [] } = useQuery({
+  const { data: notificationsResponse } = useQuery({
     queryKey: ['notifications', 'unread'],
     queryFn: () => notificationsApi.list(true),
     refetchInterval: 60_000,
   })
+
+  // Normalize response — API may return a plain array or { items, total }
+  const notifications: NotificationPreview[] = Array.isArray(notificationsResponse)
+    ? notificationsResponse
+    : notificationsResponse?.items ?? []
 
   const unreadCount = notifications.filter((n: NotificationPreview) => !n.is_read).length
 


### PR DESCRIPTION
## Summary
Fixes #1070

Dashboard was crashing with `TypeError: notifications.filter is not a function` because `notificationsApi.list()` returns `{ items: [], total: 0 }` but `NotificationBell.tsx` called `.filter()` directly on the response.

## Root Cause
The API response shape is an object with an `items` array, not a plain array, but the component assumed a plain array.

## Changes
- Normalized the API response in `NotificationBell.tsx` to safely extract the array, whether the response is a plain array or `{ items, total }`
- Falls back to an empty array if neither shape matches

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style
- [x] I have not committed `.env` or any secrets