### PR TITLE
fix : used VITE_API_BASE_URL in AISystems export via axios client

### DIFF
--- a/frontend/src/pages/AISystems.tsx
+++ b/frontend/src/pages/AISystems.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import {
  useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { aiSystemsApi } from '../services/api'
+import { aiSystemsApi, api } from '../services/api'
 import { useAuthStore } from '../stores/authStore'
 import { Bot, Plus, Trash2, Edit, Search, Filter, ArrowUpDown, X, Download } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
@@ -42,11 +42,10 @@ export default function AISystems() {
       // Guarantee the loading state is visible for at least 1 second
       const minDelay = new Promise((r) => setTimeout(r, 1000))
       const fetchExport = async () => {
-        const token = useAuthStore.getState().token
-        const response = await fetch('/api/v1/ai-systems/export', {
-          headers: { Authorization: `Bearer ${token}` },
+        const response = await api.get('/ai-systems/export', {
+          responseType: 'blob',
         })
-        return response.blob()
+        return response.data
       }
       const [blob] = await Promise.all([fetchExport(), minDelay])
       const url = URL.createObjectURL(blob)

--- a/frontend/src/pages/AISystems.tsx
+++ b/frontend/src/pages/AISystems.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import {
  useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { aiSystemsApi, api } from '../services/api'
-import { useAuthStore } from '../stores/authStore'
 import { Bot, Plus, Trash2, Edit, Search, Filter, ArrowUpDown, X, Download } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 

--- a/frontend/src/pages/AISystems.tsx
+++ b/frontend/src/pages/AISystems.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import {
  useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { aiSystemsApi, api } from '../services/api'
+import api, { aiSystemsApi } from '../services/api'
 import { Bot, Plus, Trash2, Edit, Search, Filter, ArrowUpDown, X, Download } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 


### PR DESCRIPTION
Closes #1210.

Summary of What Has Been Done:
Replaced the raw fetch('/api/v1/ai-systems/export') call in the handleExport function with the configured api axios client. The api client respects VITE_API_BASE_URL, so the export feature now works correctly in all deployment configurations.

Changes Made:
- frontend/src/pages/AISystems.tsx: Added 'api' to the services/api import; replaced fetch() with api.get('/ai-systems/export', { responseType: 'blob' })

Impact it Made:
- Export feature now respects VITE_API_BASE_URL environment variable
- Consistent API URL handling across the entire application
- Fixes export failures in deployments with custom API base paths

Note: Please assign this PR to the `tmdeveloper007` account.