### PR TITLE
fix : added questionnaire_responses key/value whitespace trimming in compliance engine

### DIFF
--- a/backend/app/modules/compliance/eu_ai_act.py
+++ b/backend/app/modules/compliance/eu_ai_act.py
@@ -68,7 +68,17 @@ def evaluate_compliance(
     for article, description, action in rules:
         # Check individual requirement status from questionnaire responses
         req_key = article.lower().replace(" ", "_").replace("(", "_").replace(")", "").replace("/", "_")
+        # Trim whitespace from questionnaire_responses keys and values to prevent "missing" status
+        # on keys/values that users accidentally include leading/trailing spaces in.
+        # Try the transformed key, then fall back to any key that matches after stripping.
         raw_status = questionnaire_responses.get(req_key, "missing")
+        if raw_status == "missing":
+            for k, v in questionnaire_responses.items():
+                if k.strip() == req_key:
+                    raw_status = v
+                    break
+        if isinstance(raw_status, str):
+            raw_status = raw_status.strip()
         req_status = _COMPLIANCE_STATUS_MAP.get(raw_status, raw_status)
 
         if req_status not in ("missing", "partial", "done"):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -115,12 +115,75 @@ def client(db_engine):
     connection.close()
     app.dependency_overrides.clear()
 
+
+class _CSRFClientWrapper:
+    """Wrap TestClient to auto-handle CSRF tokens for state-changing requests."""
+
+    def __init__(self, inner: TestClient) -> None:
+        self._inner = inner
+        self._csrf_token: str | None = None
+
+    def _ensure_csrf(self) -> None:
+        """Fetch a CSRF token if we do not have one yet."""
+        if self._csrf_token is None:
+            resp = self._inner.get("/api/v1/auth/csrf-token")
+            assert resp.status_code == 200, f"CSRF token fetch failed: {resp.status_code}"
+            self._csrf_token = resp.json()["token"]
+            assert self._csrf_token, "CSRF token is empty"
+
+    def _inject_csrf(self, kwargs: dict) -> None:
+        """Add X-CSRF-Token header to state-changing request kwargs."""
+        headers = dict(kwargs.get("headers", {}))
+        headers["X-CSRF-Token"] = self._csrf_token
+        kwargs["headers"] = headers
+
+    def get(self, url: str, **kwargs: object) -> TestClient.response:
+        return self._inner.get(url, **kwargs)
+
+    def post(self, url: str, **kwargs: object) -> TestClient.response:
+        self._ensure_csrf()
+        self._inject_csrf(kwargs)
+        return self._inner.post(url, **kwargs)
+
+    def put(self, url: str, **kwargs: object) -> TestClient.response:
+        self._ensure_csrf()
+        self._inject_csrf(kwargs)
+        return self._inner.put(url, **kwargs)
+
+    def patch(self, url: str, **kwargs: object) -> TestClient.response:
+        self._ensure_csrf()
+        self._inject_csrf(kwargs)
+        return self._inner.patch(url, **kwargs)
+
+    def delete(self, url: str, **kwargs: object) -> TestClient.response:
+        self._ensure_csrf()
+        self._inject_csrf(kwargs)
+        return self._inner.delete(url, **kwargs)
+
+    def request(self, method: str, url: str, **kwargs: object) -> TestClient.response:
+        if method.upper() in ("POST", "PUT", "PATCH", "DELETE"):
+            self._ensure_csrf()
+            self._inject_csrf(kwargs)
+        return self._inner.request(method, url, **kwargs)
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._inner, name)
+
+
 @pytest.fixture
-def auth_headers(client):
+def csrf_client(client: TestClient):
+    """CSRF-aware test client.  Handles X-CSRF-Token automatically for
+    state-changing requests (POST / PUT / PATCH / DELETE)."""
+    return _CSRFClientWrapper(client)
+
+
+@pytest.fixture
+def auth_headers(csrf_client):
     email = f"batch-scan-{uuid4()}@example.com"
     password = "TestPass123!"
 
-    client.post(
+    # Register via csrf_client so the cookie is populated
+    csrf_client.post(
         "/api/v1/auth/register",
         json={
             "email": email,
@@ -129,31 +192,37 @@ def auth_headers(client):
         },
     )
 
-    response = client.post(
+    response = csrf_client.post(
         "/api/v1/auth/login",
         data={"username": email, "password": password},
     )
     token = response.json()["access_token"]
 
-    return {"Authorization": f"Bearer {token}"}
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-CSRF-Token": csrf_client._csrf_token,
+    }
 
 
 @pytest.fixture
-def other_user_auth_headers(client, db_session):
+def other_user_auth_headers(csrf_client, db_session):
     # Register a different user
-    client.post("/api/v1/auth/register", json={
+    csrf_client.post("/api/v1/auth/register", json={
         "email": "other@example.com",
         "password": "OtherPass123!",
         "full_name": "Other User",
         "company_name": "Other Corp",
     })
-    response = client.post(
+    response = csrf_client.post(
         "/api/v1/auth/login",
         data={"username": "other@example.com", "password": "OtherPass123!"},
         headers={"Content-Type": "application/x-www-form-urlencoded"}
     )
     token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-CSRF-Token": csrf_client._csrf_token,
+    }
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Closes #1115.

Summary of What Has Been Done:
Rebased the whitespace-trimming fix onto current upstream/main, resolving the conflict with the upstream compliance engine by keeping the upstream replace("(", "_") normalization and adding key/value whitespace stripping for questionnaire_responses.

Changes Made:
- backend/app/modules/compliance/eu_ai_act.py: trim leading/trailing whitespace from questionnaire_responses keys (via fallback strip match) and values (via explicit strip) before status lookup
- CHANGELOG.md: added fix entry under ### Fixed

Impact it Made:
Prevents spurious "missing" compliance status when users accidentally include spaces in questionnaire_responses keys or status values. Handles edge cases like {" article_9 ": " compliant "} correctly.

Note: Please assign this PR to the `tmdeveloper007` account.