### PR TITLE
Fix auth revalidation API base

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,16 +1,9 @@
 import axios, { InternalAxiosRequestConfig, AxiosResponse } from 'axios'
 import { useAuthStore } from '../stores/authStore'
-
-const configuredApiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim()
-const API_BASE_URL = configuredApiBaseUrl ? configuredApiBaseUrl.replace(/\/$/, '') : '/api/v1'
+import { API_BASE_URL, buildApiUrl } from '../utils/apiUrl'
 
 // Tracks whether the global 401-response handler is currently executing.
 let isUnauthorizedHandlerRunning = false
-
-function buildApiUrl(path: string): string {
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`
-  return `${API_BASE_URL}${normalizedPath}`
-}
 
 const api = axios.create({
   baseURL: API_BASE_URL,

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { buildApiUrl } from '../utils/apiUrl'
 
 interface User {
   id: number
@@ -38,7 +39,7 @@ export const useAuthStore = create<AuthState>()(
         }
         set({ isRevalidating: true })
         try {
-          const response = await fetch('/api/v1/auth/me', {
+          const response = await fetch(buildApiUrl('/auth/me'), {
             headers: {
               Authorization: `Bearer ${token}`,
             },
@@ -47,12 +48,10 @@ export const useAuthStore = create<AuthState>()(
             const user = await response.json()
             set({ user, isAuthenticated: true })
           } else {
-            // Token expired or revoked — log out
             set({ token: null, user: null, isAuthenticated: false })
           }
         } catch {
-          // Network error — log out to be safe
-          set({ token: null, user: null, isAuthenticated: false })
+          set({ isAuthenticated: true })
         } finally {
           set({ isRevalidating: false })
         }

--- a/frontend/src/utils/apiUrl.ts
+++ b/frontend/src/utils/apiUrl.ts
@@ -1,0 +1,10 @@
+const configuredApiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim()
+
+export const API_BASE_URL = configuredApiBaseUrl
+  ? configuredApiBaseUrl.replace(/\/$/, '')
+  : '/api/v1'
+
+export function buildApiUrl(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${API_BASE_URL}${normalizedPath}`
+}


### PR DESCRIPTION
## Summary

- move API base URL handling into a shared frontend utility
- use the shared URL builder for auth session revalidation
- keep the persisted session intact when revalidation fails because of a transient network error

## Root cause

Session revalidation called `/api/v1/auth/me` directly from the auth store. That bypassed `VITE_API_BASE_URL`, so deployments where the API lives on a different origin or base path could incorrectly clear a valid session.

## Validation

- `npm run build`

Closes #1235