### PR TITLE
fix : replace datetime.utcnow() with datetime.now(timezone.utc) in guard.py

### DIFF
--- a/backend/app/api/v1/guard.py
+++ b/backend/app/api/v1/guard.py
@@ -158,7 +158,7 @@ def _build_guard_scan_log(user_id: int, prompt: str, result: dict, ip_address: s
         ml_confidence=intent_analysis.get("confidence", 0.0),
         combined_score=decision_reasoning.get("confidence", 0.0),
         prompt_length=len(prompt),
-        scanned_at=datetime.utcnow(),
+        scanned_at=datetime.now(timezone.utc),
         ip_address=ip_address,
     )
 
@@ -763,7 +763,7 @@ def get_guard_stats(
             detail="You do not have permission to query stats for another user.",
         )
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     if window == "24h":
         start_date = now - timedelta(hours=24)
     elif window == "7d":

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest fixtures for all tests."""
 
 import os
+import httpx
 import pytest
 from unittest.mock import MagicMock
 from sqlalchemy import create_engine
@@ -137,30 +138,30 @@ class _CSRFClientWrapper:
         headers["X-CSRF-Token"] = self._csrf_token
         kwargs["headers"] = headers
 
-    def get(self, url: str, **kwargs: object) -> TestClient.response:
+    def get(self, url: str, **kwargs: object) -> httpx.Response:
         return self._inner.get(url, **kwargs)
 
-    def post(self, url: str, **kwargs: object) -> TestClient.response:
+    def post(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.post(url, **kwargs)
 
-    def put(self, url: str, **kwargs: object) -> TestClient.response:
+    def put(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.put(url, **kwargs)
 
-    def patch(self, url: str, **kwargs: object) -> TestClient.response:
+    def patch(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.patch(url, **kwargs)
 
-    def delete(self, url: str, **kwargs: object) -> TestClient.response:
+    def delete(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.delete(url, **kwargs)
 
-    def request(self, method: str, url: str, **kwargs: object) -> TestClient.response:
+    def request(self, method: str, url: str, **kwargs: object) -> httpx.Response:
         if method.upper() in ("POST", "PUT", "PATCH", "DELETE"):
             self._ensure_csrf()
             self._inject_csrf(kwargs)


### PR DESCRIPTION
Closes #1259.

Summary of What Has Been Done:
Replaced deprecated datetime.utcnow() with timezone-aware datetime.now(timezone.utc) in backend/app/api/v1/guard.py at two call sites: in _build_guard_scan_log() (line 161) and in the guard_stats endpoint (line 766). Also included a necessary conftest.py fix for TestClient.response type annotation.

Changes Made:
- backend/app/api/v1/guard.py: Replaced datetime.utcnow() with datetime.now(timezone.utc) at 2 call sites (timezone already imported)
- backend/tests/conftest.py: Fixed TestClient.response return type annotations (pre-existing issue blocking all tests)

Impact it Made:
- Consistent timezone-aware datetime in guard scan logs and statistics
- 34 guard unit tests pass

Note: Please assign this PR to the `tmdeveloper007` account.