### PR TITLE
fix : replaced datetime.utcnow() with datetime.now(timezone.utc) in GuardScanLog

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -158,7 +158,7 @@ def _build_guard_scan_log(user_id: int, prompt: str, result: dict, ip_address: s
         ml_confidence=intent_analysis.get("confidence", 0.0),
         combined_score=decision_reasoning.get("confidence", 0.0),
         prompt_length=len(prompt),
-        scanned_at=datetime.utcnow(),
+        scanned_at=datetime.now(timezone.utc),
         ip_address=ip_address,
     )
 

--- a/backend/app/models/guard_scan_log.py
+++ b/backend/app/models/guard_scan_log.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 Prompts are stored as SHA-256 hashes only — never raw text — to protect user privacy.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey, JSON, Boolean
 from sqlalchemy.orm import relationship
@@ -33,9 +33,9 @@ class GuardScanLog(Base):
     ml_confidence = Column(Float, default=0.0, nullable=False)
     combined_score = Column(Float, default=0.0, nullable=False)
     prompt_length = Column(Integer, nullable=True)
-    scanned_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    scanned_at = Column(DateTime, default=datetime.now(timezone.utc), nullable=False, index=True)
     ip_address = Column(String(45), nullable=True)
 
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime, default=datetime.now(timezone.utc), nullable=False)
 
     user = relationship("User")


### PR DESCRIPTION
Closes #1207.

Summary of What Has Been Done:
Replaced naive datetime.utcnow() with timezone-aware datetime.now(timezone.utc) in the GuardScanLog model (scanned_at and created_at defaults) and in the _build_guard_scan_log function in guard.py. This fixes the PostgreSQL crash when cursor pagination compares a timezone-aware datetime (produced by cursor decode) against the naive database column.

Changes Made:
- backend/app/models/guard_scan_log.py: Changed datetime import to include timezone; updated scanned_at and created_at defaults to use datetime.now(timezone.utc)
- backend/app/api/v1/guard.py: Updated scanned_at=datetime.utcnow() to scanned_at=datetime.now(timezone.utc)

Impact it Made:
- Fixes PostgreSQL 'cannot compare timestamp without time zone with timestamp with time zone' crash
- Consistent timezone-aware timestamps in GuardScanLog
- Follows the same pattern as the already-merged PR #1170 (datetime fix in guard.py)

Note: Please assign this PR to the `tmdeveloper007` account.