### PR TITLE
fix : prevented 401 race condition with promise-based handler queue

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -4,8 +4,9 @@ import { useAuthStore } from '../stores/authStore'
 const configuredApiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim()
 const API_BASE_URL = configuredApiBaseUrl ? configuredApiBaseUrl.replace(/\/$/, '') : '/api/v1'
 
-// Tracks whether the global 401-response handler is currently executing.
-let isUnauthorizedHandlerRunning = false
+// Promise that resolves when the current 401 handler finishes.  Concurrent
+// 401 responses wait on this promise instead of being silently dropped.
+let unauthorizedHandlerPromise: Promise<void> | null = null
 
 function buildApiUrl(path: string): string {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
@@ -46,25 +47,29 @@ api.interceptors.response.use(
     const isAuthEndpoint = AUTH_ENDPOINTS.some((endpoint) => url.includes(endpoint))
     const isUnAuthorized = error.response?.status === 401 && !isAuthEndpoint
 
-    if (isUnAuthorized && !isUnauthorizedHandlerRunning) {
-
-      // Block concurrent 401 responses from entering the unauthorized handler.
-      isUnauthorizedHandlerRunning = true
-
-      // Logout and navigate to login without forcing a full page reload.
-      useAuthStore.getState().logout()
-      try {
-        window.history.pushState({}, '', '/login')
-        // Notify router listeners (e.g., react-router) to handle navigation.
-        window.dispatchEvent(new PopStateEvent('popstate'))
-      } catch (e) {
-        // Fallback: if SPA navigation fails, perform a safe replace.
-        window.location.replace('/login')
+    if (isUnAuthorized) {
+      // If a logout handler is already running, chain onto it so concurrent
+      // 401s wait for the navigation to complete rather than being dropped.
+      if (unauthorizedHandlerPromise !== null) {
+        return unauthorizedHandlerPromise.then(() => Promise.reject(error))
       }
-      finally {
-        // Allow future unauthorized responses after current logout/navigation flow has finished.
-        isUnauthorizedHandlerRunning = false
-      }
+
+      unauthorizedHandlerPromise = (async () => {
+        // Logout and navigate to login without forcing a full page reload.
+        useAuthStore.getState().logout()
+        try {
+          window.history.pushState({}, '', '/login')
+          // Notify router listeners (e.g., react-router) to handle navigation.
+          window.dispatchEvent(new PopStateEvent('popstate'))
+        } catch (e) {
+          // Fallback: if SPA navigation fails, perform a safe replace.
+          window.location.replace('/login')
+        }
+      })().finally(() => {
+        unauthorizedHandlerPromise = null
+      })
+
+      return unauthorizedHandlerPromise.then(() => Promise.reject(error))
     }
     return Promise.reject(error)
   }


### PR DESCRIPTION
Closes #1209.

Summary of What Has Been Done:
Replaced the boolean isUnauthorizedHandlerRunning guard with a promise-based queue. When a 401 response arrives while a logout is in flight, the handler chains onto the running promise instead of skipping the logout. All concurrent 401s now properly wait for the navigation to complete before being rejected.

Changes Made:
- frontend/src/services/api.ts: Replaced boolean guard with unauthorizedHandlerPromise (Promise<void> | null). Concurrent 401s chain onto the running logout promise and reject only after navigation completes.

Impact it Made:
- No more silent request drops during concurrent 401 handling
- Consistent auth state: all concurrent 401s resolve after logout completes
- Race condition eliminated under concurrent request load

Note: Please assign this PR to the `tmdeveloper007` account.