### PR TITLE
fix : wrap async webhook in sync handler so BackgroundTasks fires

### DIFF
--- a/backend/app/api/v1/webhooks.py
+++ b/backend/app/api/v1/webhooks.py
@@ -9,6 +9,7 @@ Copyright (C) 2024 Sarthak Doshi (github.com/SdSarthak)
 SPDX-License-Identifier: AGPL-3.0-only
 """
 
+import asyncio
 import hashlib
 import hmac
 import json
@@ -95,6 +96,21 @@ def _validate_webhook_url(url: str) -> None:
         raise ValueError("Internal domain names are not allowed")
 
 
+def _post_webhook_sync(
+    url: str,
+    event: str,
+    payload: dict[str, Any],
+    secret: str | None,
+) -> None:
+    """Synchronous wrapper so FastAPI BackgroundTasks can run the async _post_webhook.
+
+    FastAPI BackgroundTasks does not await coroutines — passing an async callable
+    to add_task() silently drops the request. This wrapper uses asyncio.run()
+    to execute the async delivery function synchronously in a worker thread.
+    """
+    asyncio.run(_post_webhook(url, event, payload, secret))
+
+
 def _build_signature(secret: str, payload_body: bytes) -> str:
     """Generate an HMAC-SHA256 signature for a webhook payload."""
     return hmac.new(
@@ -177,7 +193,7 @@ def deliver_webhook(
 
         try:
             background_tasks.add_task(
-                _post_webhook,
+                _post_webhook_sync,
                 url=webhook.url,
                 event=event,
                 payload=payload,


### PR DESCRIPTION
Closes #1283.

Summary of What Has Been Done:
FastAPI BackgroundTasks.add_task() silently discards async coroutines without awaiting them. The _post_webhook() function was passed directly to background_tasks.add_task(), causing all webhook HTTP requests to be silently dropped. Fixed by adding a synchronous wrapper _post_webhook_sync() that uses asyncio.run() to execute the async function in a worker thread.

Changes Made:
- backend/app/api/v1/webhooks.py: Added _post_webhook_sync() wrapper function that calls asyncio.run(_post_webhook(...)).
- Updated deliver_webhook() to call background_tasks.add_task(_post_webhook_sync, ...) instead of the raw async function.

Impact it Made:
- All outbound webhook events (guard_block, compliance_drift, scan_notification) are now actually delivered to configured endpoints.
- Fixes a silent data-loss bug where webhook HTTP requests were never sent.

Note: Please assign this PR to the `tmdeveloper007` account.