### PR TITLE
feat: add response time badge with color-coded indicator to RAG chat

### DIFF
--- a/frontend/src/hooks/useRagStream.ts
+++ b/frontend/src/hooks/useRagStream.ts
@@ -25,6 +25,7 @@ export interface UseRagStreamResult {
   answerId: string | null
   error: string | null
   finishInfo: RagStreamDone | null
+  responseTime: number | null
   ask: (question: string) => Promise<void>
   stop: () => void
   reset: () => void
@@ -37,6 +38,8 @@ export function useRagStream(): UseRagStreamResult {
   const [answerId, setAnswerId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [finishInfo, setFinishInfo] = useState<RagStreamDone | null>(null)
+  const [responseTime, setResponseTime] = useState<number | null>(null)
+  const startTimeRef = useRef<number | null>(null)
 
   // Hold a ref to the in-flight AbortController so `stop` can cancel without
   // re-binding on every render.
@@ -51,6 +54,7 @@ export function useRagStream(): UseRagStreamResult {
     setAnswerId(null)
     setError(null)
     setFinishInfo(null)
+    setResponseTime(null)
   }, [])
 
   const stop = useCallback(() => {
@@ -73,6 +77,8 @@ export function useRagStream(): UseRagStreamResult {
     setAnswerId(null)
     setError(null)
     setFinishInfo(null)
+    setResponseTime(null)
+    startTimeRef.current = performance.now()
 
     try {
       await ragApi.streamQuery(
@@ -88,6 +94,9 @@ export function useRagStream(): UseRagStreamResult {
           onDone: (done) => {
             setFinishInfo(done)
             setStatus('done')
+            if (startTimeRef.current !== null) {
+              setResponseTime((performance.now() - startTimeRef.current) / 1000)
+            }
           },
           onError: (err) => {
             setError(err.message)
@@ -112,5 +121,5 @@ export function useRagStream(): UseRagStreamResult {
     }
   }, [])
 
-  return { status, tokens, citations, answerId, error, finishInfo, ask, stop, reset }
+  return { status, tokens, citations, answerId, error, finishInfo, responseTime, ask, stop, reset }
 }

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -12,6 +12,12 @@ import {
 
 import { useRagStream } from '../hooks/useRagStream'
 
+function getResponseTimeColor(time: number): string {
+  if (time < 1) return 'text-green-600 bg-green-50'
+  if (time < 3) return 'text-yellow-600 bg-yellow-50'
+  return 'text-red-600 bg-red-50'
+}
+
 export default function RagChat() {
   const [question, setQuestion] = useState('')
   const [submittedQuestion, setSubmittedQuestion] = useState('')
@@ -22,6 +28,7 @@ export default function RagChat() {
     tokens,
     citations,
     error: streamError,
+    responseTime,
     ask,
     stop,
   } = useRagStream()
@@ -185,6 +192,18 @@ export default function RagChat() {
                         <Bot className="w-5 h-5 text-primary-600" />
                       </div>
                       <div className="space-y-5 min-w-0 flex-1">
+                        {!isStreaming && responseTime !== null && (
+                          <div className="flex justify-end">
+                            <span
+                              className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-full ${getResponseTimeColor(
+                                responseTime,
+                              )}`}
+                            >
+                              ⚡ {responseTime.toFixed(2)}s
+                            </span>
+                          </div>
+                        )}
+
                         <p className="text-gray-700 leading-7 whitespace-pre-wrap">
                           {tokens}
                           {isStreaming && (


### PR DESCRIPTION
## Summary
Fixes #1072

Added a response time badge to the RAG Chatbot that shows how long each query took to complete, with color-coded indicators.

## Changes
- `useRagStream.ts`: Added `responseTime` state, tracked using `performance.now()` from when `ask()` starts to when `onDone` fires
- `RagChat.tsx`: Added `getResponseTimeColor()` helper — green (<1s), yellow (1-3s), red (>3s)
- Displayed a badge ( {time}s) above the answer once streaming completes
- Badge resets on each new question

## Type of Change
- [x] New feature

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style
- [x] I have not committed `.env` or any secrets