### PR TITLE
feat: wire notifications page to backend API

### DIFF
--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -1,20 +1,13 @@
 import { Bell, Check, Trash2 } from 'lucide-react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { notificationsApi } from '../services/api'
 
 /**
  * Notifications page — full list of in-app events.
  *
- * TODO (good first issue — static layout):
- *   - Build the static page shell with a header and a list of placeholder
- *     notification cards (icon, title, message, timestamp, read/unread dot).
- *   - No API calls needed — use hardcoded dummy data.
- *   - Acceptance criteria: page renders a list of at least 3 dummy notifications.
- *
- * TODO (help wanted — API wiring):
- *   - Replace dummy data with useQuery to GET /api/v1/notifications.
- *   - Wire the "Mark all read" button to POST /api/v1/notifications/read.
- *   - Wire individual delete buttons to DELETE /api/v1/notifications/{id}.
- *   - Acceptance criteria: after marking as read, unread count in
- *     NotificationBell updates to 0.
+ * Displays notifications fetched from the backend and allows users
+ * to mark notifications as read or delete them. Notification state
+ * is synchronized with NotificationBell via React Query cache updates.
  */
 
 interface Notification {
@@ -26,38 +19,39 @@ interface Notification {
   created_at: string
 }
 
-// TODO (help wanted): implement this API service object
-// const notificationsApi = {
-//   list: () => axios.get('/api/v1/notifications').then(r => r.data),
-//   markRead: (ids: number[]) => axios.post('/api/v1/notifications/read', { ids }),
-//   delete: (id: number) => axios.delete(`/api/v1/notifications/${id}`),
-// }
-
-const DUMMY_NOTIFICATIONS: Notification[] = [
-  {
-    id: 1,
-    notification_type: 'system_classified',
-    title: 'AI system classified',
-    message: 'CV Screening AI was classified as High Risk under the EU AI Act.',
-    is_read: false,
-    created_at: new Date().toISOString(),
-  },
-  {
-    id: 2,
-    notification_type: 'document_generated',
-    title: 'Document generated',
-    message: 'Technical Documentation for CV Screening AI is ready to review.',
-    is_read: true,
-    created_at: new Date().toISOString(),
-  },
-]
 
 export default function Notifications() {
 
-  // TODO (help wanted): replace dummy data with real query
+  const queryClient = useQueryClient()
 
-  // const { data: notifications = [] } = useQuery({ queryKey: ['notifications'], queryFn: notificationsApi.list })
-  const notifications = DUMMY_NOTIFICATIONS
+  const { data: notifications = [], isLoading } = useQuery({
+    queryKey: ['notifications'],
+    queryFn: () => notificationsApi.list(false),
+  })
+
+  const markAllReadMutation = useMutation({
+  mutationFn: () => notificationsApi.markAllRead(),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ['notifications'] })
+    queryClient.invalidateQueries({ queryKey: ['notifications', 'unread'] })
+  },
+})
+
+const deleteMutation = useMutation({
+  mutationFn: (id: number) => notificationsApi.delete(id),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ['notifications'] })
+    queryClient.invalidateQueries({ queryKey: ['notifications', 'unread'] })
+  },
+})
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <p className="text-gray-500">Loading notifications...</p>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-6">
@@ -68,7 +62,8 @@ export default function Notifications() {
           <p className="text-gray-600">Your recent compliance and system events</p>
         </div>
         {/* TODO (help wanted): wire to POST /notifications/read with all unread IDs */}
-        <button className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg border border-gray-200">
+        <button onClick={() => markAllReadMutation.mutate()}
+        className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg border border-gray-200">
           <Check className="w-4 h-4" />
           Mark all read
         </button>
@@ -83,7 +78,7 @@ export default function Notifications() {
         </div>
       ) : (
         <div className="space-y-2">
-          {notifications.map((n) => (
+          {notifications.map((n: Notification) => (
             <div
               key={n.id}
               className={`bg-white rounded-xl border p-4 flex items-start gap-4 ${
@@ -103,7 +98,7 @@ export default function Notifications() {
                 </p>
               </div>
               {/* TODO (help wanted): wire to DELETE /notifications/{id} */}
-              <button className="p-1 text-gray-400 hover:text-red-500 rounded">
+                <button onClick={() => deleteMutation.mutate(n.id)} className="p-1 text-gray-400 hover:text-red-500 rounded">
                 <Trash2 className="w-4 h-4" />
               </button>
             </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -287,9 +287,18 @@ export const documentsApi = {
 // Notifications API
 export const notificationsApi = {
   list: (unreadOnly = false) =>
-    api.get(`/notifications?unread_only=${unreadOnly}`).then((r: AxiosResponse) => r.data.items),
+    api
+      .get(`/notifications?unread_only=${unreadOnly}`)
+      .then((r: AxiosResponse) => r.data.items),
+
   markRead: (ids: number[]) =>
     api.post('/notifications/read', { ids }),
+
+  markAllRead: () =>
+    api.post('/notifications/read-all'),
+
+  delete: (id: number) =>
+    api.delete(`/notifications/${id}`),
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #486 

Wires the Notifications page to the backend notifications API using React Query. Replaces hardcoded placeholder data with live notifications, adds loading states, and connects the "Mark all read" and delete actions to the existing backend endpoints. Query invalidation keeps the NotificationBell unread count synchronized after notification updates.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [ ] I have added/updated tests where relevant
* [ ] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [ ] I have updated documentation if needed

## Screenshots (if UI change)

N/A

