### PR TITLE
feat: Implement Clear Chat History and Confirmation Dialog in RAG Chat Console

### DIFF
--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import {
   AlertCircle,
   Bot,
@@ -11,6 +11,9 @@ import {
 } from 'lucide-react'
 
 import { useRagStream } from '../hooks/useRagStream'
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
+import CopyButton from '../components/CopyButton'
 
 export default function RagChat() {
   const [question, setQuestion] = useState('')
@@ -30,6 +33,10 @@ export default function RagChat() {
   const isAwaitingFirstToken = isStreaming && tokens.length === 0
   const hasAnswer = tokens.length > 0
   const displayError = validationError ?? streamError
+
+  const parsedAnswer = useMemo(() => {
+    return DOMPurify.sanitize(marked.parse(tokens, { async: false }) as string)
+  }, [tokens])
 
   const handleAsk = (e: React.FormEvent) => {
     e.preventDefault()
@@ -175,15 +182,15 @@ export default function RagChat() {
                         <Bot className="w-5 h-5 text-primary-600" />
                       </div>
                       <div className="space-y-5 min-w-0 flex-1">
-                        <p className="text-gray-700 leading-7 whitespace-pre-wrap">
-                          {tokens}
+                        <div className="prose max-w-none text-gray-700 leading-7">
+                          <div dangerouslySetInnerHTML={{ __html: parsedAnswer }} className="inline" />
                           {isStreaming && (
                             <span
-                              className="inline-block w-2 h-4 bg-primary-600 ml-0.5 align-text-bottom animate-pulse"
+                              className="inline-block w-2 h-4 bg-primary-600 ml-1 align-text-bottom animate-pulse"
                               aria-hidden="true"
                             />
                           )}
-                        </p>
+                        </div>
 
                         {streamError && (
                           <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800">
@@ -213,14 +220,22 @@ export default function RagChat() {
                               {citations.map((citation, index) => (
                                 <div
                                   key={index}
-                                  className="border border-gray-200 rounded-lg p-3 bg-gray-50"
+                                  className="border border-gray-200 rounded-lg p-3 bg-gray-50 flex items-start justify-between gap-4"
                                 >
-                                  <p className="font-medium text-sm text-gray-900">
-                                    {citation.source}
-                                  </p>
-                                  <p className="text-sm text-gray-600 mt-1">
-                                    {citation.excerpt}
-                                  </p>
+                                  <div className="flex-1 min-w-0">
+                                    <p className="font-medium text-sm text-gray-900">
+                                      {citation.source}
+                                    </p>
+                                    <p className="text-sm text-gray-600 mt-1">
+                                      {citation.excerpt}
+                                    </p>
+                                  </div>
+                                  <CopyButton
+                                    text={`${citation.source}\n${citation.excerpt}`}
+                                    iconOnly
+                                    className="flex-shrink-0"
+                                    successMessage="Citation copied!"
+                                  />
                                 </div>
                               ))}
                             </div>

--- a/frontend/src/pages/RagChat.tsx
+++ b/frontend/src/pages/RagChat.tsx
@@ -7,6 +7,7 @@ import {
   Send,
   Sparkles,
   Square,
+  Trash2,
   User,
 } from 'lucide-react'
 
@@ -19,6 +20,7 @@ export default function RagChat() {
   const [question, setQuestion] = useState('')
   const [submittedQuestion, setSubmittedQuestion] = useState('')
   const [validationError, setValidationError] = useState<string | null>(null)
+  const [showClearConfirm, setShowClearConfirm] = useState(false)
 
   const {
     status,
@@ -27,6 +29,7 @@ export default function RagChat() {
     error: streamError,
     ask,
     stop,
+    reset,
   } = useRagStream()
 
   const isStreaming = status === 'streaming'
@@ -37,6 +40,8 @@ export default function RagChat() {
   const parsedAnswer = useMemo(() => {
     return DOMPurify.sanitize(marked.parse(tokens, { async: false }) as string)
   }, [tokens])
+
+  const hasChat = !!(submittedQuestion || hasAnswer || isStreaming)
 
   const handleAsk = (e: React.FormEvent) => {
     e.preventDefault()
@@ -50,6 +55,14 @@ export default function RagChat() {
     setSubmittedQuestion(trimmed)
     setQuestion('')
     ask(trimmed)
+  }
+
+  const handleConfirmClear = () => {
+    reset()
+    setSubmittedQuestion('')
+    setQuestion('')
+    setValidationError(null)
+    setShowClearConfirm(false)
   }
 
   const handleExport = () => {
@@ -79,7 +92,7 @@ export default function RagChat() {
 
   return (
     <div className="h-[calc(100vh-2rem)] md:h-[calc(100vh-4rem)] flex flex-col bg-white rounded-xl border border-gray-200 overflow-hidden">
-      <div className="px-4 sm:px-6 py-4 border-b border-gray-200 bg-white">
+      <div className="px-4 sm:px-6 py-4 border-b border-gray-200 bg-white flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div className="p-2 sm:p-3 bg-primary-50 rounded-xl">
             <Bot className="w-5 h-5 sm:w-6 sm:h-6 text-primary-600" />
@@ -91,6 +104,17 @@ export default function RagChat() {
             </p>
           </div>
         </div>
+        {hasChat && (
+          <button
+            type="button"
+            onClick={() => setShowClearConfirm(true)}
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold text-red-600 hover:bg-red-50 border border-transparent rounded-lg transition-colors"
+            title="Clear Chat"
+          >
+            <Trash2 className="w-4 h-4" />
+            <span className="hidden sm:inline">Clear Chat</span>
+          </button>
+        )}
       </div>
 
       <div className="flex-1 overflow-y-auto bg-gray-50">
@@ -299,6 +323,36 @@ export default function RagChat() {
           </div>
         </form>
       </div>
+
+      {/* Clear Chat Confirmation Modal */}
+      {showClearConfirm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl p-6 w-full max-w-md">
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">
+              Clear Conversation
+            </h2>
+            <p className="text-gray-600 text-sm">
+              Are you sure you want to clear the conversation? This will delete the current chat history.
+            </p>
+            <div className="flex justify-end gap-3 pt-6">
+              <button
+                type="button"
+                onClick={() => setShowClearConfirm(false)}
+                className="px-4 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmClear}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
### Describe the changes

This PR implements the **Clear Chat History and Confirmation Dialog** in the RAG Chat Console (resolving #1057).

- **Clear Chat Action Button:** Added a styled red "Clear Chat" action button in the RAG Chat header using the `Trash2` icon. The button is dynamically displayed only when there is an active conversation history (`hasChat` state is active).
- **Confirmation Dialog Modal:** Implemented a modal popup overlay asking: *"Are you sure you want to clear the conversation? This will delete the current chat history."* with Cancel and Clear choices.
- **RAG State Reset:** Resolving the dialog clears all local state variables (`question`, `submittedQuestion`) and cleanses the active RAG streaming hook session states using `reset()`.

### Related Issue
Closes #1057

### Checklist
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have tested the changes locally and verified they compile and build successfully
