### PR TITLE
test : added unit tests for CursorPaginatedResponse schema validation

### DIFF
--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from app.schemas.pagination import PaginatedResponse
+from app.schemas.pagination import PaginatedResponse, CursorPaginatedResponse
 
 
 class ItemSchema(BaseModel):
@@ -91,3 +91,67 @@ class TestPaginatedResponseSchema:
 
         assert len(response.items) == 1
         assert response.total == 42
+
+
+class TestCursorPaginatedResponseSchema:
+    def test_cursor_paginated_response_exposes_required_fields(self):
+        schema = CursorPaginatedResponse[int].model_json_schema()
+        props = set(schema["properties"])
+        assert "items" in props
+        assert "limit" in props
+        assert "next_cursor" in props
+
+    def test_items_is_typed_as_a_list(self):
+        response = CursorPaginatedResponse[str](
+            items=["alpha", "beta"],
+            limit=10,
+            next_cursor=None,
+        )
+        assert isinstance(response.items, list)
+        assert response.items == ["alpha", "beta"]
+
+    def test_next_cursor_is_nullable(self):
+        # No cursor means no more pages
+        response = CursorPaginatedResponse[str].model_validate(
+            {"items": ["a"], "limit": 10, "next_cursor": None}
+        )
+        assert response.next_cursor is None
+
+    def test_next_cursor_accepts_string(self):
+        response = CursorPaginatedResponse[str].model_validate(
+            {"items": ["a"], "limit": 10, "next_cursor": "abc123"}
+        )
+        assert response.next_cursor == "abc123"
+
+    def test_serializes_and_deserializes_with_cursor(self):
+        response = CursorPaginatedResponse[dict].model_validate({
+            "items": [{"id": 1}, {"id": 2}],
+            "limit": 2,
+            "next_cursor": "page-2-token",
+        })
+        serialized = response.model_dump()
+        assert serialized["next_cursor"] == "page-2-token"
+        assert len(serialized["items"]) == 2
+        assert CursorPaginatedResponse[dict].model_validate(serialized) == response
+
+    def test_serializes_with_no_next_cursor(self):
+        response = CursorPaginatedResponse[int](
+            items=[1, 2, 3],
+            limit=10,
+            next_cursor=None,
+        )
+        assert response.model_dump()["next_cursor"] is None
+
+    def test_limit_field_present(self):
+        response = CursorPaginatedResponse[str](
+            items=[],
+            limit=25,
+            next_cursor=None,
+        )
+        assert response.limit == 25
+
+    def test_empty_items_list_valid(self):
+        response = CursorPaginatedResponse[str].model_validate(
+            {"items": [], "limit": 10, "next_cursor": None}
+        )
+        assert response.items == []


### PR DESCRIPTION
Closes #1295.

Summary of What Has Been Done:
Added comprehensive tests for CursorPaginatedResponse in backend/tests/test_schemas.py, covering required fields (items, limit, next_cursor), generic type resolution, nullable next_cursor behavior, serialization/deserialization roundtrips, and empty items list handling.

Changes Made:
- backend/tests/test_schemas.py: Added CursorPaginatedResponse import and TestCursorPaginatedResponseSchema class with 8 test methods

Impact it Made:
- Complete schema test coverage for the pagination module
- Prevents regressions in cursor-based pagination response format