### PR TITLE
feat : added GET /guard/logs/export endpoint for CSV and JSON scan history export

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -20,7 +20,7 @@ from typing import Optional, TypedDict
 
 from app.api.v1.webhooks import deliver_webhook
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Query, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import func, and_, or_
 from sqlalchemy.orm import Session
@@ -563,6 +563,109 @@ def get_guard_history(
     limit=limit,
     next_cursor=next_cursor,
 )
+
+
+@router.get("/logs/export")
+def export_guard_scan_logs(
+    format: str = Query("csv", pattern="^(csv|json)$", description="Export format"),
+    decision: Optional[str] = Query(None, pattern="^(allow|sanitize|block)$"),
+    intent: Optional[str] = Query(None),
+    start_date: Optional[datetime] = Query(None),
+    end_date: Optional[datetime] = Query(None),
+    limit: int = Query(10000, ge=1, le=50000, description="Max records to export"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Export guard scan logs as a streamed CSV or JSON file.
+
+    Administrators can download scan history for compliance reporting without
+    hitting the browser memory limit on large datasets.
+    """
+    if start_date and end_date and start_date > end_date:
+        raise HTTPException(status_code=400, detail="start_date cannot be after end_date")
+
+
+    export_filters = build_history_filters(
+        current_user.id,
+        decision,
+        intent,
+        start_date,
+        end_date,
+    )
+
+    query = db.query(GuardScanLog).filter(*export_filters).order_by(
+        GuardScanLog.scanned_at.desc()
+    ).limit(limit)
+
+    def csv_rows():
+        import csv
+        import io
+        output = io.StringIO()
+        writer = csv.DictWriter(
+            output,
+            fieldnames=[
+                "id", "scanned_at", "decision", "confidence",
+                "detection_type", "regex_flag", "regex_score",
+                "intent", "ml_confidence", "combined_score",
+                "prompt_length", "ip_address",
+            ],
+        )
+        writer.writeheader()
+        for log in query.yield_per(500):
+            writer.writerow({
+                "id": log.id,
+                "scanned_at": log.scanned_at.isoformat() if log.scanned_at else "",
+                "decision": log.decision,
+                "confidence": round(log.confidence, 4),
+                "detection_type": log.detection_type,
+                "regex_flag": log.regex_flag,
+                "regex_score": round(log.regex_score, 4),
+                "intent": log.intent,
+                "ml_confidence": round(log.ml_confidence, 4),
+                "combined_score": round(log.combined_score, 4),
+                "prompt_length": log.prompt_length,
+                "ip_address": log.ip_address or "",
+            })
+            yield output.getvalue().encode()
+            output.seek(0)
+            output.truncate()
+
+    def json_rows():
+        import json
+        first = True
+        yield b'{"logs":['
+        for log in query.yield_per(500):
+            if not first:
+                yield b','
+            first = False
+            yield json.dumps({
+                "id": log.id,
+                "scanned_at": log.scanned_at.isoformat() if log.scanned_at else None,
+                "decision": log.decision,
+                "confidence": round(log.confidence, 4),
+                "detection_type": log.detection_type,
+                "regex_flag": log.regex_flag,
+                "regex_score": round(log.regex_score, 4),
+                "intent": log.intent,
+                "ml_confidence": round(log.ml_confidence, 4),
+                "combined_score": round(log.combined_score, 4),
+                "prompt_length": log.prompt_length,
+                "ip_address": log.ip_address,
+            }, default=str).encode()
+        yield b']}'
+    media_type = "text/csv" if format == "csv" else "application/json"
+    filename = f"guard_scan_logs.{format}"
+    rows_fn = csv_rows if format == "csv" else json_rows
+
+    return StreamingResponse(
+        rows_fn(),
+        media_type=media_type,
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
 
 
 @router.get("/stats", response_model=GuardStatsResponse)


### PR DESCRIPTION
Closes #1098.

Summary of What Has Been Done:
Added GET /api/v1/guard/logs/export endpoint that streams guard scan audit log entries as a downloadable CSV or JSON file attachment. Supports filtering by decision (allow/sanitize/block), intent, and date range. Uses StreamingResponse with yield_per(500) to avoid memory issues on large datasets.

Changes Made:
- backend/app/api/v1/guard.py: added GET /guard/logs/export endpoint with CSV and JSON streaming support

Impact it Made:
- Administrators can export guard scan history for compliance reporting.
- Streaming response avoids browser memory limits for large datasets.
- Format flexibility: CSV for spreadsheets, JSON for programmatic processing.
- Existing guard tests remain passing (45/45).

Note: Please assign this PR to the `tmdeveloper007` account.