### PR TITLE
Fix paginated list response handling

### DIFF
--- a/backend/tests/test_frontend_empty_api_fallbacks.py
+++ b/backend/tests/test_frontend_empty_api_fallbacks.py
@@ -13,6 +13,7 @@ def test_api_service_rejects_empty_list_payloads():
 
     assert "function ensureListResponse" in source
     assert "response was empty or invalid." in source
+    assert "Array.isArray(data.items)" in source
     assert "return ensureListResponse(data, 'AI systems')" in source
     assert "return ensureListResponse(data, 'Documents')" in source
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -93,6 +93,10 @@ function ensureListResponse<T>(
     return data as T[]
   }
 
+  if (isRecord(data) && Array.isArray(data.items)) {
+    return data.items as T[]
+  }
+
   throw new Error(`${resourceName} response was empty or invalid.`)
 }
 


### PR DESCRIPTION
## Summary

- accept paginated `{ items, total, skip, limit }` responses in the shared list response helper
- keep existing array response support for compatibility
- update the frontend API fallback regression test to cover paginated `items`

## Root cause

The AI Systems and Documents endpoints return paginated response objects, while the frontend list helper only accepted raw arrays. Valid API responses were rejected before page components could render their data.

## Validation

- `npm run build`

Closes #1228