### PR TITLE
fix : replaced datetime.utcnow() with datetime.now(timezone.utc) in analytics

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -22,7 +22,7 @@ from app.models.user import User
 from app.schemas.analytics import ComplianceTimelineResponse
 from app.models.compliance_snapshot import ComplianceSnapshot
 from sqlalchemy import func
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import Query
@@ -53,7 +53,7 @@ def get_compliance_timeline(
             detail="AI system not found"
         )
 
-    since = datetime.utcnow() - timedelta(days=days)
+    since = datetime.now(timezone.utc) - timedelta(days=days)
 
     snapshots = db.query(ComplianceSnapshot).filter(
         ComplianceSnapshot.ai_system_id == system_id,
@@ -156,7 +156,7 @@ def get_audit_logs(
     if decision:
         filters.append(GuardScanLog.decision == decision)
     if days:
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         filters.append(GuardScanLog.scanned_at >= since)
 
     base_query = db.query(GuardScanLog).filter(*filters)


### PR DESCRIPTION
Closes #1211.

Summary of What Has Been Done:
Replaced naive datetime.utcnow() with timezone-aware datetime.now(timezone.utc) in both locations in analytics.py where 'since' is computed for filtering. This fixes PostgreSQL comparison failures when filtering by time against timezone-aware columns.

Changes Made:
- backend/app/api/v1/analytics.py: Added timezone to datetime import; replaced both datetime.utcnow() occurrences with datetime.now(timezone.utc)

Impact it Made:
- Fixes PostgreSQL 'cannot compare timestamp without time zone' errors in analytics endpoints
- Consistent timezone-aware datetime handling in analytics
- Follows the same fix pattern as the GuardScanLog datetime fix

Note: Please assign this PR to the `tmdeveloper007` account.