### PR TITLE
fix : prevent GuardScanLog IntegrityError and fix conftest.py TestClient.response

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -189,8 +189,6 @@ def log_scan(user_id: int, prompt: str, result: dict, ip_address: str | None = N
             except Exception:
                 db.rollback()
                 logger.warning("Failed to create block notification for scan %d", log.id)
-                db.add(log)
-                db.commit()
 
     except Exception:
         db.rollback()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.pool import StaticPool
 from fastapi import Request, HTTPException, status
 from fastapi.testclient import TestClient
+from starlette.responses import Response
 
 # Set test database before importing app
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"
@@ -137,30 +138,30 @@ class _CSRFClientWrapper:
         headers["X-CSRF-Token"] = self._csrf_token
         kwargs["headers"] = headers
 
-    def get(self, url: str, **kwargs: object) -> TestClient.response:
+    def get(self, url: str, **kwargs: object) -> Response:
         return self._inner.get(url, **kwargs)
 
-    def post(self, url: str, **kwargs: object) -> TestClient.response:
+    def post(self, url: str, **kwargs: object) -> Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.post(url, **kwargs)
 
-    def put(self, url: str, **kwargs: object) -> TestClient.response:
+    def put(self, url: str, **kwargs: object) -> Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.put(url, **kwargs)
 
-    def patch(self, url: str, **kwargs: object) -> TestClient.response:
+    def patch(self, url: str, **kwargs: object) -> Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.patch(url, **kwargs)
 
-    def delete(self, url: str, **kwargs: object) -> TestClient.response:
+    def delete(self, url: str, **kwargs: object) -> Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.delete(url, **kwargs)
 
-    def request(self, method: str, url: str, **kwargs: object) -> TestClient.response:
+    def request(self, method: str, url: str, **kwargs: object) -> Response:
         if method.upper() in ("POST", "PUT", "PATCH", "DELETE"):
             self._ensure_csrf()
             self._inject_csrf(kwargs)


### PR DESCRIPTION
Closes #1220.

Summary of What Has Been Done:
Fixed two related issues in backend/app/api/v1/guard.py log_scan():
1. Removed the redundant db.add(log) + db.commit() after db.rollback() in the create_notification error handler. The log entry was already committed before create_notification was called, so re-committing it after rollback could cause IntegrityError.
2. Cherry-picked the conftest.py TestClient.response -> Response fix which was blocking pytest from importing the test suite.

Changes Made:
- backend/app/api/v1/guard.py: Removed redundant db.add(log) + db.commit() after rollback; the committed log is safe and does not need re-committing.
- backend/tests/conftest.py: Changed _CSRFClientWrapper return types from TestClient.response to starlette.responses.Response.

Impact it Made:
- Guard scan logs are no longer silently lost when create_notification fails
- conftest.py pytest import error is resolved

Note: Please assign this PR to the `tmdeveloper007` account.