### PR TITLE
Fix notification API contract

### DIFF
--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -4,15 +4,13 @@ import { Bell, Clock, X } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { notificationsApi } from '../services/api'
 
-// TODO: Wire to GET /api/v1/notifications via useQuery (Issue #113)
-
 interface NotificationPreview {
   id: number
+  notification_type: string
   title: string
   message: string
   is_read: boolean
   created_at: string               // ISO‑8601 date string
-  type: 'alert' | 'update' | 'ai' | 'news'
 }
 
 
@@ -31,12 +29,19 @@ function timeAgo(isoDate: string): string {
 }
 
 /** Accent colour for the notification type stripe. */
-function typeColor(type: NotificationPreview['type']): string {
-  switch (type) {
-    case 'alert':  return 'bg-red-500'
-    case 'update': return 'bg-green-500'
-    case 'ai':     return 'bg-purple-500'
-    case 'news':   return 'bg-primary-500'
+function typeColor(notificationType: string): string {
+  switch (notificationType) {
+    case 'guard_block':
+    case 'compliance_drift':
+      return 'bg-red-500'
+    case 'document_generated':
+      return 'bg-green-500'
+    case 'system_classified':
+      return 'bg-purple-500'
+    case 'reassessment_due':
+      return 'bg-amber-500'
+    default:
+      return 'bg-primary-500'
   }
 }
 
@@ -182,7 +187,7 @@ export default function NotificationBell() {
 
                 <div
                   className={`w-1 self-stretch rounded-full flex-shrink-0 ${typeColor(
-                    notification.type,
+                    notification.notification_type,
                   )}`}
                 />
 

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -1,21 +1,6 @@
 import { Bell, Check, Trash2 } from 'lucide-react'
-
-/**
- * Notifications page — full list of in-app events.
- *
- * TODO (good first issue — static layout):
- *   - Build the static page shell with a header and a list of placeholder
- *     notification cards (icon, title, message, timestamp, read/unread dot).
- *   - No API calls needed — use hardcoded dummy data.
- *   - Acceptance criteria: page renders a list of at least 3 dummy notifications.
- *
- * TODO (help wanted — API wiring):
- *   - Replace dummy data with useQuery to GET /api/v1/notifications.
- *   - Wire the "Mark all read" button to POST /api/v1/notifications/read.
- *   - Wire individual delete buttons to DELETE /api/v1/notifications/{id}.
- *   - Acceptance criteria: after marking as read, unread count in
- *     NotificationBell updates to 0.
- */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { notificationsApi } from '../services/api'
 
 interface Notification {
   id: number
@@ -26,56 +11,76 @@ interface Notification {
   created_at: string
 }
 
-// TODO (help wanted): implement this API service object
-// const notificationsApi = {
-//   list: () => axios.get('/api/v1/notifications').then(r => r.data),
-//   markRead: (ids: number[]) => axios.post('/api/v1/notifications/read', { ids }),
-//   delete: (id: number) => axios.delete(`/api/v1/notifications/${id}`),
-// }
-
-const DUMMY_NOTIFICATIONS: Notification[] = [
-  {
-    id: 1,
-    notification_type: 'system_classified',
-    title: 'AI system classified',
-    message: 'CV Screening AI was classified as High Risk under the EU AI Act.',
-    is_read: false,
-    created_at: new Date().toISOString(),
-  },
-  {
-    id: 2,
-    notification_type: 'document_generated',
-    title: 'Document generated',
-    message: 'Technical Documentation for CV Screening AI is ready to review.',
-    is_read: true,
-    created_at: new Date().toISOString(),
-  },
-]
-
 export default function Notifications() {
+  const queryClient = useQueryClient()
+  const {
+    data: notifications = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['notifications'],
+    queryFn: async () => notificationsApi.list(false) as Promise<Notification[]>,
+  })
 
-  // TODO (help wanted): replace dummy data with real query
+  const invalidateNotifications = () => {
+    queryClient.invalidateQueries({ queryKey: ['notifications'] })
+    queryClient.invalidateQueries({ queryKey: ['notifications', 'unread'] })
+  }
 
-  // const { data: notifications = [] } = useQuery({ queryKey: ['notifications'], queryFn: notificationsApi.list })
-  const notifications = DUMMY_NOTIFICATIONS
+  const markAllReadMutation = useMutation({
+    mutationFn: notificationsApi.markAllRead,
+    onSuccess: invalidateNotifications,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: notificationsApi.delete,
+    onSuccess: invalidateNotifications,
+  })
+
+  const unreadCount = notifications.filter((n) => !n.is_read).length
 
   return (
     <div className="space-y-6">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Notifications</h1>
           <p className="text-gray-600">Your recent compliance and system events</p>
         </div>
-        {/* TODO (help wanted): wire to POST /notifications/read with all unread IDs */}
-        <button className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg border border-gray-200">
+        <button
+          type="button"
+          onClick={() => markAllReadMutation.mutate()}
+          disabled={unreadCount === 0 || markAllReadMutation.isPending}
+          className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg border border-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
           <Check className="w-4 h-4" />
-          Mark all read
+          {markAllReadMutation.isPending ? 'Marking...' : 'Mark all read'}
         </button>
       </div>
 
-      {/* Notification list */}
-      {notifications.length === 0 ? (
+      {isLoading ? (
+        <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
+          <Bell className="w-16 h-16 mx-auto mb-4 text-gray-300" />
+          <h3 className="text-lg font-medium text-gray-900">Loading notifications</h3>
+          <p className="text-gray-500 mt-1">Checking your recent events.</p>
+        </div>
+      ) : isError ? (
+        <div className="text-center py-12 bg-white rounded-xl border border-red-200">
+          <Bell className="w-16 h-16 mx-auto mb-4 text-red-200" />
+          <h3 className="text-lg font-medium text-gray-900">Unable to load notifications</h3>
+          <p className="text-gray-500 mt-1">
+            {error instanceof Error ? error.message : 'Please try again.'}
+          </p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="mt-4 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700"
+          >
+            Retry
+          </button>
+        </div>
+      ) : notifications.length === 0 ? (
         <div className="text-center py-12 bg-white rounded-xl border border-gray-200">
           <Bell className="w-16 h-16 mx-auto mb-4 text-gray-300" />
           <h3 className="text-lg font-medium text-gray-900">No notifications</h3>
@@ -102,8 +107,13 @@ export default function Notifications() {
                   {new Date(n.created_at).toLocaleString()}
                 </p>
               </div>
-              {/* TODO (help wanted): wire to DELETE /notifications/{id} */}
-              <button className="p-1 text-gray-400 hover:text-red-500 rounded">
+              <button
+                type="button"
+                onClick={() => deleteMutation.mutate(n.id)}
+                disabled={deleteMutation.isPending}
+                className="p-1 text-gray-400 hover:text-red-500 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label={`Delete notification: ${n.title}`}
+              >
                 <Trash2 className="w-4 h-4" />
               </button>
             </div>
@@ -113,4 +123,3 @@ export default function Notifications() {
     </div>
   )
 }
-

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -290,6 +290,10 @@ export const notificationsApi = {
     api.get(`/notifications?unread_only=${unreadOnly}`).then((r: AxiosResponse) => r.data.items),
   markRead: (ids: number[]) =>
     api.post('/notifications/read', { ids }),
+  markAllRead: () =>
+    api.post('/notifications/read-all'),
+  delete: (id: number) =>
+    api.delete(`/notifications/${id}`),
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- use `notification_type` from the backend response in the notification bell
- map backend notification types to the existing accent stripe colors
- load real notifications on the notifications page and wire mark-all-read/delete actions

## Root cause

The notification bell expected a frontend-only `type` value, while the backend returns `notification_type`. The full notifications page was also still rendering dummy data instead of the live notification endpoints.

## Validation

- `npm run build`

Closes #1231