### PR TITLE
Sanitize AI system text inputs

### DIFF
--- a/backend/app/schemas/ai_system.py
+++ b/backend/app/schemas/ai_system.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Optional, Dict, Any, List
 from datetime import datetime
 from app.models.ai_system import RiskLevel, ComplianceStatus
@@ -10,6 +10,12 @@ class AISystemCreate(BaseModel):
     version: Optional[str] = None
     use_case: Optional[str] = None
     sector: Optional[str] = None
+    @field_validator("name", "description", "version", "use_case", "sector")
+    @classmethod
+    def strip_text_fields(cls, v: str | None) -> str | None:
+        if isinstance(v, str):
+            return v.strip()
+        return v
 
 
 class AISystemUpdate(BaseModel):
@@ -19,6 +25,12 @@ class AISystemUpdate(BaseModel):
     use_case: Optional[str] = None
     sector: Optional[str] = None
     questionnaire_responses: Optional[Dict[str, Any]] = None
+    @field_validator("name", "description", "version", "use_case", "sector")
+    @classmethod
+    def strip_text_fields(cls, v: str | None) -> str | None:
+        if isinstance(v, str):
+            return v.strip()
+        return v
 
 
 class AISystemResponse(BaseModel):


### PR DESCRIPTION
## Summary

Closes #1104 

Adds input sanitization for AI system text fields by trimming leading and trailing whitespace during schema validation. This applies to both `AISystemCreate` and `AISystemUpdate` schemas, helping ensure cleaner and more consistent data before it is persisted.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [ ] Tests
* [ ] Infra / CI

## Checklist

* [x] I have read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] My code follows the project style (PEP 8 for Python, ESLint for TS)
* [ ] I have added/updated tests where relevant
* [ ] `pytest backend/tests/` passes locally
* [x] I have not committed `.env` or any secrets
* [ ] I have updated documentation if needed

## Screenshots (if UI change)

N/A – Backend schema validation change only.