### PR TITLE
fix: add session revalidation on app startup to handle expired tokens

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,11 +17,30 @@ import { Toaster } from 'react-hot-toast'
 import RagChat from './pages/RagChat'
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, isRevalidating } = useAuthStore()
+
+  if (isRevalidating) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <div className="w-8 h-8 border-4 border-primary-600 border-t-transparent rounded-full animate-spin mx-auto mb-2" />
+          <p className="text-sm text-gray-500">Verifying session...</p>
+        </div>
+      </div>
+    )
+  }
+
   return isAuthenticated ? <>{children}</> : <Navigate to="/login" />
 }
 
 function App() {
+  const { revalidateSession } = useAuthStore()
+
+  // Revalidate session on app startup to ensure token is still valid
+  useEffect(() => {
+    revalidateSession()
+  }, [revalidateSession])
+
   // ✅ Sync with system theme (only if no manual preference)
   useEffect(() => {
     const media = window.matchMedia("(prefers-color-scheme: dark)")

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -13,20 +13,50 @@ interface AuthState {
   token: string | null
   user: User | null
   isAuthenticated: boolean
+  isRevalidating: boolean
   setAuth: (token: string, user: User | null) => void
   logout: () => void
+  revalidateSession: () => Promise<void>
 }
 
 export const useAuthStore = create<AuthState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       token: null,
       user: null,
       isAuthenticated: false,
+      isRevalidating: false,
       setAuth: (token: string, user: User | null) =>
         set({ token, user, isAuthenticated: true }),
       logout: () =>
         set({ token: null, user: null, isAuthenticated: false }),
+      revalidateSession: async () => {
+        const { token } = get()
+        if (!token) {
+          set({ isAuthenticated: false, user: null })
+          return
+        }
+        set({ isRevalidating: true })
+        try {
+          const response = await fetch('/api/v1/auth/me', {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          })
+          if (response.ok) {
+            const user = await response.json()
+            set({ user, isAuthenticated: true })
+          } else {
+            // Token expired or revoked — log out
+            set({ token: null, user: null, isAuthenticated: false })
+          }
+        } catch {
+          // Network error — log out to be safe
+          set({ token: null, user: null, isAuthenticated: false })
+        } finally {
+          set({ isRevalidating: false })
+        }
+      },
     }),
     {
       name: 'auth-storage',


### PR DESCRIPTION
## Summary
Fixes #1136

Added a session revalidation mechanism that verifies token validity on app startup before restoring authenticated state.

## Root Cause
The frontend persisted auth state via Zustand `persist` middleware and restored `isAuthenticated` directly from localStorage without verifying if the token was still valid, allowing expired/revoked tokens to appear authenticated.

## Changes
- `authStore.ts`: Added `revalidateSession()` function that calls `GET /api/v1/auth/me` with the stored token. If the response is not OK, it clears auth state and logs the user out. Added `isRevalidating` state to track the check.
- `App.tsx`: Called `revalidateSession()` on app startup via `useEffect`. Added a loading spinner in `PrivateRoute` while revalidation is in progress to prevent flicker.

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the project style
- [x] I have not committed `.env` or any secrets