### PR TITLE
fix : use authApi.getMe instead of hardcoded URL in revalidateSession

### DIFF
--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { authApi } from '../services/api'
 
 interface User {
   id: number
@@ -38,20 +39,10 @@ export const useAuthStore = create<AuthState>()(
         }
         set({ isRevalidating: true })
         try {
-          const response = await fetch('/api/v1/auth/me', {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          })
-          if (response.ok) {
-            const user = await response.json()
-            set({ user, isAuthenticated: true })
-          } else {
-            // Token expired or revoked — log out
-            set({ token: null, user: null, isAuthenticated: false })
-          }
+          const user = await authApi.getMe(token)
+          set({ user, isAuthenticated: true })
         } catch {
-          // Network error — log out to be safe
+          // Token expired or revoked — log out
           set({ token: null, user: null, isAuthenticated: false })
         } finally {
           set({ isRevalidating: false })


### PR DESCRIPTION
Closes #1273.

Summary of What Has Been Done:
Replaced the hardcoded fetch('/api/v1/auth/me') call in revalidateSession with the shared authApi.getMe(token) function from api.ts. This ensures the session revalidation respects VITE_API_BASE_URL and works correctly when the backend is served at a non-root path.

Changes Made:
- frontend/src/stores/authStore.ts: replaced direct fetch() with authApi.getMe(token)
- frontend/src/stores/authStore.ts: added import for authApi from services/api

Impact it Made:
- Fixes auth session revalidation when backend base URL is configured differently
- Reduces code duplication by reusing the existing authApi helper
- Frontend lint and build both pass

Note: Please assign this PR to the `tmdeveloper007` account.