### PR TITLE
fix : added NotificationBell non-array API response handling

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -269,7 +269,7 @@ export const documentsApi = {
 // Notifications API
 export const notificationsApi = {
   list: (unreadOnly = false) =>
-    api.get(`/notifications?unread_only=${unreadOnly}`).then((r: AxiosResponse) => r.data),
+    api.get(`/notifications?unread_only=${unreadOnly}`).then((r: AxiosResponse) => r.data.items),
   markRead: (ids: number[]) =>
     api.post('/notifications/read', { ids }),
 }


### PR DESCRIPTION
Closes #1094.

Summary of What Has Been Done:
Changed frontend/src/services/api.ts notificationsApi.list() to return r.data.items (the inner array from PaginatedResponse) instead of r.data directly. The GET /api/v1/notifications endpoint returns PaginatedResponse{items,total,skip,limit}, but the component calls .filter() on the result. The mismatch caused TypeError: notifications.filter is not a function on every page load after login.

Changes Made:
- frontend/src/services/api.ts: Changed .then((r) => r.data) to .then((r) => r.data.items)

Impact it Made:
- Dashboard no longer crashes after login.
- Notification bell correctly displays unread count and list.
- Frontend TypeScript and lint checks pass cleanly.

Note: Please assign this PR to the `tmdeveloper007` account.