### PR TITLE
fix : record registration rate-limit attempt only on failure

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -184,6 +184,11 @@ def register(
         raise
     except Exception:
         db.rollback()
+        _record_attempt(
+            _auth_registration_attempts_by_ip,
+            client_ip,
+            _AUTH_REGISTER_RATE_LIMIT_WINDOW_SECONDS,
+        )
         # Generic database error handler
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -191,12 +196,6 @@ def register(
                 "field": "general",
                 "message": "An error occurred during registration. Please try again."
             }
-        )
-    finally:
-        _record_attempt(
-            _auth_registration_attempts_by_ip,
-            client_ip,
-            _AUTH_REGISTER_RATE_LIMIT_WINDOW_SECONDS,
         )
 
 


### PR DESCRIPTION
Closes #1306.

Summary of What Has Been Done:
Moved the _record_attempt() call from the finally block into the except
block in POST /register handler so only failed registrations count toward
the rate limit. This matches the login endpoint behavior and prevents
legitimate users from being blocked after successful signups.

Changes Made:
- backend/app/api/v1/auth.py: moved _record_attempt() from finally block
  into the generic Exception handler so it fires only on actual failures

Impact it Made:
- Successful registrations no longer consume rate-limit budget
- Consistent behavior with login endpoint which already records only on failure
- Prevents legitimate users being blocked after successful registrations

Note: Please assign this PR to the `tmdeveloper007` account.