### PR TITLE
Fix analytics summary loading

### DIFF
--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { formatLastUpdated } from "../utils/date";
+import { analyticsApi } from "../services/api";
 
 import ComplianceRiskChart from "../components/ComplianceRiskChart";
 
@@ -24,57 +25,23 @@ import {
   Legend,
 } from "recharts";
 
-const lineChartData = [
-  { name: "Jan", score: 65 },
-  { name: "Feb", score: 72 },
-  { name: "Mar", score: 68 },
-  { name: "Apr", score: 85 },
-  { name: "May", score: 82 },
-  { name: "Jun", score: 90 },
-];
-
-const barChartData = [
-  { name: "System A", risk: 45 },
-  { name: "System B", risk: 80 },
-  { name: "System C", risk: 30 },
-  { name: "System D", risk: 65 },
-  { name: "System E", risk: 20 },
-];
-
-const summaryStats = [
-  {
-    label: "Total Systems",
-    value: "12",
-    icon: Activity,
-    color: "text-blue-600 dark:text-blue-400",
-    bg: "bg-blue-50 dark:bg-blue-500/10",
-  },
-  {
-    label: "Avg Score",
-    value: "84%",
-    icon: TrendingUp,
-    color: "text-green-600 dark:text-green-400",
-    bg: "bg-green-50 dark:bg-green-500/10",
-  },
-  {
-    label: "Compliant",
-    value: "10",
-    icon: ShieldCheck,
-    color: "text-emerald-600 dark:text-emerald-400",
-    bg: "bg-emerald-50 dark:bg-emerald-500/10",
-  },
-  {
-    label: "High Risk",
-    value: "2",
-    icon: AlertTriangle,
-    color: "text-red-600 dark:text-red-400",
-    bg: "bg-red-50 dark:bg-red-500/10",
-  },
-];
-
 type RiskData = {
   name: string;
   value: number;
+};
+
+type AnalyticsSummary = {
+  total_systems: number;
+  average_compliance_score: number;
+  counts: Record<string, number>;
+  compliance_statuses: Record<string, number>;
+};
+
+const emptySummary: AnalyticsSummary = {
+  total_systems: 0,
+  average_compliance_score: 0,
+  counts: {},
+  compliance_statuses: {},
 };
 
 const chartThemes = {
@@ -104,13 +71,15 @@ const getChartTheme = (isDark: boolean) =>
   isDark ? chartThemes.dark : chartThemes.light;
 
 export default function Analytics() {
+  const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
   const [riskPieData, setRiskPieData] = useState<RiskData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
   const [isDark, setIsDark] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
   useEffect(() => {
-    fetchRiskDistribution();
+    fetchAnalyticsSummary();
   }, []);
 
   useEffect(() => {
@@ -132,40 +101,77 @@ export default function Analytics() {
   const chartTheme = getChartTheme(isDark);
   const chartRemountKey = isDark ? "dark" : "light";
 
-  const fetchRiskDistribution = async () => {
+  const fetchAnalyticsSummary = async () => {
     try {
-      const res = await fetch("/api/v1/analytics/summary");
+      setLoading(true);
+      setLoadError("");
+      const json = await analyticsApi.summary();
+      const nextSummary = {
+        ...emptySummary,
+        ...json,
+        counts: json.counts ?? {},
+        compliance_statuses: json.compliance_statuses ?? {},
+      };
+      const mapped: RiskData[] = [
+        { name: "Minimal Risk", value: nextSummary.counts.minimal || 0 },
+        { name: "Limited Risk", value: nextSummary.counts.limited || 0 },
+        { name: "High Risk", value: nextSummary.counts.high || 0 },
+        { name: "Unacceptable Risk", value: nextSummary.counts.unacceptable || 0 },
+      ];
 
-      if (res.ok) {
-        const json = await res.json();
-        const mapped: RiskData[] = [
-          { name: "Minimal Risk", value: json.counts?.minimal || 0 },
-          { name: "Limited Risk", value: json.counts?.limited || 0 },
-          { name: "High Risk", value: json.counts?.high || 0 },
-          { name: "Unacceptable Risk", value: json.counts?.unacceptable || 0 },
-        ];
-
-        setRiskPieData(mapped);
-      } else {
-        setRiskPieData([
-          { name: "Minimal Risk", value: 4 },
-          { name: "Limited Risk", value: 3 },
-          { name: "High Risk", value: 2 },
-          { name: "Unacceptable Risk", value: 1 },
-        ]);
-      }
-    } catch {
-      setRiskPieData([
-        { name: "Minimal Risk", value: 4 },
-        { name: "Limited Risk", value: 3 },
-        { name: "High Risk", value: 2 },
-        { name: "Unacceptable Risk", value: 1 },
-      ]);
+      setSummary(nextSummary);
+      setRiskPieData(mapped);
+    } catch (error) {
+      setSummary(null);
+      setRiskPieData([]);
+      setLoadError(
+        error instanceof Error
+          ? error.message
+          : "Unable to load analytics summary."
+      );
     } finally {
       setLoading(false);
       setLastUpdated(new Date());
     }
   };
+
+  const activeSummary = summary ?? emptySummary;
+  const averageScore = Number(activeSummary.average_compliance_score || 0);
+  const summaryStats = [
+    {
+      label: "Total Systems",
+      value: String(activeSummary.total_systems || 0),
+      icon: Activity,
+      color: "text-blue-600 dark:text-blue-400",
+      bg: "bg-blue-50 dark:bg-blue-500/10",
+    },
+    {
+      label: "Avg Score",
+      value: `${averageScore.toFixed(0)}%`,
+      icon: TrendingUp,
+      color: "text-green-600 dark:text-green-400",
+      bg: "bg-green-50 dark:bg-green-500/10",
+    },
+    {
+      label: "Compliant",
+      value: String(activeSummary.compliance_statuses.compliant || 0),
+      icon: ShieldCheck,
+      color: "text-emerald-600 dark:text-emerald-400",
+      bg: "bg-emerald-50 dark:bg-emerald-500/10",
+    },
+    {
+      label: "High Risk",
+      value: String(activeSummary.counts.high || 0),
+      icon: AlertTriangle,
+      color: "text-red-600 dark:text-red-400",
+      bg: "bg-red-50 dark:bg-red-500/10",
+    },
+  ];
+  const scoreChartData = [{ name: "Current", score: averageScore }];
+  const riskBarData = riskPieData.map((item) => ({
+    name: item.name.replace(" Risk", ""),
+    risk: item.value,
+  }));
 
   return (
     <div className="space-y-8">
@@ -203,7 +209,7 @@ export default function Analytics() {
           <div className="flex items-center gap-2 mb-6">
             <TrendingUp className="w-5 h-5 text-primary-600" />
             <h2 className="font-semibold text-gray-900 dark:text-white">
-              Compliance Score Timeline
+              Compliance Score Snapshot
             </h2>
           </div>
 
@@ -213,7 +219,7 @@ export default function Analytics() {
               width="100%"
               height="100%"
             >
-              <LineChart data={lineChartData}>
+              <LineChart data={scoreChartData}>
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={chartTheme.grid} />
                 <XAxis
                   dataKey="name"
@@ -253,7 +259,7 @@ export default function Analytics() {
           <div className="flex items-center gap-2 mb-6">
             <BarChart2 className="w-5 h-5 text-primary-600" />
             <h2 className="font-semibold text-gray-900 dark:text-white">
-              Risk Distribution by System
+              Risk Distribution
             </h2>
           </div>
 
@@ -263,7 +269,7 @@ export default function Analytics() {
               width="100%"
               height="100%"
             >
-              <BarChart data={barChartData}>
+              <BarChart data={riskBarData}>
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={chartTheme.grid} />
                 <XAxis
                   dataKey="name"
@@ -303,6 +309,10 @@ export default function Analytics() {
         <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm h-80 flex items-center justify-center text-gray-500 dark:text-gray-400">
           Loading risk distribution...
         </div>
+      ) : loadError ? (
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-red-200 dark:border-red-900/50 p-6 shadow-sm h-80 flex items-center justify-center text-red-600 dark:text-red-400">
+          {loadError}
+        </div>
       ) : riskPieData.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 shadow-sm h-80 flex items-center justify-center text-gray-500 dark:text-gray-400">
           No analytics data available.
@@ -313,4 +323,3 @@ export default function Analytics() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary

- load analytics data through the shared API client
- render summary cards and risk charts from the backend summary response
- show an error state instead of replacing failed requests with fallback data

## Root cause

The Analytics page was calling `/api/v1/analytics/summary` directly and still rendered hardcoded/fallback values. That bypassed the configured API base URL and could show misleading analytics when the request failed.

## Validation

- `npm run build`

Closes #1230