### PR TITLE
fix: resolve embedding space incompatibility between ingestion and query pipelines

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -60,7 +60,10 @@ class Settings(BaseSettings):
     RAG_DOCUMENT_STORAGE_PATH: str = "rag_documents"
     FAISS_INDEX_BASE_PATH: str = "faiss_data"
     MLFLOW_TRACKING_URI: str = ""
+    EMBEDDING_PROVIDER: str = "ollama"
     EMBEDDINGS_MODEL: str = "nomic-embed-text"
+    OPENAI_EMBEDDING_MODEL: str = "text-embedding-3-small"
+    OPENAI_API_KEY: str = ""
     RAG_MAX_FILES_PER_REQUEST: int = 10
     RAG_MAX_FILE_SIZE_BYTES: int = 10 * 1024 * 1024
     RAG_TOTAL_BUDGET_BYTES: int = 50 * 1024 * 1024

--- a/backend/app/modules/rag/embeddings.py
+++ b/backend/app/modules/rag/embeddings.py
@@ -1,0 +1,32 @@
+"""Centralized embedding factory for AegisAI RAG pipeline.
+
+Ensures the same embedding model is used for both document ingestion
+and query processing, preventing embedding space incompatibility.
+"""
+
+from functools import lru_cache
+
+from app.core.config import settings
+
+
+@lru_cache(maxsize=1)
+def get_embeddings():
+    """Return the configured embeddings model based on settings."""
+    provider = settings.EMBEDDING_PROVIDER
+
+    if provider == "openai":
+        from langchain_openai import OpenAIEmbeddings
+
+        return OpenAIEmbeddings(
+            model=settings.OPENAI_EMBEDDING_MODEL,
+            openai_api_key=settings.OPENAI_API_KEY,
+        )
+    elif provider == "ollama":
+        from langchain_ollama import OllamaEmbeddings
+
+        base = settings.LLM_BASE_URL or "http://ollama:11434"
+        if base.endswith("/v1"):
+            base = base[:-3]
+        return OllamaEmbeddings(model=settings.EMBEDDINGS_MODEL, base_url=base)
+    else:
+        raise ValueError(f"Unknown embedding provider: {provider}")

--- a/backend/app/modules/rag/groundedness.py
+++ b/backend/app/modules/rag/groundedness.py
@@ -15,9 +15,9 @@ EmbeddingsFn = Callable[[list[str]], list[list[float]]]
 
 def get_embeddings():
     """Return configured embeddings for legacy groundedness helpers."""
-    from app.modules.rag.vector_store import get_embeddings as load_embeddings
+    from app.modules.rag.embeddings import get_embeddings as _get_embeddings
 
-    return load_embeddings()
+    return _get_embeddings()
 
 
 def cosine_similarity(left: list[float], right: list[float]) -> float:
@@ -294,37 +294,6 @@ def _cosine_similarity(left: np.ndarray, right: np.ndarray) -> float:
     if left_norm == 0.0 or right_norm == 0.0:
         return 0.0
     return float(np.dot(left, right) / (left_norm * right_norm))
-
-
-def cosine_similarity(left: list[float], right: list[float]) -> float:
-    """Backward-compatible public cosine similarity helper for legacy tests."""
-    return _cosine_similarity(
-        np.asarray(left, dtype=float),
-        np.asarray(right, dtype=float),
-    )
-
-
-def get_embeddings():
-    """Lazy embeddings wrapper retained for older groundedness callers/tests."""
-    from .vector_store import get_embeddings as loader
-
-    return loader()
-
-
-def compute_groundedness(answer: str, chunks: list[str]) -> float:
-    """Return the legacy answer-to-source groundedness score."""
-    if not answer.strip() or not chunks:
-        return 0.0
-
-    try:
-        embeddings = get_embeddings()
-        answer_embedding = embeddings.embed_query(answer)
-        source_embedding = embeddings.embed_query("\n\n".join(chunks))
-    except Exception:
-        logger.warning("Legacy groundedness computation failed", exc_info=True)
-        return 0.0
-
-    return _clamp_score(cosine_similarity(answer_embedding, source_embedding))
 
 
 def _clamp_score(score: float) -> float:

--- a/backend/app/modules/rag/ingest_nist.py
+++ b/backend/app/modules/rag/ingest_nist.py
@@ -12,13 +12,14 @@ Run once:
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
 
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders import PyPDFLoader
 from langchain_community.vectorstores import FAISS
-from langchain_openai import OpenAIEmbeddings
+
+from app.core.config import settings
+from app.modules.rag.embeddings import get_embeddings
 
 logger = logging.getLogger(__name__)
 
@@ -27,10 +28,8 @@ NIST_PDF_PATH = Path(__file__).parent.parent.parent.parent / (
     "data/regulatory_docs/NIST_AI_RMF_1.0.pdf"
 )
 
-# FAISS index path same as used by the existing RAG module
-FAISS_INDEX_PATH = Path(__file__).parent.parent.parent.parent / (
-    "data/faiss_index"
-)
+# FAISS index path from settings
+FAISS_INDEX_PATH = Path(settings.FAISS_INDEX_PATH)
 
 # Chunk settings keep consistent with existing ingestion
 CHUNK_SIZE = 1000
@@ -70,19 +69,12 @@ def ingest_nist_ai_rmf() -> None:
         if "framework" not in chunk.metadata:
             chunk.metadata["framework"] = "NIST AI RMF 1.0"
 
-    # Load embeddings — validate key presence first
-    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
-    if not api_key:
-        raise RuntimeError(
-            "OPENAI_API_KEY environment variable is not set. "
-            "Set it to a valid OpenAI API key before running NIST ingestion."
-        )
-
+    # Load embeddings using the shared factory
     try:
-        embeddings = OpenAIEmbeddings(openai_api_key=api_key)
-    except Exception as exc:  # noqa: BLE001
+        embeddings = get_embeddings()
+    except Exception as exc:
         raise RuntimeError(
-            f"Failed to initialise OpenAI embeddings (check OPENAI_API_KEY): {exc}"
+            f"Failed to initialise embeddings: {exc}"
         ) from exc
 
     # Load existing FAISS index and merge, or create new if none exists

--- a/backend/app/modules/rag/vector_store.py
+++ b/backend/app/modules/rag/vector_store.py
@@ -8,6 +8,7 @@ Addresses: Import-time provider failures, broken mocks, and partial index writes
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import tempfile
@@ -35,13 +36,10 @@ def _get_faiss_class() -> Any:
 
 
 def get_embeddings() -> Any:
-    """Return the configured embeddings model."""
-    from langchain_community.embeddings import OllamaEmbeddings
+    """Return the configured embeddings model from the shared factory."""
+    from app.modules.rag.embeddings import get_embeddings as _get_embeddings
 
-    base = settings.LLM_BASE_URL or "http://ollama:11434"
-    if base.endswith("/v1"):
-        base = base[:-3]
-    return OllamaEmbeddings(model=settings.EMBEDDINGS_MODEL, base_url=base)
+    return _get_embeddings()
 
 
 def _get_index_path(user_id: int | None = None) -> str:
@@ -127,3 +125,32 @@ def load_vector_store(user_id: int | None = None) -> Any:
 def check_index_exists(user_id: int | None = None) -> bool:
     """Check if FAISS index exists on disk for the given user (or globally)."""
     return os.path.exists(_get_index_path(user_id))
+
+
+def validate_embedding_consistency(user_id: int | None = None) -> None:
+    """Validate that the existing FAISS index dimension matches the current embedding model."""
+    index_path = _get_index_path(user_id)
+    if not os.path.exists(index_path):
+        return
+
+    try:
+        faiss_cls = _get_faiss_class()
+        embeddings = get_embeddings()
+        test_vector = embeddings.embed_query("dimension probe")
+        model_dim = len(test_vector)
+
+        store = faiss_cls.load_local(
+            index_path,
+            embeddings,
+            allow_dangerous_deserialization=True,
+        )
+        index_dim = store.index.d
+        if index_dim != model_dim:
+            logger.warning(
+                "FAISS index dimension (%d) doesn't match embedding model dimension (%d). "
+                "Reingest documents with the current embedding model.",
+                index_dim,
+                model_dim,
+            )
+    except Exception as exc:
+        logger.warning("Could not validate embedding consistency: %s", exc)


### PR DESCRIPTION
## Summary

Closes #1075

The RAG pipeline used two different embedding models — OpenAI `text-embedding-3-small` for NIST ingestion and Ollama `nomic-embed-text` for query processing — making similarity search produce meaningless results. This PR adds a centralized embedding factory (`embeddings.py`) that both ingestion and query pipelines use, fixes the hardcoded FAISS index path in `ingest_nist.py`, removes duplicate function definitions in `groundedness.py`, and adds an embedding consistency validation check.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed