### PR TITLE
fix : replace datetime.utcnow() with datetime.now(timezone.utc) in scheduler.py

### DIFF
--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from sqlalchemy.orm import Session
@@ -55,12 +55,12 @@ def send_reassessment_reminders():
     """Send notifications for risk assessments expiring within 30 days."""
     db: Session = SessionLocal()
     try:
-        thirty_days = datetime.utcnow() + timedelta(days=30)
+        thirty_days = datetime.now(timezone.utc) + timedelta(days=30)
         expiring = (
             db.query(RiskAssessment)
             .filter(
                 RiskAssessment.valid_until <= thirty_days,
-                RiskAssessment.valid_until > datetime.utcnow(),
+                RiskAssessment.valid_until > datetime.now(timezone.utc),
             )
             .all()
         )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest fixtures for all tests."""
 
 import os
+import httpx
 import pytest
 from unittest.mock import MagicMock
 from sqlalchemy import create_engine
@@ -137,30 +138,30 @@ class _CSRFClientWrapper:
         headers["X-CSRF-Token"] = self._csrf_token
         kwargs["headers"] = headers
 
-    def get(self, url: str, **kwargs: object) -> TestClient.response:
+    def get(self, url: str, **kwargs: object) -> httpx.Response:
         return self._inner.get(url, **kwargs)
 
-    def post(self, url: str, **kwargs: object) -> TestClient.response:
+    def post(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.post(url, **kwargs)
 
-    def put(self, url: str, **kwargs: object) -> TestClient.response:
+    def put(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.put(url, **kwargs)
 
-    def patch(self, url: str, **kwargs: object) -> TestClient.response:
+    def patch(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.patch(url, **kwargs)
 
-    def delete(self, url: str, **kwargs: object) -> TestClient.response:
+    def delete(self, url: str, **kwargs: object) -> httpx.Response:
         self._ensure_csrf()
         self._inject_csrf(kwargs)
         return self._inner.delete(url, **kwargs)
 
-    def request(self, method: str, url: str, **kwargs: object) -> TestClient.response:
+    def request(self, method: str, url: str, **kwargs: object) -> httpx.Response:
         if method.upper() in ("POST", "PUT", "PATCH", "DELETE"):
             self._ensure_csrf()
             self._inject_csrf(kwargs)


### PR DESCRIPTION
Closes #1267.

Summary of What Has Been Done:
Replaced deprecated datetime.utcnow() with timezone-aware datetime.now(timezone.utc) in backend/app/tasks/scheduler.py. Two naive datetime calls at lines 58 and 63 were producing datetime objects without timezone info, which can cause comparison issues with timezone-aware datetime values in the database. Also included necessary conftest.py fix.

Changes Made:
- backend/app/tasks/scheduler.py: Added timezone to datetime import; replaced datetime.utcnow() with datetime.now(timezone.utc) at 2 call sites
- backend/tests/conftest.py: Fixed TestClient.response type annotation bug (pre-existing)

Impact it Made:
- Consistent timezone-aware datetime handling in the background scheduler
- Prevents potential naive/aware datetime comparison errors
- Aligns with datetime fixes applied in other API modules

Note: Please assign this PR to the `tmdeveloper007` account.