### PR TITLE
fix : replace datetime.utcnow() with datetime.now(timezone.utc) in audit_log.py

### DIFF
--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -8,7 +8,7 @@ Copyright (C) 2024 Sarthak Doshi (github.com/SdSarthak)
 SPDX-License-Identifier: AGPL-3.0-only
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 import enum
 import uuid
 
@@ -114,6 +114,6 @@ def after_ai_system_update(mapper, connection, target):
                 changed_by_id=changed_by_id,
                 old_values=_json_safe_value(old_values),
                 new_values=_json_safe_value(new_values),
-                changed_at=datetime.utcnow(),
+                changed_at=datetime.now(timezone.utc),
             )
         )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest fixtures for all tests."""
 
 import os
+import httpx
 import pytest
 from unittest.mock import MagicMock
 from sqlalchemy import create_engine
@@ -137,30 +138,30 @@ class _CSRFClientWrapper:
         headers["X-CSRF-Token"] = self._csrf_token
         kwargs["headers"] = headers
 
-    def get(self, url: str, **kwargs: object) -> TestClient.response:
+    def get(self, url: str, **kwargs: object) -> httpx.Response:
         return self._inner.get(url, **kwargs)
 
-    def post(self, url: str, **kwargs: object) -> TestClient.response:
+    def post(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.post(url, **kwargs)
 
-    def put(self, url: str, **kwargs: object) -> TestClient.response:
+    def put(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.put(url, **kwargs)
 
-    def patch(self, url: str, **kwargs: object) -> TestClient.response:
+    def patch(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.patch(url, **kwargs)
 
-    def delete(self, url: str, **kwargs: object) -> TestClient.response:
+    def delete(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.delete(url, **kwargs)
 
-    def request(self, method: str, url: str, **kwargs: object) -> TestClient.response:
+    def request(self, method: str, url: str, **kwargs: object) -> httpx.Response:
         if method.upper() in ("POST", "PUT", "PATCH", "DELETE"):
             self._ensure_csrf()
             self._inject_csrf(kwargs)


### PR DESCRIPTION
Closes #1261.

Summary of What Has Been Done:
Replaced deprecated datetime.utcnow() with timezone-aware datetime.now(timezone.utc) in backend/app/models/audit_log.py. The change is in the SQLAlchemy event listener that records audit log entries for AI system changes. Also included necessary conftest.py fix.

Changes Made:
- backend/app/models/audit_log.py: Added timezone to datetime import; replaced datetime.utcnow() with datetime.now(timezone.utc) in the event listener
- backend/tests/conftest.py: Fixed TestClient.response type annotation bug (pre-existing, blocks all tests)

Impact it Made:
- Consistent timezone-aware datetime in audit log records
- Prevents potential PostgreSQL timestamp comparison issues with timezone-aware columns

Note: Please assign this PR to the `tmdeveloper007` account.