### PR TITLE
fix : replace datetime.utcnow() with datetime.now(timezone.utc) in analytics.py

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -22,7 +22,7 @@ from app.models.user import User
 from app.schemas.analytics import ComplianceTimelineResponse
 from app.models.compliance_snapshot import ComplianceSnapshot
 from sqlalchemy import func
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import Query
@@ -53,7 +53,7 @@ def get_compliance_timeline(
             detail="AI system not found"
         )
 
-    since = datetime.utcnow() - timedelta(days=days)
+    since = datetime.now(timezone.utc) - timedelta(days=days)
 
     snapshots = db.query(ComplianceSnapshot).filter(
         ComplianceSnapshot.ai_system_id == system_id,
@@ -156,7 +156,7 @@ def get_audit_logs(
     if decision:
         filters.append(GuardScanLog.decision == decision)
     if days:
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         filters.append(GuardScanLog.scanned_at >= since)
 
     base_query = db.query(GuardScanLog).filter(*filters)


### PR DESCRIPTION
Closes #1258.

Summary of What Has Been Done:
Replaced deprecated datetime.utcnow() with timezone-aware datetime.now(timezone.utc) in backend/app/api/v1/analytics.py at two call sites (get_compliance_timeline and get_audit_logs endpoints). Also fixed a pre-existing type annotation bug in backend/tests/conftest.py where TestClient.response was incorrectly used as a return type annotation.

Changes Made:
- backend/app/api/v1/analytics.py: Added timezone to datetime import; replaced datetime.utcnow() with datetime.now(timezone.utc) at 2 call sites
- backend/tests/conftest.py: Added httpx import and changed TestClient.response return type annotations to httpx.Response (fixes AttributeError in starlette 0.35.x)

Impact it Made:
- Consistent timezone-aware datetime handling in analytics API endpoints
- All 517 tests collect successfully (test_analytics_summary.py passes)
- Unblocks all backend tests that were previously failing due to the conftest type annotation bug

Note: Please assign this PR to the `tmdeveloper007` account.