### PR TITLE
fix : removed raw user_prompt from LLMGuard.guard() result dict

### DIFF
--- a/backend/app/modules/guard/llm_guard.py
+++ b/backend/app/modules/guard/llm_guard.py
@@ -95,7 +95,6 @@ class LLMGuard:
 
         result = {
             "timestamp": timestamp,
-            "user_prompt": user_prompt,
             "normalized_prompt": normalized_prompt,
             "decision": None,
             "response": None,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.pool import StaticPool
 from fastapi import Request, HTTPException, status
 from fastapi.testclient import TestClient
+from starlette.responses import Response
 
 # Set test database before importing app
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"
@@ -137,30 +138,30 @@ class _CSRFClientWrapper:
         headers["X-CSRF-Token"] = self._csrf_token
         kwargs["headers"] = headers
 
-    def get(self, url: str, **kwargs: object) -> TestClient.response:
+    def get(self, url: str, **kwargs: object) -> Response:
         return self._inner.get(url, **kwargs)
 
-    def post(self, url: str, **kwargs: object) -> TestClient.response:
+    def post(self, url: str, **kwargs: object) -> Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.post(url, **kwargs)
 
-    def put(self, url: str, **kwargs: object) -> TestClient.response:
+    def put(self, url: str, **kwargs: object) -> Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.put(url, **kwargs)
 
-    def patch(self, url: str, **kwargs: object) -> TestClient.response:
+    def patch(self, url: str, **kwargs: object) -> Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.patch(url, **kwargs)
 
-    def delete(self, url: str, **kwargs: object) -> TestClient.response:
+    def delete(self, url: str, **kwargs: object) -> Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.delete(url, **kwargs)
 
-    def request(self, method: str, url: str, **kwargs: object) -> TestClient.response:
+    def request(self, method: str, url: str, **kwargs: object) -> Response:
         if method.upper() in ("POST", "PUT", "PATCH", "DELETE"):
             self._ensure_csrf()
             self._inject_csrf(kwargs)


### PR DESCRIPTION
Closes #1219.

Summary of What Has Been Done:
Removed the plaintext user_prompt field from the result dictionary returned by LLMGuard.guard() in backend/app/modules/guard/llm_guard.py. The raw prompt was being exposed in API responses (e.g., GuardTestResponse) despite the design intent being hash-only storage.

Changes Made:
- backend/app/modules/guard/llm_guard.py: Removed "user_prompt": user_prompt from the result dict. The prompt remains available as a function parameter for local use (normalization, length calculation) but is no longer leaked into API responses.

Impact it Made:
- Eliminates plaintext prompt exposure in GuardTestResponse and other API responses
- Aligns implementation with the documented hash-only storage design
- No downstream code relies on result.user_prompt — all callers use the separate prompt argument

Note: Please assign this PR to the `tmdeveloper007` account.