### PR TITLE
fix: normalize notifications API response to prevent TypeError in NotificationBellFix/notification bell filter crash

### DIFF
--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -51,7 +51,10 @@ export default function NotificationBell() {
   const queryClient = useQueryClient()
   const { data: notificationsResponse } = useQuery({
     queryKey: ['notifications', 'unread'],
-    queryFn: () => notificationsApi.list(true),
+    queryFn: async () => {
+      const result = await notificationsApi.list(true)
+      return Array.isArray(result) ? result : (result?.items ?? [])
+     },
     refetchInterval: 60_000,
   })
 


### PR DESCRIPTION
## Summary

Closes #1070 

The `notificationsApi.list()` returns an object `{items: [], total: 0}` instead of a plain array. `NotificationBell.tsx` was calling `.filter()` directly on this object causing a TypeError that crashed the entire dashboard after login.

Fixed by normalizing the API response in queryFn to always return an array.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests
- [ ] Infra / CI

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
- [ ] I have added/updated tests where relevant
- [ ] `pytest backend/tests/` passes locally
- [x] I have not committed `.env` or any secrets
- [ ] I have updated documentation if needed

## Screenshots 

## Before: Dashboard goes blank. Console log

<img width="667" height="842" alt="bug-2(1)" src="https://github.com/user-attachments/assets/ba236058-2dbb-426b-b3fd-f77856cf6a64" />

<img width="791" height="763" alt="bug-2(2)" src="https://github.com/user-attachments/assets/7099ede2-f126-47ca-9ec9-7b44871ca0fc" />

After: Dashboard loads successfully

<img width="1912" height="1068" alt="bug-fix" src="https://github.com/user-attachments/assets/8a954849-671d-4494-bb68-bcaac517f37d" />




