### PR TITLE
fix: correct inverted ALLOW confidence score in guard-sdk DecisionEngine

### DIFF
--- a/guard-sdk/src/aegisai_guard/decision_engine.py
+++ b/guard-sdk/src/aegisai_guard/decision_engine.py
@@ -64,6 +64,10 @@ class DecisionEngine:
         Returns:
             DecisionResult with decision, confidence, and reasoning
         """
+        assert 0.0 <= regex_score <= 1.0, f"regex_score out of range: {regex_score}"
+        assert 0.0 <= intent_score <= 1.0, f"intent_score out of range: {intent_score}"
+        assert intent in ("benign", "suspicious", "malicious"), f"unknown intent: {intent}"
+
         # Combine signals
         combined_score = (self.regex_weight * regex_score) + (self.intent_weight * intent_score)
 
@@ -106,7 +110,7 @@ class DecisionEngine:
         # Default: Allow benign prompts
         return DecisionResult(
             decision=Decision.ALLOW,
-            confidence=1.0 - intent_score if intent == "benign" else 0.5,
+            confidence=intent_score,
             reasoning="Prompt classified as benign - no risk detected",
             rule_matched="default_allow",
         )


### PR DESCRIPTION
## Summary

Closes #1076

The `DecisionEngine.decide()` method's default_allow branch in the guard SDK had a logic inversion: when the classifier returned `intent="benign"` with `intent_score=0.95`, confidence was computed as `1.0 - 0.95 = 0.05`, causing downstream consumers to think the guard was highly uncertain about safe inputs. This PR fixes the inversion so confidence correctly reflects the model's certainty, and adds defensive input assertions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [x] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed