### PR TITLE
fix : use analyticsApi instead of hardcoded fetch URL in Analytics page

### DIFF
--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { formatLastUpdated } from "../utils/date";
+import { analyticsApi } from "../services/api";
 
 import ComplianceRiskChart from "../components/ComplianceRiskChart";
 
@@ -134,26 +135,14 @@ export default function Analytics() {
 
   const fetchRiskDistribution = async () => {
     try {
-      const res = await fetch("/api/v1/analytics/summary");
-
-      if (res.ok) {
-        const json = await res.json();
-        const mapped: RiskData[] = [
-          { name: "Minimal Risk", value: json.counts?.minimal || 0 },
-          { name: "Limited Risk", value: json.counts?.limited || 0 },
-          { name: "High Risk", value: json.counts?.high || 0 },
-          { name: "Unacceptable Risk", value: json.counts?.unacceptable || 0 },
-        ];
-
-        setRiskPieData(mapped);
-      } else {
-        setRiskPieData([
-          { name: "Minimal Risk", value: 4 },
-          { name: "Limited Risk", value: 3 },
-          { name: "High Risk", value: 2 },
-          { name: "Unacceptable Risk", value: 1 },
-        ]);
-      }
+      const json = await analyticsApi.summary();
+      const mapped: RiskData[] = [
+        { name: "Minimal Risk", value: json.counts?.minimal || 0 },
+        { name: "Limited Risk", value: json.counts?.limited || 0 },
+        { name: "High Risk", value: json.counts?.high || 0 },
+        { name: "Unacceptable Risk", value: json.counts?.unacceptable || 0 },
+      ];
+      setRiskPieData(mapped);
     } catch {
       setRiskPieData([
         { name: "Minimal Risk", value: 4 },


### PR DESCRIPTION
Closes #1272.

Summary of What Has Been Done:
Replaced the hardcoded fetch("/api/v1/analytics/summary") call in the Analytics page with the shared analyticsApi.summary() function from the configured api.ts. This ensures the analytics page respects VITE_API_BASE_URL and works correctly when the backend is served at a non-root path.

Changes Made:
- frontend/src/pages/Analytics.tsx: replaced direct fetch() with analyticsApi.summary()
- frontend/src/pages/Analytics.tsx: added import for analyticsApi

Impact it Made:
- Fixes analytics page data loading when backend base URL is configured differently
- Aligns with how other pages (AI Systems, Documents, Guard) handle API calls
- Frontend lint and build both pass

Note: Please assign this PR to the `tmdeveloper007` account.